### PR TITLE
Import `IntoMaybeErased` to resolve import error

### DIFF
--- a/csr/admin/Cargo.toml
+++ b/csr/admin/Cargo.toml
@@ -11,3 +11,6 @@ shared = { path = "../../shared" }
 [[bin]]
 name = "admin-csr"
 path = "src/main.rs"
+
+[lints.clippy]
+pedantic = "warn"

--- a/csr/home/Cargo.toml
+++ b/csr/home/Cargo.toml
@@ -11,3 +11,6 @@ shared = { path = "../../shared" }
 [[bin]]
 name = "home-csr"
 path = "src/main.rs"
+
+[lints.clippy]
+pedantic = "warn"

--- a/csr/user/Cargo.toml
+++ b/csr/user/Cargo.toml
@@ -11,3 +11,6 @@ shared = { path = "../../shared" }
 [[bin]]
 name = "user-csr"
 path = "src/main.rs"
+
+[lints.clippy]
+pedantic = "warn"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2024"
 
 [dependencies]
 leptos = { version = "0.8", features = ["ssr"] }
+
+[lints.clippy]
+pedantic = "warn"

--- a/shared/src/admin/app.rs
+++ b/shared/src/admin/app.rs
@@ -1,3 +1,5 @@
+#[allow(unused_imports)]
+use leptos::prelude::IntoMaybeErased;
 use leptos::{IntoView, component, prelude::ElementChild, view};
 
 use crate::Nav;

--- a/shared/src/home/app.rs
+++ b/shared/src/home/app.rs
@@ -1,3 +1,5 @@
+#[allow(unused_imports)]
+use leptos::prelude::IntoMaybeErased;
 use leptos::{IntoView, component, prelude::ElementChild, view};
 
 use crate::Nav;

--- a/shared/src/user/app.rs
+++ b/shared/src/user/app.rs
@@ -1,3 +1,5 @@
+#[allow(unused_imports)]
+use leptos::prelude::IntoMaybeErased;
 use leptos::{IntoView, component, prelude::ElementChild, view};
 
 use crate::Nav;

--- a/ssr/admin/Cargo.toml
+++ b/ssr/admin/Cargo.toml
@@ -10,3 +10,6 @@ shared = { path = "../../shared" }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[lints.clippy]
+pedantic = "warn"

--- a/ssr/home/Cargo.toml
+++ b/ssr/home/Cargo.toml
@@ -10,3 +10,6 @@ shared = { path = "../../shared" }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[lints.clippy]
+pedantic = "warn"

--- a/ssr/user/Cargo.toml
+++ b/ssr/user/Cargo.toml
@@ -10,3 +10,6 @@ shared = { path = "../../shared" }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[lints.clippy]
+pedantic = "warn"


### PR DESCRIPTION
This might be caused by a recent change in the dependencies that leptos uses, which now requires the `IntoMaybeErased` trait to be imported explicitly.