### PR TITLE
Add Docker Compose infrastructure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,46 @@
+# ---------------------------------------------------------------------------
+# PostgreSQL
+# ---------------------------------------------------------------------------
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/auth_db
+DATABASE_ADMIN_URL=postgres://postgres:postgres@localhost:5432/postgres
+AUDIT_DATABASE_URL=postgres://audit_writer:changeme@localhost:5432/audit_db
+
+# ---------------------------------------------------------------------------
+# OpenBao (Vault-compatible secret management)
+# ---------------------------------------------------------------------------
+BAO_DEV_ROOT_TOKEN_ID=dev-root-token
+BAO_ADDR=http://localhost:8200
+
+# ---------------------------------------------------------------------------
+# Keycloak (Identity & Access Management)
+# ---------------------------------------------------------------------------
+KEYCLOAK_ADMIN=admin
+KEYCLOAK_ADMIN_PASSWORD=admin
+KEYCLOAK_URL=http://localhost:8080
+KEYCLOAK_REALM=aimer
+KEYCLOAK_CLIENT_ID=aimer-bff
+KEYCLOAK_CLIENT_SECRET=changeme-bff-secret
+
+# ---------------------------------------------------------------------------
+# mTLS (mutual TLS for backend service communication)
+# ---------------------------------------------------------------------------
+MTLS_CERT_PATH=
+MTLS_KEY_PATH=
+MTLS_CA_PATH=
+
+# ---------------------------------------------------------------------------
+# GraphQL
+# ---------------------------------------------------------------------------
+REVIEW_GRAPHQL_ENDPOINT=
+
+# ---------------------------------------------------------------------------
+# Application
+# ---------------------------------------------------------------------------
+DATA_DIR=./data
+JWT_EXPIRATION_MINUTES=15
+CSRF_SECRET=
+INIT_ADMIN_USERNAME=
+INIT_ADMIN_PASSWORD=
+DEFAULT_LOCALE=en

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,45 @@
+# Dependencies
+node_modules/
+
+# Next.js
+.next/
+out/
+
+# Build
+dist/
+build/
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# TLS certificates (generated locally)
+infra/certs/*.pem
+infra/certs/*.key
+infra/certs/*.crt
+
+# Docker volumes
+pgdata/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# TypeScript
+*.tsbuildinfo
+
+# Vercel
+.vercel

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,109 @@
+services:
+  postgres:
+    image: postgres:18-trixie
+    profiles: [dev, prod]
+    environment:
+      POSTGRES_DB: auth_db
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/18/docker
+      - ./infra/postgres/init-audit-db.sql:/docker-entrypoint-initdb.d/init-audit-db.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  openbao:
+    image: openbao/openbao:latest
+    profiles: [dev]
+    cap_add:
+      - IPC_LOCK
+    environment:
+      BAO_DEV_ROOT_TOKEN_ID: ${BAO_DEV_ROOT_TOKEN_ID:-dev-root-token}
+      BAO_DEV_LISTEN_ADDRESS: "0.0.0.0:8200"
+      BAO_ADDR: "http://127.0.0.1:8200"
+    ports:
+      - "8200:8200"
+    volumes:
+      - ./infra/openbao/init-transit.sh:/usr/local/bin/init-transit.sh:ro
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        bao server -dev &
+        BAO_PID=$$!
+        /usr/local/bin/init-transit.sh
+        wait $$BAO_PID
+    healthcheck:
+      test: ["CMD", "bao", "status"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0
+    profiles: [dev]
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:-admin}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./infra/keycloak/aimer-realm.json:/opt/keycloak/data/import/aimer-realm.json:ro
+    command: start-dev --import-realm
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8080 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\n\\r\\n' >&3 && head -1 <&3 | grep -q 200"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  nginx-dev:
+    image: nginx:alpine
+    profiles: [dev]
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./infra/nginx/nginx.dev.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./infra/certs:/etc/nginx/certs:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      keycloak:
+        condition: service_healthy
+
+  next-app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    profiles: [prod]
+    expose:
+      - "3000"
+    env_file:
+      - .env
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  nginx-prod:
+    image: nginx:alpine
+    profiles: [prod]
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./infra/nginx/nginx.prod.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./infra/certs:/etc/nginx/certs:ro
+    depends_on:
+      - next-app
+
+volumes:
+  pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8080 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\n\\r\\n' >&3 && head -1 <&3 | grep -q 200"]
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9000 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\n\\r\\n' >&3 && head -1 <&3 | grep -q 200"]
       interval: 10s
       timeout: 5s
       retries: 12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - "8080:8080"
     volumes:
       - ./infra/keycloak/aimer-realm.json:/opt/keycloak/data/import/aimer-realm.json:ro
-    command: start-dev --import-realm
+    command: start-dev --import-realm --health-enabled=true
     depends_on:
       postgres:
         condition: service_healthy

--- a/infra/certs/README.md
+++ b/infra/certs/README.md
@@ -1,0 +1,46 @@
+# Local Development TLS Certificates
+
+This directory holds self-signed TLS certificates for local development.
+The certificate files are gitignored and must be generated locally.
+
+## Option 1: mkcert (recommended)
+
+[mkcert](https://github.com/FiloSottile/mkcert) creates locally-trusted
+certificates without browser warnings.
+
+```sh
+# Install mkcert (macOS)
+brew install mkcert
+mkcert -install
+
+# Generate certificates in this directory
+cd infra/certs
+mkcert localhost 127.0.0.1 ::1
+# Produces: localhost+2.pem and localhost+2-key.pem
+
+# Rename to match nginx.dev.conf expectations
+mv localhost+2.pem localhost.pem
+mv localhost+2-key.pem localhost-key.pem
+```
+
+## Option 2: openssl
+
+```sh
+cd infra/certs
+openssl req -x509 -nodes -days 365 \
+  -newkey rsa:2048 \
+  -keyout localhost-key.pem \
+  -out localhost.pem \
+  -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1,IP:::1"
+```
+
+Note: Browsers will show a security warning with self-signed openssl
+certificates. Use mkcert to avoid this.
+
+## Expected files
+
+The Nginx dev config expects these files in this directory:
+
+- `localhost.pem` -- TLS certificate
+- `localhost-key.pem` -- TLS private key

--- a/infra/keycloak/aimer-realm.json
+++ b/infra/keycloak/aimer-realm.json
@@ -1,0 +1,48 @@
+{
+  "realm": "aimer",
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": true,
+  "roles": {
+    "realm": [
+      {
+        "name": "user",
+        "description": "Default user role"
+      },
+      {
+        "name": "admin",
+        "description": "Administrator role"
+      }
+    ]
+  },
+  "defaultRoles": ["user"],
+  "clients": [
+    {
+      "clientId": "aimer-bff",
+      "name": "Aimer BFF Client",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "changeme-bff-secret",
+      "redirectUris": [
+        "https://localhost/*",
+        "http://localhost:3000/*"
+      ],
+      "webOrigins": [
+        "https://localhost",
+        "http://localhost:3000"
+      ],
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "authorizationServicesEnabled": false,
+      "fullScopeAllowed": true
+    }
+  ]
+}

--- a/infra/nginx/nginx.dev.conf
+++ b/infra/nginx/nginx.dev.conf
@@ -1,0 +1,47 @@
+upstream nextjs {
+    server host.docker.internal:3000;
+}
+
+upstream keycloak {
+    server keycloak:8080;
+}
+
+server {
+    listen 80;
+    server_name localhost;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name localhost;
+
+    ssl_certificate     /etc/nginx/certs/localhost.pem;
+    ssl_certificate_key /etc/nginx/certs/localhost-key.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+
+    # Next.js application
+    location / {
+        proxy_pass http://nextjs;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Keycloak auth endpoints
+    location /auth/ {
+        proxy_pass http://keycloak/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+    }
+}

--- a/infra/openbao/init-transit.sh
+++ b/infra/openbao/init-transit.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Wait for OpenBao to become ready, then enable the Transit secret engine.
+set -e
+
+export BAO_ADDR="http://127.0.0.1:8200"
+export BAO_TOKEN="${BAO_DEV_ROOT_TOKEN_ID:-dev-root-token}"
+
+echo "Waiting for OpenBao to start..."
+until bao status >/dev/null 2>&1; do
+    sleep 1
+done
+
+echo "Enabling Transit secret engine..."
+bao secrets enable transit || echo "Transit engine already enabled"
+
+echo "Transit secret engine is ready."

--- a/infra/postgres/init-audit-db.sql
+++ b/infra/postgres/init-audit-db.sql
@@ -17,6 +17,6 @@ GRANT CONNECT ON DATABASE audit_db TO audit_writer;
 -- Switch to audit_db to grant schema-level privileges
 \connect audit_db
 
-GRANT USAGE ON SCHEMA public TO audit_writer;
+GRANT USAGE, CREATE ON SCHEMA public TO audit_writer;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
     GRANT SELECT, INSERT ON TABLES TO audit_writer;

--- a/infra/postgres/init-audit-db.sql
+++ b/infra/postgres/init-audit-db.sql
@@ -1,0 +1,22 @@
+-- Create the audit_db database and audit_writer role.
+-- This script runs automatically on first PostgreSQL startup
+-- via the docker-entrypoint-initdb.d mechanism.
+
+CREATE DATABASE audit_db;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'audit_writer') THEN
+        CREATE ROLE audit_writer WITH LOGIN PASSWORD 'changeme';
+    END IF;
+END
+$$;
+
+GRANT CONNECT ON DATABASE audit_db TO audit_writer;
+
+-- Switch to audit_db to grant schema-level privileges
+\connect audit_db
+
+GRANT USAGE ON SCHEMA public TO audit_writer;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT SELECT, INSERT ON TABLES TO audit_writer;


### PR DESCRIPTION
## Summary

- Add `docker-compose.yml` with PostgreSQL 18, OpenBao (dev mode), Keycloak 26, and Nginx services, all with health checks and dependency ordering
- PostgreSQL init script (`infra/postgres/init-audit-db.sql`) creates `audit_db` database and `audit_writer` role with limited privileges
- OpenBao init script (`infra/openbao/init-transit.sh`) enables the Transit secret engine for envelope encryption
- Keycloak auto-imports the `aimer` realm (`infra/keycloak/aimer-realm.json`) with a confidential `aimer-bff` OIDC client
- Nginx dev config (`infra/nginx/nginx.dev.conf`) provides TLS termination and reverse-proxies to Next.js and Keycloak
- `.env.example` documents all required environment variables including OpenBao and Keycloak settings
- `.gitignore` excludes generated certs, `.env`, `node_modules`, and build artifacts
- `infra/certs/README.md` has instructions for generating self-signed dev certificates with mkcert or openssl

Closes #16

## Test plan

- [x] Generate self-signed TLS certs following `infra/certs/README.md`
- [x] Copy `.env.example` to `.env`
- [x] Run `docker compose --profile dev up` and verify all services become healthy (`docker compose ps`)
- [x] Confirm `auth_db` and `audit_db` exist: `docker compose exec postgres psql -U postgres -c '\l'`
- [x] Confirm OpenBao Transit engine is enabled: `docker compose exec openbao bao secrets list`
- [x] Open Keycloak admin console at http://localhost:8080 and verify the `aimer` realm is present
- [x] Verify Nginx TLS at https://localhost (accept the self-signed cert warning)