### PR TITLE
Add Keycloak custom sign-in theme

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       - "8080:8080"
     volumes:
       - ./infra/keycloak/aimer-realm.json:/opt/keycloak/data/import/aimer-realm.json:ro
+      - ./infra/keycloak/themes/aimer:/opt/keycloak/themes/aimer:ro
     command: start-dev --import-realm --health-enabled=true
     depends_on:
       postgres:

--- a/infra/keycloak/aimer-realm.json
+++ b/infra/keycloak/aimer-realm.json
@@ -1,6 +1,7 @@
 {
   "realm": "aimer",
   "enabled": true,
+  "loginTheme": "aimer",
   "sslRequired": "external",
   "registrationAllowed": false,
   "loginWithEmailAllowed": true,

--- a/infra/keycloak/themes/aimer/META-INF/keycloak-themes.json
+++ b/infra/keycloak/themes/aimer/META-INF/keycloak-themes.json
@@ -1,0 +1,8 @@
+{
+  "themes": [
+    {
+      "name": "aimer",
+      "types": ["login"]
+    }
+  ]
+}

--- a/infra/keycloak/themes/aimer/login/error.ftl
+++ b/infra/keycloak/themes/aimer/login/error.ftl
@@ -1,0 +1,33 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=false; section>
+    <#if section = "form">
+        <h1 class="aimer-title">${kcSanitize(msg("errorTitle"))?no_esc}</h1>
+
+        <div class="aimer-alert">
+            <svg class="aimer-alert-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="10"/>
+                <line x1="12" y1="8" x2="12" y2="12"/>
+                <line x1="12" y1="16" x2="12.01" y2="16"/>
+            </svg>
+            <span>
+                <#if message?has_content>
+                    ${kcSanitize(message.summary)?no_esc}
+                <#else>
+                    ${kcSanitize(msg("errorGeneric"))?no_esc}
+                </#if>
+            </span>
+        </div>
+
+        <#if skipLink?? && skipLink>
+        <#else>
+            <#if client?? && client.baseUrl?has_content>
+                <div style="margin-top: 24px;">
+                    <a href="${client.baseUrl}" class="aimer-btn aimer-btn-primary" style="display: flex;">
+                        ${kcSanitize(msg("backToApplication"))?no_esc}
+                    </a>
+                </div>
+            </#if>
+        </#if>
+    </#if>
+</@layout.registrationLayout>

--- a/infra/keycloak/themes/aimer/login/info.ftl
+++ b/infra/keycloak/themes/aimer/login/info.ftl
@@ -1,0 +1,53 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=false displayInfo=true; section>
+    <#if section = "form">
+        <div class="aimer-info-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+                 stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="10"/>
+                <line x1="12" y1="16" x2="12" y2="12"/>
+                <line x1="12" y1="8" x2="12.01" y2="8"/>
+            </svg>
+        </div>
+
+        <#if message?has_content>
+            <#if message.type = 'error'>
+                <div class="aimer-alert">
+                    <span>${kcSanitize(message.summary)?no_esc}</span>
+                </div>
+            <#else>
+                <p class="aimer-subtitle">${kcSanitize(message.summary)?no_esc}</p>
+            </#if>
+        </#if>
+    </#if>
+    <#if section = "info">
+        <#if requiredActions??>
+            <p class="aimer-subtitle">
+                <#list requiredActions as reqActionItem>${kcSanitize(msg("requiredAction.${reqActionItem}"))?no_esc}<#sep>, </#list>
+            </p>
+        </#if>
+
+        <#if skipLink??>
+        <#else>
+            <#if pageRedirectUri?has_content>
+                <div style="margin-top: 24px;">
+                    <a href="${pageRedirectUri}" class="aimer-btn aimer-btn-primary" style="display: flex;">
+                        ${kcSanitize(msg("backToApplication"))?no_esc}
+                    </a>
+                </div>
+            <#elseif actionUri?has_content>
+                <div style="margin-top: 24px;">
+                    <a href="${actionUri}" class="aimer-btn aimer-btn-primary" style="display: flex;">
+                        ${kcSanitize(msg("proceedWithAction"))?no_esc}
+                    </a>
+                </div>
+            <#elseif (client.baseUrl)?has_content>
+                <div style="margin-top: 24px;">
+                    <a href="${client.baseUrl}" class="aimer-btn aimer-btn-primary" style="display: flex;">
+                        ${kcSanitize(msg("backToApplication"))?no_esc}
+                    </a>
+                </div>
+            </#if>
+        </#if>
+    </#if>
+</@layout.registrationLayout>

--- a/infra/keycloak/themes/aimer/login/login-otp.ftl
+++ b/infra/keycloak/themes/aimer/login/login-otp.ftl
@@ -1,0 +1,33 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('totp'); section>
+    <#if section = "form">
+        <h1 class="aimer-title">${msg("loginTotpTitle")}</h1>
+        <p class="aimer-subtitle">${msg("loginTotpIntro")}</p>
+
+        <#if message?has_content && message.type = 'error'>
+            <div class="aimer-alert">
+                <svg class="aimer-alert-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                     fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="10"/>
+                    <line x1="12" y1="8" x2="12" y2="12"/>
+                    <line x1="12" y1="16" x2="12.01" y2="16"/>
+                </svg>
+                <span>${kcSanitize(message.summary)?no_esc}</span>
+            </div>
+        </#if>
+
+        <form id="kc-otp-login-form" action="${url.loginAction}" method="post">
+            <div class="aimer-form-group">
+                <label for="otp" class="aimer-label">${msg("loginTotpOneTime")}</label>
+                <input id="otp" name="otp" type="text"
+                       class="aimer-otp-input<#if messagesPerField.existsError('totp')> has-error</#if>"
+                       inputmode="numeric" pattern="[0-9]*"
+                       autocomplete="one-time-code"
+                       autofocus />
+            </div>
+
+            <input type="submit" class="aimer-btn aimer-btn-primary"
+                   value="${msg("doLogIn")}" />
+        </form>
+    </#if>
+</@layout.registrationLayout>

--- a/infra/keycloak/themes/aimer/login/login-reset-password.ftl
+++ b/infra/keycloak/themes/aimer/login/login-reset-password.ftl
@@ -1,0 +1,25 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=true; section>
+    <#if section = "form">
+        <h1 class="aimer-title">${msg("emailForgotTitle")}</h1>
+
+        <div class="aimer-info-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+                 stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="10"/>
+                <line x1="12" y1="16" x2="12" y2="12"/>
+                <line x1="12" y1="8" x2="12.01" y2="8"/>
+            </svg>
+        </div>
+
+        <p class="aimer-subtitle">
+            To reset your password, please contact your system administrator.
+        </p>
+
+        <div style="margin-top: 24px;">
+            <a href="${url.loginUrl}" class="aimer-btn aimer-btn-primary" style="display: flex;">
+                ${kcSanitize(msg("backToLogin"))?no_esc}
+            </a>
+        </div>
+    </#if>
+</@layout.registrationLayout>

--- a/infra/keycloak/themes/aimer/login/login.ftl
+++ b/infra/keycloak/themes/aimer/login/login.ftl
@@ -1,0 +1,137 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('username','password'); section>
+    <#if section = "form">
+        <h1 class="aimer-title">${msg("loginAccountTitle")}</h1>
+
+        <#if messagesPerField.existsError('username','password')>
+            <div class="aimer-alert">
+                <svg class="aimer-alert-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                     fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="10"/>
+                    <line x1="12" y1="8" x2="12" y2="12"/>
+                    <line x1="12" y1="16" x2="12.01" y2="16"/>
+                </svg>
+                <span>${kcSanitize(messagesPerField.getFirstError('username','password'))?no_esc}</span>
+            </div>
+        <#elseif message?has_content && (message.type != 'warning' || !isAppInitiatedAction??)>
+            <#if message.type = 'error'>
+                <div class="aimer-alert">
+                    <svg class="aimer-alert-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                         fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="10"/>
+                        <line x1="12" y1="8" x2="12" y2="12"/>
+                        <line x1="12" y1="16" x2="12.01" y2="16"/>
+                    </svg>
+                    <span>${kcSanitize(message.summary)?no_esc}</span>
+                </div>
+            </#if>
+        </#if>
+
+        <form id="kc-form-login" action="${url.loginAction}" method="post" onsubmit="login.disabled = true; return true;">
+            <div class="aimer-form-group">
+                <label for="username" class="aimer-label">${msg("email")}</label>
+                <input id="username" name="username" type="text"
+                       class="aimer-input<#if messagesPerField.existsError('username')> has-error</#if>"
+                       value="${(login.username!'')}"
+                       placeholder="${msg("email")}"
+                       autofocus autocomplete="email" />
+            </div>
+
+            <div class="aimer-form-group">
+                <label for="password" class="aimer-label">${msg("password")}</label>
+                <div class="aimer-input-wrapper">
+                    <input id="password" name="password" type="password"
+                           class="aimer-input<#if messagesPerField.existsError('password')> has-error</#if>"
+                           placeholder="${msg("password")}"
+                           autocomplete="current-password" />
+                    <button type="button" class="aimer-password-toggle" onclick="togglePassword()" aria-label="Toggle password visibility">
+                        <svg id="eye-open" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                             fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+                            <circle cx="12" cy="12" r="3"/>
+                        </svg>
+                        <svg id="eye-closed" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                             fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                             style="display:none">
+                            <path d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19m-6.72-1.07a3 3 0 01-4.24-4.24"/>
+                            <line x1="1" y1="1" x2="23" y2="23"/>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+
+            <div class="aimer-form-actions">
+                <a href="#" class="aimer-link" onclick="openForgotModal(event)">${msg("doForgotPassword")}</a>
+            </div>
+
+            <input id="login-btn" name="login" type="submit"
+                   class="aimer-btn aimer-btn-primary"
+                   value="${msg("doLogIn")}" />
+        </form>
+
+        <#if realm.registrationAllowed>
+            <div class="aimer-footer">
+                ${msg("noAccount")} <a href="${url.registrationUrl}">${msg("doRegister")}</a>
+            </div>
+        </#if>
+
+        <div class="aimer-modal-overlay" id="forgot-modal">
+            <div class="aimer-modal">
+                <h2 class="aimer-modal-title">${msg("doForgotPassword")}</h2>
+                <p class="aimer-modal-body">
+                    To reset your password, please contact your system administrator.
+                </p>
+                <div class="aimer-modal-actions">
+                    <button type="button" class="aimer-btn aimer-btn-secondary" onclick="closeForgotModal()">
+                        ${msg("doCancel")}
+                    </button>
+                </div>
+            </div>
+        </div>
+
+        <script>
+            function togglePassword() {
+                var pwd = document.getElementById('password');
+                var eyeOpen = document.getElementById('eye-open');
+                var eyeClosed = document.getElementById('eye-closed');
+                if (pwd.type === 'password') {
+                    pwd.type = 'text';
+                    eyeOpen.style.display = 'none';
+                    eyeClosed.style.display = 'block';
+                } else {
+                    pwd.type = 'password';
+                    eyeOpen.style.display = 'block';
+                    eyeClosed.style.display = 'none';
+                }
+            }
+
+            function openForgotModal(e) {
+                e.preventDefault();
+                document.getElementById('forgot-modal').classList.add('is-open');
+            }
+
+            function closeForgotModal() {
+                document.getElementById('forgot-modal').classList.remove('is-open');
+            }
+
+            document.getElementById('forgot-modal').addEventListener('click', function(e) {
+                if (e.target === this) closeForgotModal();
+            });
+
+            (function() {
+                var form = document.getElementById('kc-form-login');
+                var username = document.getElementById('username');
+                var password = document.getElementById('password');
+                var btn = document.getElementById('login-btn');
+
+                function updateBtn() {
+                    btn.disabled = !username.value.trim() || !password.value.trim();
+                }
+
+                updateBtn();
+                username.addEventListener('input', updateBtn);
+                password.addEventListener('input', updateBtn);
+            })();
+        </script>
+    </#if>
+</@layout.registrationLayout>

--- a/infra/keycloak/themes/aimer/login/register.ftl
+++ b/infra/keycloak/themes/aimer/login/register.ftl
@@ -1,0 +1,149 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('firstName','lastName','email','username','password','password-confirm'); section>
+    <#if section = "form">
+        <h1 class="aimer-title">${msg("registerTitle")}</h1>
+
+        <#if message?has_content && message.type = 'error'>
+            <div class="aimer-alert">
+                <svg class="aimer-alert-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                     fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="10"/>
+                    <line x1="12" y1="8" x2="12" y2="12"/>
+                    <line x1="12" y1="16" x2="12.01" y2="16"/>
+                </svg>
+                <span>${kcSanitize(message.summary)?no_esc}</span>
+            </div>
+        </#if>
+
+        <form id="kc-register-form" action="${url.registrationAction}" method="post">
+            <div class="aimer-form-group">
+                <label for="firstName" class="aimer-label">${msg("firstName")}</label>
+                <input id="firstName" name="firstName" type="text"
+                       class="aimer-input<#if messagesPerField.existsError('firstName')> has-error</#if>"
+                       value="${(register.formData.firstName!'')}"
+                       placeholder="${msg("firstName")}" />
+                <#if messagesPerField.existsError('firstName')>
+                    <div class="aimer-error">
+                        <svg class="aimer-error-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                             fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="12" cy="12" r="10"/>
+                            <line x1="12" y1="8" x2="12" y2="12"/>
+                            <line x1="12" y1="16" x2="12.01" y2="16"/>
+                        </svg>
+                        <span>${kcSanitize(messagesPerField.getFirstError('firstName'))?no_esc}</span>
+                    </div>
+                </#if>
+            </div>
+
+            <div class="aimer-form-group">
+                <label for="lastName" class="aimer-label">${msg("lastName")}</label>
+                <input id="lastName" name="lastName" type="text"
+                       class="aimer-input<#if messagesPerField.existsError('lastName')> has-error</#if>"
+                       value="${(register.formData.lastName!'')}"
+                       placeholder="${msg("lastName")}" />
+                <#if messagesPerField.existsError('lastName')>
+                    <div class="aimer-error">
+                        <svg class="aimer-error-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                             fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="12" cy="12" r="10"/>
+                            <line x1="12" y1="8" x2="12" y2="12"/>
+                            <line x1="12" y1="16" x2="12.01" y2="16"/>
+                        </svg>
+                        <span>${kcSanitize(messagesPerField.getFirstError('lastName'))?no_esc}</span>
+                    </div>
+                </#if>
+            </div>
+
+            <div class="aimer-form-group">
+                <label for="email" class="aimer-label">${msg("email")}</label>
+                <input id="email" name="email" type="email"
+                       class="aimer-input<#if messagesPerField.existsError('email')> has-error</#if>"
+                       value="${(register.formData.email!'')}"
+                       placeholder="${msg("email")}"
+                       autocomplete="email" />
+                <#if messagesPerField.existsError('email')>
+                    <div class="aimer-error">
+                        <svg class="aimer-error-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                             fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="12" cy="12" r="10"/>
+                            <line x1="12" y1="8" x2="12" y2="12"/>
+                            <line x1="12" y1="16" x2="12.01" y2="16"/>
+                        </svg>
+                        <span>${kcSanitize(messagesPerField.getFirstError('email'))?no_esc}</span>
+                    </div>
+                </#if>
+            </div>
+
+            <#if !realm.registrationEmailAsUsername>
+                <div class="aimer-form-group">
+                    <label for="username" class="aimer-label">${msg("username")}</label>
+                    <input id="username" name="username" type="text"
+                           class="aimer-input<#if messagesPerField.existsError('username')> has-error</#if>"
+                           value="${(register.formData.username!'')}"
+                           placeholder="${msg("username")}"
+                           autocomplete="username" />
+                    <#if messagesPerField.existsError('username')>
+                        <div class="aimer-error">
+                            <svg class="aimer-error-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <circle cx="12" cy="12" r="10"/>
+                                <line x1="12" y1="8" x2="12" y2="12"/>
+                                <line x1="12" y1="16" x2="12.01" y2="16"/>
+                            </svg>
+                            <span>${kcSanitize(messagesPerField.getFirstError('username'))?no_esc}</span>
+                        </div>
+                    </#if>
+                </div>
+            </#if>
+
+            <div class="aimer-form-group">
+                <label for="password" class="aimer-label">${msg("password")}</label>
+                <div class="aimer-input-wrapper">
+                    <input id="password" name="password" type="password"
+                           class="aimer-input<#if messagesPerField.existsError('password')> has-error</#if>"
+                           placeholder="${msg("password")}"
+                           autocomplete="new-password" />
+                </div>
+                <#if messagesPerField.existsError('password')>
+                    <div class="aimer-error">
+                        <svg class="aimer-error-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                             fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="12" cy="12" r="10"/>
+                            <line x1="12" y1="8" x2="12" y2="12"/>
+                            <line x1="12" y1="16" x2="12.01" y2="16"/>
+                        </svg>
+                        <span>${kcSanitize(messagesPerField.getFirstError('password'))?no_esc}</span>
+                    </div>
+                </#if>
+            </div>
+
+            <div class="aimer-form-group">
+                <label for="password-confirm" class="aimer-label">${msg("passwordConfirm")}</label>
+                <div class="aimer-input-wrapper">
+                    <input id="password-confirm" name="password-confirm" type="password"
+                           class="aimer-input<#if messagesPerField.existsError('password-confirm')> has-error</#if>"
+                           placeholder="${msg("passwordConfirm")}"
+                           autocomplete="new-password" />
+                </div>
+                <#if messagesPerField.existsError('password-confirm')>
+                    <div class="aimer-error">
+                        <svg class="aimer-error-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                             fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="12" cy="12" r="10"/>
+                            <line x1="12" y1="8" x2="12" y2="12"/>
+                            <line x1="12" y1="16" x2="12.01" y2="16"/>
+                        </svg>
+                        <span>${kcSanitize(messagesPerField.getFirstError('password-confirm'))?no_esc}</span>
+                    </div>
+                </#if>
+            </div>
+
+            <input type="submit" class="aimer-btn aimer-btn-primary"
+                   value="${msg("doRegister")}" />
+        </form>
+
+        <div class="aimer-footer">
+            <a href="${url.loginUrl}">${kcSanitize(msg("backToLogin"))?no_esc}</a>
+        </div>
+    </#if>
+</@layout.registrationLayout>

--- a/infra/keycloak/themes/aimer/login/resources/css/login.css
+++ b/infra/keycloak/themes/aimer/login/resources/css/login.css
@@ -1,0 +1,474 @@
+/* Aimer Keycloak Login Theme
+ * Design tokens from Discussion #15 */
+
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap');
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.min.css');
+
+/* ── Light mode (default) ── */
+:root {
+  --aimer-bg-canvas: #f9fafa;
+  --aimer-card-bg: #ffffff;
+  --aimer-control-bg: rgba(97, 105, 116, 0.08);
+  --aimer-control-placeholder: #616974;
+  --aimer-text-primary: #212428;
+  --aimer-text-secondary: #474c55;
+  --aimer-btn-primary-bg: #156ef2;
+  --aimer-btn-primary-bg-hover: #0d5fd8;
+  --aimer-btn-primary-bg-disabled: #c5e4f7;
+  --aimer-btn-primary-fg: #ffffff;
+  --aimer-danger: #db1d03;
+  --aimer-danger-bg: #fff9f9;
+  --aimer-border: rgba(97, 105, 116, 0.16);
+  --aimer-card-shadow: 0 10px 10px rgba(0, 0, 0, 0.04),
+    0 20px 25px rgba(0, 0, 0, 0.01);
+  --aimer-logo-color: #212428;
+}
+
+/* ── Dark mode via system preference ── */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    --aimer-bg-canvas: #1a1d20;
+    --aimer-card-bg: rgba(97, 105, 116, 0.08);
+    --aimer-control-bg: rgba(97, 105, 116, 0.24);
+    --aimer-control-placeholder: #616974;
+    --aimer-text-primary: #fafafa;
+    --aimer-text-secondary: #b4bbc6;
+    --aimer-btn-primary-bg: #156ef2;
+    --aimer-btn-primary-bg-hover: #0d5fd8;
+    --aimer-btn-primary-bg-disabled: rgba(21, 110, 242, 0.3);
+    --aimer-btn-primary-fg: #ffffff;
+    --aimer-danger: #fb2c10;
+    --aimer-danger-bg: rgba(219, 29, 3, 0.1);
+    --aimer-border: rgba(97, 105, 116, 0.24);
+    --aimer-card-shadow: 0 10px 10px rgba(0, 0, 0, 0.12),
+      0 20px 25px rgba(0, 0, 0, 0.08);
+    --aimer-logo-color: #fafafa;
+  }
+}
+
+/* ── Dark mode via data attribute ── */
+[data-theme='dark'] {
+  --aimer-bg-canvas: #1a1d20;
+  --aimer-card-bg: rgba(97, 105, 116, 0.08);
+  --aimer-control-bg: rgba(97, 105, 116, 0.24);
+  --aimer-control-placeholder: #616974;
+  --aimer-text-primary: #fafafa;
+  --aimer-text-secondary: #b4bbc6;
+  --aimer-btn-primary-bg: #156ef2;
+  --aimer-btn-primary-bg-hover: #0d5fd8;
+  --aimer-btn-primary-bg-disabled: rgba(21, 110, 242, 0.3);
+  --aimer-btn-primary-fg: #ffffff;
+  --aimer-danger: #fb2c10;
+  --aimer-danger-bg: rgba(219, 29, 3, 0.1);
+  --aimer-border: rgba(97, 105, 116, 0.24);
+  --aimer-card-shadow: 0 10px 10px rgba(0, 0, 0, 0.12),
+    0 20px 25px rgba(0, 0, 0, 0.08);
+  --aimer-logo-color: #fafafa;
+}
+
+/* ── Reset & base ── */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body.aimer-login {
+  margin: 0;
+  padding: 0;
+  font-family: 'Pretendard', 'Roboto', system-ui, -apple-system, sans-serif;
+  background-color: var(--aimer-bg-canvas);
+  color: var(--aimer-text-primary);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* ── Layout container ── */
+.aimer-container {
+  width: 100%;
+  max-width: 448px;
+  padding: 16px;
+}
+
+/* ── Card ── */
+.aimer-card {
+  background: var(--aimer-card-bg);
+  border-radius: 6px;
+  box-shadow: var(--aimer-card-shadow);
+  padding: 40px 32px;
+  border: 1px solid var(--aimer-border);
+}
+
+/* ── Logo ── */
+.aimer-logo {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 32px;
+}
+
+.aimer-logo svg,
+.aimer-logo img {
+  height: 32px;
+  width: auto;
+  color: var(--aimer-logo-color);
+}
+
+/* ── Typography ── */
+.aimer-title {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--aimer-text-primary);
+  text-align: center;
+  margin: 0 0 24px;
+}
+
+.aimer-subtitle {
+  font-size: 14px;
+  color: var(--aimer-text-secondary);
+  text-align: center;
+  margin: 0 0 24px;
+}
+
+/* ── Form elements ── */
+.aimer-form-group {
+  margin-bottom: 16px;
+}
+
+.aimer-label {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--aimer-text-secondary);
+  margin-bottom: 6px;
+  font-family: 'Roboto', sans-serif;
+}
+
+.aimer-input-wrapper {
+  position: relative;
+}
+
+.aimer-input {
+  width: 100%;
+  height: 36px;
+  padding: 0 12px;
+  font-size: 14px;
+  font-family: 'Pretendard', 'Roboto', system-ui, sans-serif;
+  color: var(--aimer-text-primary);
+  background: var(--aimer-control-bg);
+  border: 1px solid transparent;
+  border-radius: 8px;
+  outline: none;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.aimer-input::placeholder {
+  color: var(--aimer-control-placeholder);
+}
+
+.aimer-input:focus {
+  border-color: var(--aimer-btn-primary-bg);
+}
+
+.aimer-input.has-error {
+  border-color: var(--aimer-danger);
+  background: var(--aimer-danger-bg);
+}
+
+/* ── Password toggle ── */
+.aimer-password-toggle {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  color: var(--aimer-control-placeholder);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.aimer-password-toggle:hover {
+  color: var(--aimer-text-secondary);
+}
+
+.aimer-password-toggle svg {
+  width: 18px;
+  height: 18px;
+}
+
+.aimer-input-wrapper .aimer-input {
+  padding-right: 36px;
+}
+
+/* ── Error message ── */
+.aimer-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  margin-top: 6px;
+  font-size: 13px;
+  color: var(--aimer-danger);
+  font-family: 'Roboto', sans-serif;
+}
+
+.aimer-error-icon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  margin-top: 1px;
+}
+
+.aimer-alert {
+  background: var(--aimer-danger-bg);
+  border: 1px solid var(--aimer-danger);
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--aimer-danger);
+}
+
+.aimer-alert-icon {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  margin-top: 1px;
+}
+
+/* ── Buttons ── */
+.aimer-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 36px;
+  padding: 0 16px;
+  font-size: 14px;
+  font-weight: 500;
+  font-family: 'Pretendard', 'Roboto', system-ui, sans-serif;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.15s ease, opacity 0.15s ease;
+  text-decoration: none;
+}
+
+.aimer-btn-primary {
+  width: 100%;
+  background: var(--aimer-btn-primary-bg);
+  color: var(--aimer-btn-primary-fg);
+}
+
+.aimer-btn-primary:hover:not(:disabled) {
+  background: var(--aimer-btn-primary-bg-hover);
+}
+
+.aimer-btn-primary:disabled {
+  background: var(--aimer-btn-primary-bg-disabled);
+  cursor: not-allowed;
+}
+
+.aimer-btn-secondary {
+  background: var(--aimer-control-bg);
+  color: var(--aimer-text-primary);
+}
+
+.aimer-btn-secondary:hover {
+  opacity: 0.8;
+}
+
+/* ── Links ── */
+.aimer-link {
+  color: var(--aimer-btn-primary-bg);
+  font-size: 13px;
+  text-decoration: none;
+  font-family: 'Roboto', sans-serif;
+}
+
+.aimer-link:hover {
+  text-decoration: underline;
+}
+
+.aimer-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 20px;
+}
+
+/* ── Divider ── */
+.aimer-divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 20px 0;
+  font-size: 12px;
+  color: var(--aimer-control-placeholder);
+}
+
+.aimer-divider::before,
+.aimer-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--aimer-border);
+}
+
+/* ── Footer ── */
+.aimer-footer {
+  text-align: center;
+  margin-top: 16px;
+  font-size: 13px;
+  color: var(--aimer-text-secondary);
+}
+
+.aimer-footer a {
+  color: var(--aimer-btn-primary-bg);
+  text-decoration: none;
+}
+
+.aimer-footer a:hover {
+  text-decoration: underline;
+}
+
+/* ── Theme toggle ── */
+.aimer-theme-toggle {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid var(--aimer-border);
+  background: var(--aimer-card-bg);
+  color: var(--aimer-text-secondary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.15s ease;
+}
+
+.aimer-theme-toggle:hover {
+  opacity: 0.8;
+}
+
+.aimer-theme-toggle svg {
+  width: 18px;
+  height: 18px;
+}
+
+/* ── Modal (for password recovery) ── */
+.aimer-modal-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 100;
+  justify-content: center;
+  align-items: center;
+}
+
+.aimer-modal-overlay.is-open {
+  display: flex;
+}
+
+.aimer-modal {
+  background: var(--aimer-card-bg);
+  border-radius: 6px;
+  box-shadow: var(--aimer-card-shadow);
+  padding: 32px;
+  max-width: 400px;
+  width: calc(100% - 32px);
+  border: 1px solid var(--aimer-border);
+}
+
+.aimer-modal-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--aimer-text-primary);
+  margin: 0 0 12px;
+}
+
+.aimer-modal-body {
+  font-size: 14px;
+  color: var(--aimer-text-secondary);
+  margin-bottom: 20px;
+  line-height: 1.5;
+}
+
+.aimer-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* ── MFA / OTP styling ── */
+.aimer-otp-input {
+  width: 100%;
+  height: 36px;
+  padding: 0 12px;
+  font-size: 18px;
+  font-family: 'Roboto', monospace;
+  letter-spacing: 4px;
+  text-align: center;
+  color: var(--aimer-text-primary);
+  background: var(--aimer-control-bg);
+  border: 1px solid transparent;
+  border-radius: 8px;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.aimer-otp-input:focus {
+  border-color: var(--aimer-btn-primary-bg);
+}
+
+/* ── WebAuthn ── */
+.aimer-webauthn-icon {
+  display: flex;
+  justify-content: center;
+  margin: 24px 0;
+  color: var(--aimer-btn-primary-bg);
+}
+
+.aimer-webauthn-icon svg {
+  width: 64px;
+  height: 64px;
+}
+
+/* ── Info page ── */
+.aimer-info-icon {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 16px;
+  color: var(--aimer-btn-primary-bg);
+}
+
+.aimer-info-icon svg {
+  width: 48px;
+  height: 48px;
+}
+
+/* ── Responsive ── */
+@media (max-width: 480px) {
+  .aimer-container {
+    max-width: 100%;
+    padding: 12px;
+  }
+
+  .aimer-card {
+    padding: 32px 20px;
+    border-radius: 0;
+    box-shadow: none;
+    border-left: none;
+    border-right: none;
+  }
+}

--- a/infra/keycloak/themes/aimer/login/resources/img/logo.svg
+++ b/infra/keycloak/themes/aimer/login/resources/img/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 32" fill="none">
+  <circle cx="16" cy="16" r="12" fill="#156ef2"/>
+  <path d="M10 20l6-12 6 12" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="38" y="22" font-family="system-ui, sans-serif" font-size="20" font-weight="700" fill="currentColor">aimer</text>
+</svg>

--- a/infra/keycloak/themes/aimer/login/template.ftl
+++ b/infra/keycloak/themes/aimer/login/template.ftl
@@ -1,0 +1,68 @@
+<#macro registrationLayout bodyClass="" displayInfo=false displayMessage=true displayRequiredFields=false>
+<!DOCTYPE html>
+<html lang="${locale.currentLanguageTag!'en'}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    <title>${msg("loginTitle",(realm.displayName!''))}</title>
+    <#if properties.styles?has_content>
+        <#list properties.styles?split(' ') as style>
+            <link rel="stylesheet" href="${url.resourcesPath}/${style}">
+        </#list>
+    </#if>
+    <script>
+        (function() {
+            var theme = localStorage.getItem('aimer-theme');
+            if (theme === 'dark' || theme === 'light') {
+                document.documentElement.setAttribute('data-theme', theme);
+            }
+        })();
+    </script>
+</head>
+<body class="aimer-login ${bodyClass}">
+    <div class="aimer-container">
+        <div class="aimer-card">
+            <div class="aimer-logo">
+                <img src="${url.resourcesPath}/img/logo.svg" alt="${realm.displayName!'Aimer'}" />
+            </div>
+            <#nested "form">
+            <#if displayInfo>
+                <#nested "info">
+            </#if>
+        </div>
+    </div>
+
+    <button class="aimer-theme-toggle" type="button" onclick="toggleTheme()" aria-label="Toggle theme">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="5"/>
+            <line x1="12" y1="1" x2="12" y2="3"/>
+            <line x1="12" y1="21" x2="12" y2="23"/>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+            <line x1="1" y1="12" x2="3" y2="12"/>
+            <line x1="21" y1="12" x2="23" y2="12"/>
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+        </svg>
+    </button>
+
+    <script>
+        function toggleTheme() {
+            var current = document.documentElement.getAttribute('data-theme');
+            var next;
+            if (current === 'dark') {
+                next = 'light';
+            } else if (current === 'light') {
+                next = 'dark';
+            } else {
+                next = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'light' : 'dark';
+            }
+            document.documentElement.setAttribute('data-theme', next);
+            localStorage.setItem('aimer-theme', next);
+        }
+    </script>
+</body>
+</html>
+</#macro>

--- a/infra/keycloak/themes/aimer/login/template.ftl
+++ b/infra/keycloak/themes/aimer/login/template.ftl
@@ -1,6 +1,6 @@
 <#macro registrationLayout bodyClass="" displayInfo=false displayMessage=true displayRequiredFields=false>
 <!DOCTYPE html>
-<html lang="${locale.currentLanguageTag!'en'}">
+<html lang="<#if locale??>${locale.currentLanguageTag!'en'}<#else>en</#if>">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/infra/keycloak/themes/aimer/login/theme.properties
+++ b/infra/keycloak/themes/aimer/login/theme.properties
@@ -1,0 +1,3 @@
+parent=keycloak.v2
+import=common/keycloak
+styles=css/login.css

--- a/infra/keycloak/themes/aimer/login/webauthn-authenticate.ftl
+++ b/infra/keycloak/themes/aimer/login/webauthn-authenticate.ftl
@@ -1,0 +1,85 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=true; section>
+    <#if section = "form">
+        <h1 class="aimer-title">${msg("webauthn-login-title")}</h1>
+
+        <div class="aimer-webauthn-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+                 stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+                <path d="M7 11V7a5 5 0 0110 0v4"/>
+                <circle cx="12" cy="16" r="1"/>
+            </svg>
+        </div>
+
+        <p class="aimer-subtitle">
+            ${msg("webauthn-login-request")}
+        </p>
+
+        <#if message?has_content && message.type = 'error'>
+            <div class="aimer-alert">
+                <svg class="aimer-alert-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                     fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="10"/>
+                    <line x1="12" y1="8" x2="12" y2="12"/>
+                    <line x1="12" y1="16" x2="12.01" y2="16"/>
+                </svg>
+                <span>${kcSanitize(message.summary)?no_esc}</span>
+            </div>
+        </#if>
+
+        <form id="webauth" action="${url.loginAction}" method="post">
+            <input type="hidden" id="clientDataJSON" name="clientDataJSON"/>
+            <input type="hidden" id="authenticatorData" name="authenticatorData"/>
+            <input type="hidden" id="signature" name="signature"/>
+            <input type="hidden" id="credentialId" name="credentialId"/>
+            <input type="hidden" id="userHandle" name="userHandle"/>
+            <input type="hidden" id="error" name="error"/>
+        </form>
+
+        <#if authenticators??>
+            <script type="text/javascript">
+                (function() {
+                    var challenge = "${challenge}";
+                    var rpId = "${rpId}";
+                    var createTimeout = ${createTimeout};
+                    var allowCredentials = [
+                        <#list authenticators.authenticators as authenticator>
+                            {
+                                id: base64url.decode("${authenticator.credentialId}"),
+                                type: "public-key"
+                            }<#if authenticator?has_next>,</#if>
+                        </#list>
+                    ];
+
+                    var publicKey = {
+                        rpId: rpId,
+                        challenge: base64url.decode(challenge),
+                        allowCredentials: allowCredentials,
+                        timeout: createTimeout
+                    };
+
+                    navigator.credentials.get({publicKey: publicKey})
+                        .then(function(result) {
+                            document.getElementById("clientDataJSON").value = base64url.encode(new Uint8Array(result.response.clientDataJSON));
+                            document.getElementById("authenticatorData").value = base64url.encode(new Uint8Array(result.response.authenticatorData));
+                            document.getElementById("signature").value = base64url.encode(new Uint8Array(result.response.signature));
+                            document.getElementById("credentialId").value = result.id;
+                            if (result.response.userHandle) {
+                                document.getElementById("userHandle").value = base64url.encode(new Uint8Array(result.response.userHandle));
+                            }
+                            document.getElementById("webauth").submit();
+                        })
+                        .catch(function(err) {
+                            document.getElementById("error").value = err;
+                            document.getElementById("webauth").submit();
+                        });
+                })();
+            </script>
+        </#if>
+
+        <div class="aimer-footer" style="margin-top: 24px;">
+            <a href="${url.loginUrl}">${kcSanitize(msg("backToLogin"))?no_esc}</a>
+        </div>
+    </#if>
+</@layout.registrationLayout>


### PR DESCRIPTION
## Summary

- Add custom Keycloak login theme at `infra/keycloak/themes/aimer/` with full light/dark mode support using CSS custom properties and `prefers-color-scheme` media queries.
- Theme covers sign-in, registration, TOTP MFA, WebAuthn, password recovery (contact admin message), error, and info pages — all styled with the aimer-web design tokens (Pretendard + Roboto fonts, 448px card, 36px inputs/buttons, primary blue #156ef2).
- Mount theme volume in `docker-compose.yml` and set `loginTheme: "aimer"` in the realm config so Keycloak uses the custom theme automatically.

## Theme files

| File | Purpose |
|------|---------|
| `META-INF/keycloak-themes.json` | Theme manifest |
| `login/theme.properties` | Inherits from `keycloak.v2`, imports CSS |
| `login/resources/css/login.css` | All design tokens, light/dark mode, responsive |
| `login/resources/img/logo.svg` | Placeholder Aimer logo |
| `login/template.ftl` | Base HTML template with theme toggle |
| `login/login.ftl` | Sign-in page with password toggle, disabled-button logic, forgot-password modal |
| `login/register.ftl` | Registration page |
| `login/login-otp.ftl` | TOTP MFA input |
| `login/webauthn-authenticate.ftl` | WebAuthn security key prompt |
| `login/login-reset-password.ftl` | Password recovery — directs user to contact admin |
| `login/error.ftl` | Error page |
| `login/info.ftl` | Info/redirect page |

## Test plan

- [x] Run `docker compose --profile dev up` and navigate to `http://localhost:8080/realms/aimer/account`
- [x] Verify the sign-in page renders with the custom theme (card layout, blue button, Aimer logo)
- [x] Toggle system dark mode and confirm dark theme applies correctly
- [x] Click the theme toggle button (bottom-right) and confirm manual override works
- [x] Test sign-in with invalid credentials and verify error state (red border, alert banner)
- [x] Verify the "Forgot password?" link opens a modal directing user to contact admin
- [x] Verify sign-in button is disabled when fields are empty, enabled when filled
- [x] Check responsive layout on mobile viewport (card takes full width)

Closes #19