### PR TITLE
Add PostgreSQL integration tests for migration runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,6 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - uses: biomejs/setup-biome@v2
-        with:
-          version: 2.4.7
       - run: pnpm check
       - run: pnpm typecheck
       - uses: DavidAnson/markdownlint-cli2-action@v22

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
     "ignoreUnknown": true,

--- a/src/lib/db/__tests__/db-test-helpers.ts
+++ b/src/lib/db/__tests__/db-test-helpers.ts
@@ -7,8 +7,7 @@ const AUTH_ADMIN_URL =
   process.env.DATABASE_ADMIN_URL ?? process.env.DATABASE_URL;
 // For audit: prefer a dedicated audit admin URL, otherwise fall back to
 // the auth admin URL (assumes same PostgreSQL instance).
-const AUDIT_ADMIN_URL =
-  process.env.AUDIT_DATABASE_ADMIN_URL ?? AUTH_ADMIN_URL;
+const AUDIT_ADMIN_URL = process.env.AUDIT_DATABASE_ADMIN_URL ?? AUTH_ADMIN_URL;
 
 /**
  * Whether PostgreSQL is available for integration tests.

--- a/src/lib/db/__tests__/db-test-helpers.ts
+++ b/src/lib/db/__tests__/db-test-helpers.ts
@@ -1,38 +1,62 @@
 import { Pool } from "pg";
 
-const ADMIN_URL = process.env.DATABASE_URL;
+// Prefer the superuser admin URL for CREATE/DROP DATABASE operations.
+// Fall back to DATABASE_URL for CI environments where only the
+// superuser URL is provided as DATABASE_URL.
+const AUTH_ADMIN_URL =
+  process.env.DATABASE_ADMIN_URL ?? process.env.DATABASE_URL;
+// For audit: prefer a dedicated audit admin URL, otherwise fall back to
+// the auth admin URL (assumes same PostgreSQL instance).
+const AUDIT_ADMIN_URL =
+  process.env.AUDIT_DATABASE_ADMIN_URL ?? AUTH_ADMIN_URL;
 
 /**
  * Whether PostgreSQL is available for integration tests.
  * Tests should skip when this is false (local dev without Docker).
  */
-export const hasPostgres = !!ADMIN_URL;
+export const hasPostgres = !!AUTH_ADMIN_URL;
 
-let adminPool: Pool | undefined;
+const adminPools = new Map<string, Pool>();
 
-/** Pool connected to the default database (for creating/dropping test DBs). */
-export function getAdminPool(): Pool {
-  if (!adminPool) {
-    adminPool = new Pool({ connectionString: ADMIN_URL });
+/** Pool connected to the given admin URL (for creating/dropping test DBs). */
+function getAdminPool(url: string): Pool {
+  let pool = adminPools.get(url);
+  if (!pool) {
+    pool = new Pool({ connectionString: url });
+    adminPools.set(url, pool);
   }
-  return adminPool;
+  return pool;
 }
 
-/** Create a fresh test database and return a Pool connected to it. */
-export async function createTestDatabase(prefix: string): Promise<{
+/**
+ * Create a fresh test database and return a Pool connected to it.
+ *
+ * @param prefix - Name prefix for the test database
+ * @param scope  - "auth" (default) or "audit" to select the admin URL
+ */
+export async function createTestDatabase(
+  prefix: string,
+  scope: "auth" | "audit" = "auth",
+): Promise<{
   dbName: string;
   pool: Pool;
   url: string;
 }> {
+  const adminUrl = scope === "audit" ? AUDIT_ADMIN_URL : AUTH_ADMIN_URL;
+  if (!adminUrl) {
+    throw new Error(
+      `No admin URL for scope "${scope}". Set DATABASE_ADMIN_URL or AUDIT_DATABASE_ADMIN_URL.`,
+    );
+  }
+
   const dbName = `test_${prefix}_${Date.now()}`;
-  const admin = getAdminPool();
+  const admin = getAdminPool(adminUrl);
 
   await admin.query(`CREATE DATABASE ${dbName}`);
 
   // Build a connection URL for the new database by replacing the
   // database name in the admin URL.
-  // hasPostgres guard ensures ADMIN_URL is defined before this is called
-  const url = (ADMIN_URL as string).replace(/\/[^/?]+(\?|$)/, `/${dbName}$1`);
+  const url = adminUrl.replace(/\/[^/?]+(\?|$)/, `/${dbName}$1`);
   const pool = new Pool({ connectionString: url });
 
   return { dbName, pool, url };
@@ -42,11 +66,15 @@ export async function createTestDatabase(prefix: string): Promise<{
 export async function dropTestDatabase(
   dbName: string,
   pool?: Pool,
+  scope: "auth" | "audit" = "auth",
 ): Promise<void> {
   if (pool) {
     await pool.end();
   }
-  const admin = getAdminPool();
+  const adminUrl = (
+    scope === "audit" ? AUDIT_ADMIN_URL : AUTH_ADMIN_URL
+  ) as string;
+  const admin = getAdminPool(adminUrl);
   await admin.query(`
     SELECT pg_terminate_backend(pid)
     FROM pg_stat_activity
@@ -55,24 +83,30 @@ export async function dropTestDatabase(
   await admin.query(`DROP DATABASE IF EXISTS ${dbName}`);
 }
 
-/** Shut down the admin pool. Call in the top-level afterAll. */
+/** Shut down all admin pools. Call in the top-level afterAll. */
 export async function closeAdminPool(): Promise<void> {
-  if (adminPool) {
-    await adminPool.end();
-    adminPool = undefined;
+  for (const pool of adminPools.values()) {
+    await pool.end();
   }
+  adminPools.clear();
 }
 
 /**
  * Create a Pool connected to a specific database as a specific role.
  * Useful for testing role permissions (e.g., connect as aimer_auth).
+ *
+ * @param scope - "auth" or "audit" to derive host/port from the correct admin URL
  */
 export function createRolePool(
   dbName: string,
   role: string,
   password: string,
+  scope: "auth" | "audit" = "auth",
 ): Pool {
-  const parsed = new URL(ADMIN_URL as string);
+  const adminUrl = (
+    scope === "audit" ? AUDIT_ADMIN_URL : AUTH_ADMIN_URL
+  ) as string;
+  const parsed = new URL(adminUrl);
   parsed.username = role;
   parsed.password = password;
   parsed.pathname = `/${dbName}`;

--- a/src/lib/db/__tests__/db-test-helpers.ts
+++ b/src/lib/db/__tests__/db-test-helpers.ts
@@ -1,0 +1,80 @@
+import { Pool } from "pg";
+
+const ADMIN_URL = process.env.DATABASE_URL;
+
+/**
+ * Whether PostgreSQL is available for integration tests.
+ * Tests should skip when this is false (local dev without Docker).
+ */
+export const hasPostgres = !!ADMIN_URL;
+
+let adminPool: Pool | undefined;
+
+/** Pool connected to the default database (for creating/dropping test DBs). */
+export function getAdminPool(): Pool {
+  if (!adminPool) {
+    adminPool = new Pool({ connectionString: ADMIN_URL });
+  }
+  return adminPool;
+}
+
+/** Create a fresh test database and return a Pool connected to it. */
+export async function createTestDatabase(prefix: string): Promise<{
+  dbName: string;
+  pool: Pool;
+  url: string;
+}> {
+  const dbName = `test_${prefix}_${Date.now()}`;
+  const admin = getAdminPool();
+
+  await admin.query(`CREATE DATABASE ${dbName}`);
+
+  // Build a connection URL for the new database by replacing the
+  // database name in the admin URL.
+  // hasPostgres guard ensures ADMIN_URL is defined before this is called
+  const url = (ADMIN_URL as string).replace(/\/[^/?]+(\?|$)/, `/${dbName}$1`);
+  const pool = new Pool({ connectionString: url });
+
+  return { dbName, pool, url };
+}
+
+/** Drop a test database (terminates active connections first). */
+export async function dropTestDatabase(
+  dbName: string,
+  pool?: Pool,
+): Promise<void> {
+  if (pool) {
+    await pool.end();
+  }
+  const admin = getAdminPool();
+  await admin.query(`
+    SELECT pg_terminate_backend(pid)
+    FROM pg_stat_activity
+    WHERE datname = '${dbName}' AND pid <> pg_backend_pid()
+  `);
+  await admin.query(`DROP DATABASE IF EXISTS ${dbName}`);
+}
+
+/** Shut down the admin pool. Call in the top-level afterAll. */
+export async function closeAdminPool(): Promise<void> {
+  if (adminPool) {
+    await adminPool.end();
+    adminPool = undefined;
+  }
+}
+
+/**
+ * Create a Pool connected to a specific database as a specific role.
+ * Useful for testing role permissions (e.g., connect as aimer_auth).
+ */
+export function createRolePool(
+  dbName: string,
+  role: string,
+  password: string,
+): Pool {
+  const parsed = new URL(ADMIN_URL as string);
+  parsed.username = role;
+  parsed.password = password;
+  parsed.pathname = `/${dbName}`;
+  return new Pool({ connectionString: parsed.toString() });
+}

--- a/src/lib/db/__tests__/migrate.db.test.ts
+++ b/src/lib/db/__tests__/migrate.db.test.ts
@@ -1,0 +1,271 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Pool } from "pg";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { runMigrations } from "../migrate";
+import {
+  closeAdminPool,
+  createTestDatabase,
+  dropTestDatabase,
+  hasPostgres,
+} from "./db-test-helpers";
+
+describe.skipIf(!hasPostgres)(
+  "Migration runner (PostgreSQL integration)",
+  () => {
+    let dbName: string;
+    let pool: Pool;
+    let tempDir: string;
+    const LOCK_ID = 99999;
+
+    beforeAll(async () => {
+      const db = await createTestDatabase("migrate");
+      dbName = db.dbName;
+      pool = db.pool;
+    });
+
+    afterAll(async () => {
+      await dropTestDatabase(dbName, pool);
+      await closeAdminPool();
+    });
+
+    beforeEach(async () => {
+      // Reset: drop _migrations and any test tables
+      const client = await pool.connect();
+      try {
+        await client.query("DROP TABLE IF EXISTS _migrations CASCADE");
+        await client.query("DROP TABLE IF EXISTS test_table CASCADE");
+        await client.query("DROP TABLE IF EXISTS t1 CASCADE");
+        await client.query("DROP TABLE IF EXISTS t2 CASCADE");
+        await client.query("DROP TABLE IF EXISTS t3 CASCADE");
+        await client.query("DROP TABLE IF EXISTS t4 CASCADE");
+        await client.query("DROP TABLE IF EXISTS t5 CASCADE");
+        await client.query("DROP TABLE IF EXISTS ts_test CASCADE");
+      } finally {
+        client.release();
+      }
+      // Fresh temp directory for migration files
+      tempDir = await mkdtemp(join(tmpdir(), "db-migrate-"));
+    });
+
+    it("auto-creates _migrations table (idempotent)", async () => {
+      // First run: table doesn't exist yet
+      await runMigrations(pool, tempDir, LOCK_ID);
+      const { rows: r1 } = await pool.query(
+        "SELECT EXISTS (SELECT FROM pg_tables WHERE tablename = '_migrations')",
+      );
+      expect(r1[0].exists).toBe(true);
+
+      // Second run: table already exists, no error
+      await runMigrations(pool, tempDir, LOCK_ID);
+      const { rows: r2 } = await pool.query("SELECT COUNT(*) FROM _migrations");
+      expect(Number(r2[0].count)).toBe(0);
+    });
+
+    it("advisory lock prevents concurrent runners from duplicating migrations", async () => {
+      // Create a slow migration using pg_sleep
+      await writeFile(
+        join(tempDir, "0001_slow.sql"),
+        "SELECT pg_sleep(0.5); CREATE TABLE test_table (id int);",
+      );
+
+      // Launch two runners concurrently
+      const [r1, r2] = await Promise.allSettled([
+        runMigrations(pool, tempDir, LOCK_ID),
+        runMigrations(pool, tempDir, LOCK_ID),
+      ]);
+
+      expect(r1.status).toBe("fulfilled");
+      expect(r2.status).toBe("fulfilled");
+
+      // Migration should be applied exactly once
+      const { rows } = await pool.query(
+        "SELECT COUNT(*) FROM _migrations WHERE version = '0001'",
+      );
+      expect(Number(rows[0].count)).toBe(1);
+
+      // Table should exist
+      const { rows: tables } = await pool.query(
+        "SELECT EXISTS (SELECT FROM pg_tables WHERE tablename = 'test_table')",
+      );
+      expect(tables[0].exists).toBe(true);
+    });
+
+    it("no-transaction migration with CREATE INDEX CONCURRENTLY", async () => {
+      // First migration creates a table
+      await writeFile(
+        join(tempDir, "0001_create.sql"),
+        "CREATE TABLE test_table (id int, name text);",
+      );
+      await runMigrations(pool, tempDir, LOCK_ID);
+
+      // Add a no-transaction migration
+      await writeFile(
+        join(tempDir, "0002_index.sql"),
+        "-- no-transaction\nCREATE INDEX CONCURRENTLY idx_test_name ON test_table (name);",
+      );
+      await runMigrations(pool, tempDir, LOCK_ID);
+
+      // Verify index exists
+      const { rows } = await pool.query(
+        "SELECT indexname FROM pg_indexes WHERE tablename = 'test_table' AND indexname = 'idx_test_name'",
+      );
+      expect(rows).toHaveLength(1);
+    });
+
+    it("rolls back failed migration without affecting prior successes", async () => {
+      await writeFile(
+        join(tempDir, "0001_ok.sql"),
+        "CREATE TABLE test_table (id serial PRIMARY KEY);",
+      );
+      await writeFile(
+        join(tempDir, "0002_fail.sql"),
+        "CREATE TABLE nonexistent_ref (id int REFERENCES does_not_exist(id));",
+      );
+
+      await expect(runMigrations(pool, tempDir, LOCK_ID)).rejects.toThrow(
+        "0002_fail",
+      );
+
+      // Migration 1 should be committed
+      const { rows: applied } = await pool.query(
+        "SELECT version FROM _migrations",
+      );
+      expect(applied.map((r) => r.version)).toEqual(["0001"]);
+
+      // Table from migration 1 should exist
+      const { rows: tables } = await pool.query(
+        "SELECT EXISTS (SELECT FROM pg_tables WHERE tablename = 'test_table')",
+      );
+      expect(tables[0].exists).toBe(true);
+    });
+
+    it("detects checksum mismatch for modified migration", async () => {
+      await writeFile(
+        join(tempDir, "0001_init.sql"),
+        "CREATE TABLE test_table (id int);",
+      );
+      await runMigrations(pool, tempDir, LOCK_ID);
+
+      // Modify the file
+      await writeFile(
+        join(tempDir, "0001_init.sql"),
+        "CREATE TABLE test_table (id int, extra text);",
+      );
+
+      await expect(runMigrations(pool, tempDir, LOCK_ID)).rejects.toThrow(
+        "Checksum mismatch",
+      );
+    });
+
+    it("commits migrations 1-2, fails on 3, skips 4-5", async () => {
+      await writeFile(
+        join(tempDir, "0001_t1.sql"),
+        "CREATE TABLE t1 (id int);",
+      );
+      await writeFile(
+        join(tempDir, "0002_t2.sql"),
+        "CREATE TABLE t2 (id int);",
+      );
+      await writeFile(join(tempDir, "0003_t3.sql"), "INVALID SQL STATEMENT;");
+      await writeFile(
+        join(tempDir, "0004_t4.sql"),
+        "CREATE TABLE t4 (id int);",
+      );
+      await writeFile(
+        join(tempDir, "0005_t5.sql"),
+        "CREATE TABLE t5 (id int);",
+      );
+
+      await expect(runMigrations(pool, tempDir, LOCK_ID)).rejects.toThrow(
+        "0003_t3",
+      );
+
+      // Only 1-2 recorded
+      const { rows: applied } = await pool.query(
+        "SELECT version FROM _migrations ORDER BY version",
+      );
+      expect(applied.map((r) => r.version)).toEqual(["0001", "0002"]);
+
+      // t1, t2 exist; t3, t4, t5 don't
+      for (const [table, expected] of [
+        ["t1", true],
+        ["t2", true],
+        ["t3", false],
+        ["t4", false],
+        ["t5", false],
+      ] as const) {
+        const { rows } = await pool.query(
+          `SELECT EXISTS (SELECT FROM pg_tables WHERE tablename = '${table}')`,
+        );
+        expect(rows[0].exists).toBe(expected);
+      }
+    });
+
+    it("executes TypeScript migration with default export function", async () => {
+      // Create the target table first
+      await writeFile(
+        join(tempDir, "0001_setup.sql"),
+        "CREATE TABLE ts_test (id serial PRIMARY KEY, value text);",
+      );
+
+      // Create a .ts migration that inserts a row
+      await writeFile(
+        join(tempDir, "0002_seed.ts"),
+        `export default async function(client) {
+          await client.query("INSERT INTO ts_test (value) VALUES ('hello')");
+        }`,
+      );
+
+      await runMigrations(pool, tempDir, LOCK_ID);
+
+      // Verify the row was inserted
+      const { rows } = await pool.query("SELECT value FROM ts_test");
+      expect(rows).toEqual([{ value: "hello" }]);
+
+      // Verify both migrations recorded
+      const { rows: applied } = await pool.query(
+        "SELECT version FROM _migrations ORDER BY version",
+      );
+      expect(applied.map((r) => r.version)).toEqual(["0001", "0002"]);
+    });
+
+    it("rejects TypeScript migration without default function export", async () => {
+      await writeFile(
+        join(tempDir, "0001_bad.ts"),
+        'export default "not a function";',
+      );
+
+      await expect(runMigrations(pool, tempDir, LOCK_ID)).rejects.toThrow(
+        "must export a default function",
+      );
+    });
+
+    it("passes MigrationContext to TypeScript migration", async () => {
+      // Create a table to store the context proof
+      await writeFile(
+        join(tempDir, "0001_setup.sql"),
+        "CREATE TABLE ts_test (id serial PRIMARY KEY, value text);",
+      );
+
+      // Migration that uses context
+      await writeFile(
+        join(tempDir, "0002_ctx.ts"),
+        `export default async function(client, context) {
+          const val = context?.decryptDek ? "has_context" : "no_context";
+          await client.query("INSERT INTO ts_test (value) VALUES ($1)", [val]);
+        }`,
+      );
+
+      const mockContext = {
+        decryptDek: async () => Buffer.from("test"),
+      };
+
+      await runMigrations(pool, tempDir, LOCK_ID, mockContext);
+
+      const { rows } = await pool.query("SELECT value FROM ts_test");
+      expect(rows[0].value).toBe("has_context");
+    });
+  },
+);

--- a/src/lib/db/__tests__/schema.db.test.ts
+++ b/src/lib/db/__tests__/schema.db.test.ts
@@ -394,7 +394,7 @@ describe.skipIf(!hasPostgres)("Schema verification (audit_db)", () => {
   let pool: Pool;
 
   beforeAll(async () => {
-    const db = await createTestDatabase("schema_audit");
+    const db = await createTestDatabase("schema_audit", "audit");
     dbName = db.dbName;
     pool = db.pool;
 
@@ -403,7 +403,7 @@ describe.skipIf(!hasPostgres)("Schema verification (audit_db)", () => {
   });
 
   afterAll(async () => {
-    await dropTestDatabase(dbName, pool);
+    await dropTestDatabase(dbName, pool, "audit");
     await closeAdminPool();
   });
 
@@ -436,7 +436,7 @@ describe.skipIf(!hasPostgres)("Schema verification (audit_db)", () => {
         "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO aimer_audit",
       );
 
-      rolePool = createRolePool(dbName, "aimer_audit", "changeme");
+      rolePool = createRolePool(dbName, "aimer_audit", "changeme", "audit");
     });
 
     afterAll(async () => {

--- a/src/lib/db/__tests__/schema.db.test.ts
+++ b/src/lib/db/__tests__/schema.db.test.ts
@@ -198,6 +198,39 @@ describe.skipIf(!hasPostgres)("Schema verification (auth_db)", () => {
       ).rejects.toThrow();
     });
 
+    it("customers.external_key", async () => {
+      await pool.query(
+        "INSERT INTO customers (external_key, name) VALUES ('dup_ek', 'C1')",
+      );
+      await expect(
+        pool.query(
+          "INSERT INTO customers (external_key, name) VALUES ('dup_ek', 'C2')",
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("roles.name", async () => {
+      await pool.query(
+        "INSERT INTO roles (name, auth_context) VALUES ('uniq_role', 'general')",
+      );
+      await expect(
+        pool.query(
+          "INSERT INTO roles (name, auth_context) VALUES ('uniq_role', 'general')",
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("pending_connections.jti", async () => {
+      await pool.query(
+        "INSERT INTO pending_connections (jti, issuer, aice_id, customer_ids, expires_at) VALUES ('dup_jti', 'i', 'a', ARRAY['x'], NOW())",
+      );
+      await expect(
+        pool.query(
+          "INSERT INTO pending_connections (jti, issuer, aice_id, customer_ids, expires_at) VALUES ('dup_jti', 'i', 'a', ARRAY['x'], NOW())",
+        ),
+      ).rejects.toThrow();
+    });
+
     it("trust_registry(aice_id, issuer, kid)", async () => {
       // Create prerequisite aice_environment
       await pool.query(
@@ -343,27 +376,49 @@ describe.skipIf(!hasPostgres)("Schema verification (auth_db)", () => {
     });
 
     it("can SELECT, INSERT, UPDATE, DELETE on application tables", async () => {
-      // INSERT
+      // Test CRUD on customers
       const { rows } = await rolePool.query(
         "INSERT INTO customers (external_key, name) VALUES ('role_test', 'RoleC') RETURNING id",
       );
       expect(rows).toHaveLength(1);
 
-      // SELECT
       const { rows: selected } = await rolePool.query(
         "SELECT name FROM customers WHERE external_key = 'role_test'",
       );
       expect(selected[0].name).toBe("RoleC");
 
-      // UPDATE
       await rolePool.query(
         "UPDATE customers SET name = 'Updated' WHERE external_key = 'role_test'",
       );
 
-      // DELETE
       await rolePool.query(
         "DELETE FROM customers WHERE external_key = 'role_test'",
       );
+    });
+
+    it("can access all granted application tables", async () => {
+      // Verify SELECT on every table granted in 0012_runtime_role.sql.
+      // Full CRUD tables (13 total):
+      const crudTables = [
+        "system_settings",
+        "customers",
+        "accounts",
+        "account_customer_memberships",
+        "analyst_customer_assignments",
+        "sessions",
+        "aice_environments",
+        "aice_environment_customers",
+        "trust_registry",
+        "pending_connections",
+        "invitations",
+        "analyst_invitations",
+        "staged_event_payloads",
+        "staged_event_customers",
+      ];
+      for (const table of crudTables) {
+        const { rows } = await rolePool.query(`SELECT COUNT(*) FROM ${table}`);
+        expect(Number(rows[0].count)).toBeGreaterThanOrEqual(0);
+      }
     });
 
     it("can only SELECT on roles and role_permissions", async () => {

--- a/src/lib/db/__tests__/schema.db.test.ts
+++ b/src/lib/db/__tests__/schema.db.test.ts
@@ -1,0 +1,464 @@
+import { join } from "node:path";
+import type { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { runMigrations } from "../migrate";
+import {
+  closeAdminPool,
+  createRolePool,
+  createTestDatabase,
+  dropTestDatabase,
+  hasPostgres,
+} from "./db-test-helpers";
+
+const MIGRATIONS_ROOT = join(process.cwd(), "migrations");
+const LOCK_ID_AUTH = 1000;
+const LOCK_ID_AUDIT = 1001;
+
+describe.skipIf(!hasPostgres)("Schema verification (auth_db)", () => {
+  let dbName: string;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    const db = await createTestDatabase("schema_auth");
+    dbName = db.dbName;
+    pool = db.pool;
+
+    // Apply all auth migrations
+    await runMigrations(pool, join(MIGRATIONS_ROOT, "auth"), LOCK_ID_AUTH);
+  });
+
+  afterAll(async () => {
+    await dropTestDatabase(dbName, pool);
+  });
+
+  it("applies all 15 auth migrations cleanly", async () => {
+    const { rows } = await pool.query(
+      "SELECT version FROM _migrations ORDER BY version",
+    );
+    expect(rows).toHaveLength(15);
+  });
+
+  // -- Built-in roles --
+
+  it("seeds 4 built-in roles with correct permission counts", async () => {
+    const { rows } = await pool.query(`
+      SELECT r.name, r.auth_context, COUNT(rp.permission)::int AS perm_count
+      FROM roles r
+      LEFT JOIN role_permissions rp ON rp.role_id = r.id
+      WHERE r.is_builtin = true
+      GROUP BY r.id, r.name, r.auth_context
+      ORDER BY r.name
+    `);
+
+    expect(rows).toEqual([
+      { name: "Analyst", auth_context: "general", perm_count: 12 },
+      { name: "Manager", auth_context: "general", perm_count: 11 },
+      {
+        name: "System Administrator",
+        auth_context: "admin",
+        perm_count: 13,
+      },
+      { name: "User", auth_context: "general", perm_count: 7 },
+    ]);
+  });
+
+  // -- CHECK constraints: sessions --
+
+  describe("sessions CHECK constraints", () => {
+    let accountId: string;
+
+    beforeAll(async () => {
+      // Insert prerequisite data
+      const { rows } = await pool.query(
+        "INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name) VALUES ('test', 'sub1', 'testuser', 'Test') RETURNING id",
+      );
+      accountId = rows[0].id;
+    });
+
+    it("rejects admin session with bridge fields", async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO sessions (account_id, auth_context, bridge_aice_id, bridge_customer_ids, ip_address, user_agent)
+           VALUES ($1, 'admin', 'aice1', ARRAY[$2]::uuid[], '1.1.1.1', 'test')`,
+          [accountId, "00000000-0000-0000-0000-000000000001"],
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("rejects session with only one bridge field NULL", async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO sessions (account_id, auth_context, bridge_aice_id, bridge_customer_ids, ip_address, user_agent)
+           VALUES ($1, 'general', 'aice1', NULL, '1.1.1.1', 'test')`,
+          [accountId],
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  // -- CHECK constraints: status enums --
+
+  describe("status CHECK constraints reject invalid values", () => {
+    it("customers.status", async () => {
+      await expect(
+        pool.query(
+          "INSERT INTO customers (external_key, name, status) VALUES ('ck1', 'c', 'invalid')",
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("customers.database_status", async () => {
+      await expect(
+        pool.query(
+          "INSERT INTO customers (external_key, name, database_status) VALUES ('ck2', 'c', 'invalid')",
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("accounts.status", async () => {
+      await expect(
+        pool.query(
+          "INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, status) VALUES ('i', 's2', 'u', 'd', 'invalid')",
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("pending_connections.status", async () => {
+      await expect(
+        pool.query(
+          "INSERT INTO pending_connections (jti, issuer, aice_id, customer_ids, status, expires_at) VALUES ('j1', 'i', 'a', ARRAY['x'], 'invalid', NOW())",
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("invitations.status", async () => {
+      await expect(
+        pool.query(
+          "INSERT INTO invitations (token_hash, customer_id, invited_email, role_id, invited_by, status) VALUES ('h1', gen_random_uuid(), 'a@b.c', 1, gen_random_uuid(), 'invalid')",
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("analyst_invitations.status", async () => {
+      await expect(
+        pool.query(
+          "INSERT INTO analyst_invitations (email, invited_by, token_hash, status) VALUES ('a@b.c', gen_random_uuid(), 'h2', 'invalid')",
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("staged_event_customers.status", async () => {
+      await expect(
+        pool.query(
+          "INSERT INTO staged_event_customers (payload_id, customer_id, status) VALUES (gen_random_uuid(), gen_random_uuid(), 'invalid')",
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  // -- UNIQUE constraints --
+
+  describe("UNIQUE constraints reject duplicates", () => {
+    it("accounts(oidc_issuer, oidc_subject)", async () => {
+      await pool.query(
+        "INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name) VALUES ('iss1', 'dup', 'u1', 'D1')",
+      );
+      await expect(
+        pool.query(
+          "INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name) VALUES ('iss1', 'dup', 'u2', 'D2')",
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("invitations partial unique (customer_id, email) WHERE pending", async () => {
+      // Create prerequisite customer and account
+      const { rows: cRows } = await pool.query(
+        "INSERT INTO customers (external_key, name) VALUES ('uniq_test', 'C') RETURNING id",
+      );
+      const custId = cRows[0].id;
+      const { rows: aRows } = await pool.query(
+        "INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name) VALUES ('iss2', 'sub_uniq', 'u3', 'D3') RETURNING id",
+      );
+      const acctId = aRows[0].id;
+      // Get a general-context role
+      const { rows: rRows } = await pool.query(
+        "SELECT id FROM roles WHERE name = 'User'",
+      );
+      const roleId = rRows[0].id;
+
+      await pool.query(
+        "INSERT INTO invitations (token_hash, customer_id, invited_email, role_id, invited_by, status) VALUES ('t1', $1, 'dup@test.com', $2, $3, 'pending')",
+        [custId, roleId, acctId],
+      );
+      await expect(
+        pool.query(
+          "INSERT INTO invitations (token_hash, customer_id, invited_email, role_id, invited_by, status) VALUES ('t2', $1, 'dup@test.com', $2, $3, 'pending')",
+          [custId, roleId, acctId],
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("trust_registry(aice_id, issuer, kid)", async () => {
+      // Create prerequisite aice_environment
+      await pool.query(
+        "INSERT INTO aice_environments (aice_id, name) VALUES ('aice_uniq', 'Env')",
+      );
+      await pool.query(
+        "INSERT INTO trust_registry (aice_id, issuer, kid, public_key) VALUES ('aice_uniq', 'iss', 'kid1', '{}')",
+      );
+      await expect(
+        pool.query(
+          "INSERT INTO trust_registry (aice_id, issuer, kid, public_key) VALUES ('aice_uniq', 'iss', 'kid1', '{}')",
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  // -- Triggers --
+
+  describe("triggers enforce auth_context separation", () => {
+    let adminRoleId: number;
+    let customerId: string;
+    let accountId: string;
+
+    beforeAll(async () => {
+      const { rows: roles } = await pool.query(
+        "SELECT id, auth_context FROM roles WHERE name IN ('System Administrator', 'User') ORDER BY name",
+      );
+      adminRoleId = roles.find((r) => r.auth_context === "admin")?.id;
+
+      const { rows: cRows } = await pool.query(
+        "INSERT INTO customers (external_key, name) VALUES ('trg_test', 'TrgC') RETURNING id",
+      );
+      customerId = cRows[0].id;
+
+      const { rows: aRows } = await pool.query(
+        "INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name) VALUES ('trg_iss', 'trg_sub', 'trg_u', 'Trg') RETURNING id",
+      );
+      accountId = aRows[0].id;
+    });
+
+    it("trg_membership_role_check rejects admin-context role", async () => {
+      await expect(
+        pool.query(
+          "INSERT INTO account_customer_memberships (account_id, customer_id, role_id) VALUES ($1, $2, $3)",
+          [accountId, customerId, adminRoleId],
+        ),
+      ).rejects.toThrow("auth_context=general");
+    });
+
+    it("trg_invitation_role_check rejects admin-context role", async () => {
+      await expect(
+        pool.query(
+          "INSERT INTO invitations (token_hash, customer_id, invited_email, role_id, invited_by) VALUES ('trg_t1', $1, 'x@y.z', $2, $3)",
+          [customerId, adminRoleId, accountId],
+        ),
+      ).rejects.toThrow("auth_context=general");
+    });
+
+    it("trg_roles_auth_context_guard rejects general→admin when referenced by memberships", async () => {
+      // Create a custom general role referenced by a membership
+      const { rows: rRows } = await pool.query(
+        "INSERT INTO roles (name, auth_context) VALUES ('guard_test_m', 'general') RETURNING id",
+      );
+      const roleId = rRows[0].id;
+      await pool.query(
+        "INSERT INTO account_customer_memberships (account_id, customer_id, role_id) VALUES ($1, $2, $3)",
+        [accountId, customerId, roleId],
+      );
+
+      await expect(
+        pool.query("UPDATE roles SET auth_context = 'admin' WHERE id = $1", [
+          roleId,
+        ]),
+      ).rejects.toThrow("account_customer_memberships");
+    });
+
+    it("trg_roles_auth_context_guard rejects general→admin when referenced by invitations", async () => {
+      const { rows: rRows } = await pool.query(
+        "INSERT INTO roles (name, auth_context) VALUES ('guard_test_i', 'general') RETURNING id",
+      );
+      const roleId = rRows[0].id;
+      await pool.query(
+        "INSERT INTO invitations (token_hash, customer_id, invited_email, role_id, invited_by) VALUES ('guard_i1', $1, 'g@h.i', $2, $3)",
+        [customerId, roleId, accountId],
+      );
+
+      await expect(
+        pool.query("UPDATE roles SET auth_context = 'admin' WHERE id = $1", [
+          roleId,
+        ]),
+      ).rejects.toThrow("invitations");
+    });
+
+    it("trg_roles_auth_context_guard rejects general→admin when referenced by both", async () => {
+      const { rows: rRows } = await pool.query(
+        "INSERT INTO roles (name, auth_context) VALUES ('guard_test_b', 'general') RETURNING id",
+      );
+      const roleId = rRows[0].id;
+
+      // Create a new account to avoid PK conflict
+      const { rows: aRows } = await pool.query(
+        "INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name) VALUES ('trg_iss2', 'trg_sub2', 'trg_u2', 'Trg2') RETURNING id",
+      );
+      const acctId2 = aRows[0].id;
+
+      await pool.query(
+        "INSERT INTO account_customer_memberships (account_id, customer_id, role_id) VALUES ($1, $2, $3)",
+        [acctId2, customerId, roleId],
+      );
+      await pool.query(
+        "INSERT INTO invitations (token_hash, customer_id, invited_email, role_id, invited_by) VALUES ('guard_b1', $1, 'b@c.d', $2, $3)",
+        [customerId, roleId, acctId2],
+      );
+
+      await expect(
+        pool.query("UPDATE roles SET auth_context = 'admin' WHERE id = $1", [
+          roleId,
+        ]),
+      ).rejects.toThrow("account_customer_memberships");
+    });
+  });
+
+  // -- Runtime role permissions --
+
+  describe("runtime role (aimer_auth) permissions", () => {
+    let rolePool: Pool;
+
+    beforeAll(async () => {
+      // Grant aimer_auth the necessary privileges on the test database.
+      // The init-audit-db.sql only grants on the original auth_db, not
+      // our test database. We must grant here.
+      await pool.query(`GRANT CONNECT ON DATABASE ${dbName} TO aimer_auth`);
+      await pool.query("GRANT USAGE ON SCHEMA public TO aimer_auth");
+      // Re-run the runtime role grants (migration 0012 already ran but
+      // on this test DB as superuser — the GRANT statements are
+      // effective because the tables were created by the superuser).
+
+      rolePool = createRolePool(dbName, "aimer_auth", "changeme");
+    });
+
+    afterAll(async () => {
+      await rolePool.end();
+    });
+
+    it("can SELECT, INSERT, UPDATE, DELETE on application tables", async () => {
+      // INSERT
+      const { rows } = await rolePool.query(
+        "INSERT INTO customers (external_key, name) VALUES ('role_test', 'RoleC') RETURNING id",
+      );
+      expect(rows).toHaveLength(1);
+
+      // SELECT
+      const { rows: selected } = await rolePool.query(
+        "SELECT name FROM customers WHERE external_key = 'role_test'",
+      );
+      expect(selected[0].name).toBe("RoleC");
+
+      // UPDATE
+      await rolePool.query(
+        "UPDATE customers SET name = 'Updated' WHERE external_key = 'role_test'",
+      );
+
+      // DELETE
+      await rolePool.query(
+        "DELETE FROM customers WHERE external_key = 'role_test'",
+      );
+    });
+
+    it("can only SELECT on roles and role_permissions", async () => {
+      // SELECT should work
+      const { rows } = await rolePool.query("SELECT COUNT(*) FROM roles");
+      expect(Number(rows[0].count)).toBeGreaterThan(0);
+
+      // INSERT should fail
+      await expect(
+        rolePool.query(
+          "INSERT INTO roles (name, auth_context) VALUES ('hack', 'general')",
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("cannot perform DDL", async () => {
+      await expect(
+        rolePool.query("CREATE TABLE hack_table (id int)"),
+      ).rejects.toThrow();
+    });
+  });
+});
+
+// -- Audit database tests --
+
+describe.skipIf(!hasPostgres)("Schema verification (audit_db)", () => {
+  let dbName: string;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    const db = await createTestDatabase("schema_audit");
+    dbName = db.dbName;
+    pool = db.pool;
+
+    // Apply all audit migrations
+    await runMigrations(pool, join(MIGRATIONS_ROOT, "audit"), LOCK_ID_AUDIT);
+  });
+
+  afterAll(async () => {
+    await dropTestDatabase(dbName, pool);
+    await closeAdminPool();
+  });
+
+  it("applies both audit migrations cleanly", async () => {
+    const { rows } = await pool.query(
+      "SELECT version FROM _migrations ORDER BY version",
+    );
+    expect(rows).toHaveLength(2);
+  });
+
+  it("audit_logs.auth_context rejects invalid values", async () => {
+    await expect(
+      pool.query(
+        "INSERT INTO audit_logs (actor_id, auth_context, action, target_type) VALUES ('a', 'invalid', 'test', 'test')",
+      ),
+    ).rejects.toThrow();
+  });
+
+  describe("audit runtime role (aimer_audit) permissions", () => {
+    let rolePool: Pool;
+
+    beforeAll(async () => {
+      await pool.query(`GRANT CONNECT ON DATABASE ${dbName} TO aimer_audit`);
+      await pool.query("GRANT USAGE ON SCHEMA public TO aimer_audit");
+      // The audit role grants are applied by migration 0001_audit_roles.sql
+      // which grants to aimer_audit_owner and aimer_audit. Since we ran
+      // migrations as superuser, re-grant explicitly.
+      await pool.query("GRANT SELECT, INSERT ON audit_logs TO aimer_audit");
+      await pool.query(
+        "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO aimer_audit",
+      );
+
+      rolePool = createRolePool(dbName, "aimer_audit", "changeme");
+    });
+
+    afterAll(async () => {
+      await rolePool.end();
+    });
+
+    it("can INSERT and SELECT on audit_logs", async () => {
+      await rolePool.query(
+        "INSERT INTO audit_logs (actor_id, action, target_type) VALUES ('test', 'test', 'test')",
+      );
+      const { rows } = await rolePool.query("SELECT COUNT(*) FROM audit_logs");
+      expect(Number(rows[0].count)).toBeGreaterThan(0);
+    });
+
+    it("cannot UPDATE or DELETE on audit_logs", async () => {
+      await expect(
+        rolePool.query("UPDATE audit_logs SET action = 'hack' WHERE id = 1"),
+      ).rejects.toThrow();
+
+      await expect(
+        rolePool.query("DELETE FROM audit_logs WHERE id = 1"),
+      ).rejects.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add 9 migration runner integration tests: advisory lock contention, `_migrations` table idempotency, `-- no-transaction` with `CREATE INDEX CONCURRENTLY`, rollback on failure, checksum mismatch, multi-migration partial failure, TS migration execution/error/context passthrough
- Add 30 schema verification tests: all auth/audit migrations apply cleanly, built-in roles with correct permission counts, CHECK constraints (sessions, status enums), UNIQUE constraints (6 cases), trigger enforcement (membership/invitation role checks, auth context guard), runtime role CRUD + table access for all 14 granted tables, audit role INSERT/SELECT-only restriction
- Add shared `db-test-helpers.ts` with test database create/drop and role pool factory (supports separate auth/audit admin URLs)
- Use latest biome in CI instead of pinned version

## Test plan

- [x] CI `db` job passes with all 39 new tests
- [x] CI `unit` job still passes (17 existing tests unaffected)
- [x] CI `check` job passes (biome, typecheck)

Closes #66