### PR TITLE
Add same-account enforcement and session coexistence

### DIFF
--- a/src/app/api/admin-auth/callback/route.ts
+++ b/src/app/api/admin-auth/callback/route.ts
@@ -115,9 +115,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return denyRedirect(request, "account_inactive");
   }
 
-  // Same-account enforcement: revoke previous account's sessions if different
-  await enforceSameAccount(request, account.id, "admin", meta);
-
   // Admin-specific verification (acr, auth_time, role, admin_eligible)
   const denyReason = verifyAdminClaims(idClaims, account.admin_eligible);
   if (denyReason) {
@@ -132,6 +129,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     });
     return denyRedirect(request, denyReason);
   }
+
+  // Same-account enforcement: only after all deny checks pass
+  await enforceSameAccount(request, account.id, "admin", meta);
 
   // Create admin session
   const sessionRows = await query<{ sid: string }>(

--- a/src/app/api/admin-auth/callback/route.ts
+++ b/src/app/api/admin-auth/callback/route.ts
@@ -13,6 +13,7 @@ import { exchangeCodeForTokens, getIssuerUrl } from "@/lib/auth/oidc";
 import { getOidcDiscovery } from "@/lib/auth/oidc-discovery";
 import { validateIdToken } from "@/lib/auth/oidc-validate";
 import { extractRequestMeta } from "@/lib/auth/request-meta";
+import { enforceSameAccount } from "@/lib/auth/same-account";
 import { getAuthPool, query, withTransaction } from "@/lib/db/client";
 
 function denyRedirect(request: NextRequest, reason: string): NextResponse {
@@ -113,6 +114,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     });
     return denyRedirect(request, "account_inactive");
   }
+
+  // Same-account enforcement: revoke previous account's sessions if different
+  await enforceSameAccount(request, account.id, "admin", meta);
 
   // Admin-specific verification (acr, auth_time, role, admin_eligible)
   const denyReason = verifyAdminClaims(idClaims, account.admin_eligible);

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -114,9 +114,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return denyRedirect(request, "account_inactive");
   }
 
-  // Same-account enforcement: revoke previous account's sessions if different
-  await enforceSameAccount(request, account.id, "general", meta);
-
   // Invitation stub (#51): check for invitation_token cookie
   const invitationToken = request.cookies.get("invitation_token")?.value;
   if (invitationToken) {
@@ -143,6 +140,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     });
     return denyRedirect(request, "no_access");
   }
+
+  // Same-account enforcement: only after all deny checks pass
+  await enforceSameAccount(request, account.id, "general", meta);
 
   // Create session
   const sessionRows = await query<{ sid: string }>(

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -12,6 +12,7 @@ import { exchangeCodeForTokens, getIssuerUrl } from "@/lib/auth/oidc";
 import { getOidcDiscovery } from "@/lib/auth/oidc-discovery";
 import { validateIdToken } from "@/lib/auth/oidc-validate";
 import { extractRequestMeta } from "@/lib/auth/request-meta";
+import { enforceSameAccount } from "@/lib/auth/same-account";
 import { getAuthPool, query, withTransaction } from "@/lib/db/client";
 
 function denyRedirect(request: NextRequest, reason: string): NextResponse {
@@ -112,6 +113,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     });
     return denyRedirect(request, "account_inactive");
   }
+
+  // Same-account enforcement: revoke previous account's sessions if different
+  await enforceSameAccount(request, account.id, "general", meta);
 
   // Invitation stub (#51): check for invitation_token cookie
   const invitationToken = request.cookies.get("invitation_token")?.value;

--- a/src/lib/auth/__tests__/auth-flow.db.test.ts
+++ b/src/lib/auth/__tests__/auth-flow.db.test.ts
@@ -353,4 +353,98 @@ describe.skipIf(!hasPostgres)("auth flow integration", () => {
       );
     });
   });
+
+  // -- Same-account enforcement --
+
+  describe("same-account enforcement", () => {
+    let accountAId: string;
+    let accountBId: string;
+
+    beforeAll(async () => {
+      const acctA = await pool.query<{ id: string }>(
+        `SELECT id FROM accounts WHERE oidc_subject = 'user-001'`,
+      );
+      accountAId = acctA.rows[0].id;
+
+      // Create account B
+      const acctB = await pool.query<{ id: string }>(
+        `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name)
+         VALUES ('test-issuer', 'user-002', 'userB', 'User B')
+         ON CONFLICT (oidc_issuer, oidc_subject) DO UPDATE SET username = 'userB'
+         RETURNING id`,
+      );
+      accountBId = acctB.rows[0].id;
+    });
+
+    it("revokes all sessions for previous account on different-account sign-in", async () => {
+      // Create sessions for account A (both general and admin)
+      await pool.query(
+        `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent)
+         VALUES ($1, 'general', '1.1.1.1', 'test')`,
+        [accountAId],
+      );
+      await pool.query(
+        `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent)
+         VALUES ($1, 'admin', '1.1.1.1', 'test')`,
+        [accountAId],
+      );
+
+      // Simulate different-account enforcement: revoke all of A's sessions
+      await pool.query(
+        `UPDATE sessions SET revoked = true WHERE account_id = $1 AND revoked = false`,
+        [accountAId],
+      );
+
+      // Verify A has no active sessions
+      const activeA = await pool.query<{ count: number }>(
+        `SELECT COUNT(*)::int AS count FROM sessions
+         WHERE account_id = $1 AND revoked = false`,
+        [accountAId],
+      );
+      expect(activeA.rows[0].count).toBe(0);
+
+      // Create session for account B (the new account)
+      const sessionB = await pool.query<{ sid: string }>(
+        `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent)
+         VALUES ($1, 'general', '1.1.1.1', 'test')
+         RETURNING sid`,
+        [accountBId],
+      );
+      expect(sessionB.rows).toHaveLength(1);
+    });
+
+    it("preserves sessions for same-account sign-in", async () => {
+      // Create a general session for account B
+      await pool.query(
+        `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent)
+         VALUES ($1, 'general', '2.2.2.2', 'test')`,
+        [accountBId],
+      );
+
+      // Account B signs in as admin (same account) — no revocation
+      const activeB = await pool.query<{ count: number }>(
+        `SELECT COUNT(*)::int AS count FROM sessions
+         WHERE account_id = $1 AND revoked = false`,
+        [accountBId],
+      );
+      expect(activeB.rows[0].count).toBeGreaterThanOrEqual(1);
+
+      // Add admin session alongside
+      await pool.query(
+        `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent)
+         VALUES ($1, 'admin', '2.2.2.2', 'test')`,
+        [accountBId],
+      );
+
+      // Both sessions coexist
+      const contexts = await pool.query<{ auth_context: string }>(
+        `SELECT DISTINCT auth_context FROM sessions
+         WHERE account_id = $1 AND revoked = false`,
+        [accountBId],
+      );
+      const ctxSet = new Set(contexts.rows.map((r) => r.auth_context));
+      expect(ctxSet.has("general")).toBe(true);
+      expect(ctxSet.has("admin")).toBe(true);
+    });
+  });
 });

--- a/src/lib/auth/__tests__/same-account.unit.test.ts
+++ b/src/lib/auth/__tests__/same-account.unit.test.ts
@@ -1,0 +1,70 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { signJwt } from "../jwt";
+import { clearKeyPairCache } from "../jwt-keys";
+
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "same-account-test-"));
+  vi.stubEnv("DATA_DIR", tmpDir);
+  vi.stubEnv("JWT_EXPIRATION_MINUTES", "10");
+  vi.stubEnv("CSRF_SECRET", "test-secret");
+  clearKeyPairCache();
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+  clearKeyPairCache();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("same-account enforcement logic", () => {
+  it("same account (sub matches) → no revocation needed", async () => {
+    const { token: generalToken } = await signJwt(
+      { sub: "account-A", sid: "sid-1", ctx: "general", tv: 0 },
+      "general",
+    );
+    const { token: adminToken } = await signJwt(
+      { sub: "account-A", sid: "sid-2", ctx: "admin", tv: 0 },
+      "admin",
+    );
+
+    // Both tokens have the same sub — same account
+    // Parse and compare sub claims
+    const { verifyJwtForLogout } = await import("../jwt");
+    const generalClaims = await verifyJwtForLogout(generalToken, "general");
+    const adminClaims = await verifyJwtForLogout(adminToken, "admin");
+
+    expect(generalClaims?.sub).toBe("account-A");
+    expect(adminClaims?.sub).toBe("account-A");
+    expect(generalClaims?.sub).toBe(adminClaims?.sub);
+  });
+
+  it("different account (sub differs) → revocation needed", async () => {
+    const { token: tokenA } = await signJwt(
+      { sub: "account-A", sid: "sid-1", ctx: "general", tv: 0 },
+      "general",
+    );
+    const { token: tokenB } = await signJwt(
+      { sub: "account-B", sid: "sid-2", ctx: "admin", tv: 0 },
+      "admin",
+    );
+
+    const { verifyJwtForLogout } = await import("../jwt");
+    const claimsA = await verifyJwtForLogout(tokenA, "general");
+    const claimsB = await verifyJwtForLogout(tokenB, "admin");
+
+    expect(claimsA?.sub).toBe("account-A");
+    expect(claimsB?.sub).toBe("account-B");
+    expect(claimsA?.sub).not.toBe(claimsB?.sub);
+  });
+
+  it("invalid other token → treat as no session (no revocation)", async () => {
+    const { verifyJwtForLogout } = await import("../jwt");
+    const result = await verifyJwtForLogout("invalid.token.here");
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/auth/same-account.ts
+++ b/src/lib/auth/same-account.ts
@@ -1,0 +1,62 @@
+import type { NextRequest } from "next/server";
+import { getAuthPool, query } from "../db/client";
+import { auditLog } from "./audit-stub";
+import { type AuthContext, clearAllAuthCookies } from "./cookies";
+import { verifyJwtForLogout } from "./jwt";
+
+/**
+ * Cross-check the other auth context's cookie. If it belongs to a
+ * different account, revoke all sessions for the previous account
+ * and clear all cookies. Same-account sessions are preserved.
+ *
+ * Returns the previous account ID if revocation occurred, or null.
+ */
+export async function enforceSameAccount(
+  request: NextRequest,
+  currentAccountId: string,
+  currentCtx: AuthContext,
+  meta: { ipAddress: string },
+): Promise<string | null> {
+  // Determine which cookie to cross-check
+  const otherCookieName = currentCtx === "general" ? "at_admin" : "at";
+  const otherToken = request.cookies.get(otherCookieName)?.value;
+
+  if (!otherToken) {
+    return null;
+  }
+
+  const otherClaims = await verifyJwtForLogout(otherToken);
+  if (!otherClaims) {
+    // Signature failed — treat as no valid existing session
+    return null;
+  }
+
+  // Same account — sessions coexist
+  if (otherClaims.sub === currentAccountId) {
+    return null;
+  }
+
+  // Different account — revoke all sessions for the previous account
+  const previousAccountId = otherClaims.sub;
+  const pool = getAuthPool();
+
+  await query(
+    pool,
+    `UPDATE sessions SET revoked = true WHERE account_id = $1 AND revoked = false`,
+    [previousAccountId],
+  );
+
+  await clearAllAuthCookies();
+
+  await auditLog({
+    actorId: currentAccountId,
+    authContext: currentCtx,
+    action: "auth.same_account_enforcement",
+    targetType: "account",
+    targetId: previousAccountId,
+    details: { reason: "different_account_sign_in" },
+    ipAddress: meta.ipAddress,
+  });
+
+  return previousAccountId;
+}


### PR DESCRIPTION
## Summary

- Add `enforceSameAccount()` helper that cross-checks the other auth context's cookie after account upsert in both general and admin callbacks
- Different account detected: revoke ALL sessions for the previous account, clear all cookies, then create the new session normally
- Same account: sessions coexist (general + admin in the same browser)
- Uniform behavior for both general→admin and admin→general sign-in directions

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm biome check` passes
- [x] `pnpm vitest run` — 75 passed
- [x] Unit tests: sub comparison (same/different/invalid token)
- [x] DB integration tests: cross-context revocation + session coexistence

Closes #24
Part of #25