### PR TITLE
Add invitation entry endpoint and callback processing

### DIFF
--- a/e2e/deny-page.spec.ts
+++ b/e2e/deny-page.spec.ts
@@ -25,6 +25,28 @@ test.describe("deny page", () => {
     await expect(page.locator("h1")).toContainText("Access Denied");
   });
 
+  test("renders invitation_expired reason", async ({ page }) => {
+    await page.goto("/deny?reason=invitation_expired");
+    await expect(page.locator("h1")).toContainText("Access Denied");
+    await expect(
+      page.locator("text=expired or is no longer valid"),
+    ).toBeVisible();
+  });
+
+  test("renders invitation_email_mismatch reason", async ({ page }) => {
+    await page.goto("/deny?reason=invitation_email_mismatch");
+    await expect(page.locator("h1")).toContainText("Access Denied");
+    await expect(
+      page.locator("text=does not match the invited email"),
+    ).toBeVisible();
+  });
+
+  test("renders invitation_email_not_verified reason", async ({ page }) => {
+    await page.goto("/deny?reason=invitation_email_not_verified");
+    await expect(page.locator("h1")).toContainText("Access Denied");
+    await expect(page.locator("text=has not been verified")).toBeVisible();
+  });
+
   test("back to sign in link points to /api/auth/sign-in", async ({ page }) => {
     await page.goto("/deny?reason=no_access");
     const link = page.locator('a[href="/api/auth/sign-in"]');

--- a/e2e/invite-entry.spec.ts
+++ b/e2e/invite-entry.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/test";
+
+// These tests exercise the GET /api/auth/invite/:token HTTP layer.
+// They verify the endpoint exists, rejects invalid tokens, and returns
+// correct redirect/cookie behavior at the HTTP level.
+//
+// Full invitation acceptance logic is covered by DB integration tests
+// (src/lib/auth/__tests__/invitations.db.test.ts).
+
+test.describe("GET /api/auth/invite/:token", () => {
+  test("redirects to deny page for non-existent token", async ({ request }) => {
+    const res = await request.get("/api/auth/invite/nonexistent-token-value", {
+      maxRedirects: 0,
+    });
+    // Next.js redirect → 307
+    expect(res.status()).toBe(307);
+    const location = res.headers().location;
+    expect(location).toContain("/deny?reason=invitation_expired");
+  });
+
+  test("sets Referrer-Policy header on valid redirect", async ({ request }) => {
+    // Even though this token doesn't exist, the deny redirect path
+    // doesn't set Referrer-Policy. The sign-in redirect (valid token)
+    // would set it, but we can only test the deny path without a DB.
+    const res = await request.get("/api/auth/invite/fake-token", {
+      maxRedirects: 0,
+    });
+    expect(res.status()).toBe(307);
+  });
+
+  test("returns 405 for POST method", async ({ request }) => {
+    const res = await request.post("/api/auth/invite/some-token");
+    expect(res.status()).toBe(405);
+  });
+
+  test("returns 405 for PUT method", async ({ request }) => {
+    const res = await request.put("/api/auth/invite/some-token");
+    expect(res.status()).toBe(405);
+  });
+
+  test("returns 405 for DELETE method", async ({ request }) => {
+    const res = await request.delete("/api/auth/invite/some-token");
+    expect(res.status()).toBe(405);
+  });
+});

--- a/src/app/[locale]/(auth)/deny/page.tsx
+++ b/src/app/[locale]/(auth)/deny/page.tsx
@@ -7,6 +7,9 @@ type DenyMessageKey =
   | "adminAuthTooOld"
   | "adminRoleMissing"
   | "adminNotEligible"
+  | "invitationExpired"
+  | "invitationEmailMismatch"
+  | "invitationEmailNotVerified"
   | "genericError";
 
 const REASON_KEYS: Record<string, DenyMessageKey> = {
@@ -16,6 +19,9 @@ const REASON_KEYS: Record<string, DenyMessageKey> = {
   admin_auth_too_old: "adminAuthTooOld",
   admin_role_missing: "adminRoleMissing",
   admin_not_eligible: "adminNotEligible",
+  invitation_expired: "invitationExpired",
+  invitation_email_mismatch: "invitationEmailMismatch",
+  invitation_email_not_verified: "invitationEmailNotVerified",
 };
 
 export default async function DenyPage({

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -2,11 +2,13 @@ import { type NextRequest, NextResponse } from "next/server";
 import { countAccessibleCustomers, upsertAccount } from "@/lib/auth/account";
 import { auditLog } from "@/lib/auth/audit-stub";
 import {
+  clearInvitationTokenCookie,
   clearOidcTempCookies,
   getOidcTempCookies,
   setAuthCookies,
 } from "@/lib/auth/cookies";
 import { generateCsrf } from "@/lib/auth/csrf";
+import { acceptInvitation } from "@/lib/auth/invitations";
 import { signJwt } from "@/lib/auth/jwt";
 import { exchangeCodeForTokens, getIssuerUrl } from "@/lib/auth/oidc";
 import { getOidcDiscovery } from "@/lib/auth/oidc-discovery";
@@ -114,10 +116,44 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return denyRedirect(request, "account_inactive");
   }
 
-  // Invitation stub (#51): check for invitation_token cookie
+  // Invitation processing (#77): accept invitation if token cookie exists
   const invitationToken = request.cookies.get("invitation_token")?.value;
   if (invitationToken) {
-    // TODO(#51): Process invitation acceptance
+    const result = await acceptInvitation(pool, {
+      token: invitationToken,
+      accountId: account.id,
+      email: idClaims.email,
+      emailVerified: idClaims.email_verified,
+    });
+
+    if (result.deny) {
+      // Clear cookie for non-retryable denials to avoid blocking
+      // subsequent sign-in attempts with a stale token.
+      if (result.deny === "invitation_expired") {
+        await clearInvitationTokenCookie();
+      }
+      await auditLog({
+        actorId: account.id,
+        authContext: "general",
+        action: "auth.invitation_denied",
+        targetType: "invitation",
+        details: { reason: result.deny },
+        ipAddress: meta.ipAddress,
+      });
+      return denyRedirect(request, result.deny);
+    }
+
+    await clearInvitationTokenCookie();
+
+    await auditLog({
+      actorId: account.id,
+      authContext: "general",
+      action: "auth.invitation_accepted",
+      targetType: "invitation",
+      targetId: result.invitationId,
+      details: { customerId: result.customerId },
+      ipAddress: meta.ipAddress,
+    });
   }
 
   // Bridge stub (#33): check for connection_id cookie

--- a/src/app/api/auth/invite/[token]/route.ts
+++ b/src/app/api/auth/invite/[token]/route.ts
@@ -1,0 +1,37 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { clearFlowCookies, setInvitationTokenCookie } from "@/lib/auth/cookies";
+import { hashToken } from "@/lib/auth/invitations";
+import { getAuthPool, query } from "@/lib/db/client";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+): Promise<NextResponse> {
+  const { token } = await params;
+
+  const tokenHash = hashToken(token);
+  const pool = getAuthPool();
+
+  const rows = await query<{ id: string }>(
+    pool,
+    `SELECT id FROM invitations
+     WHERE token_hash = $1 AND status = 'pending' AND expires_at > NOW()`,
+    [tokenHash],
+  );
+
+  if (rows.length === 0) {
+    return NextResponse.redirect(
+      new URL("/deny?reason=invitation_expired", request.url),
+    );
+  }
+
+  // Clear stale flow cookies before setting new ones (conflict prevention)
+  await clearFlowCookies();
+  await setInvitationTokenCookie(token);
+
+  const response = NextResponse.redirect(
+    new URL("/api/auth/sign-in", request.url),
+  );
+  response.headers.set("Referrer-Policy", "no-referrer");
+  return response;
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -24,6 +24,9 @@
       "adminAuthTooOld": "Your authentication has expired. System Admin sign-in must be completed within 5 minutes.",
       "adminRoleMissing": "You do not have the System Admin role. Contact an administrator to request access.",
       "adminNotEligible": "Your account is not eligible for System Admin access.",
+      "invitationExpired": "This invitation has expired or is no longer valid. Please request a new invitation.",
+      "invitationEmailMismatch": "The email address you signed in with does not match the invited email. Please sign in with the correct account.",
+      "invitationEmailNotVerified": "Your email address has not been verified. Please verify your email before accepting the invitation.",
       "backToSignIn": "Back to Sign In",
       "contactAdmin": "If you believe this is an error, please contact your system administrator."
     }

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -24,6 +24,9 @@
       "adminAuthTooOld": "인증이 만료되었습니다. 시스템 관리자 로그인은 5분 이내에 완료해야 합니다.",
       "adminRoleMissing": "시스템 관리자 역할이 없습니다. 접근 권한이 필요하면 관리자에게 문의해 주세요.",
       "adminNotEligible": "이 계정은 시스템 관리자 접근 대상이 아닙니다.",
+      "invitationExpired": "초대가 만료되었거나 더 이상 유효하지 않습니다. 새로운 초대를 요청해 주세요.",
+      "invitationEmailMismatch": "로그인한 이메일 주소가 초대된 이메일과 일치하지 않습니다. 올바른 계정으로 로그인해 주세요.",
+      "invitationEmailNotVerified": "이메일 주소가 인증되지 않았습니다. 초대를 수락하기 전에 이메일을 인증해 주세요.",
       "backToSignIn": "로그인으로 돌아가기",
       "contactAdmin": "오류라고 생각되시면 시스템 관리자에게 문의해 주세요."
     }

--- a/src/lib/auth/__tests__/invitations.db.test.ts
+++ b/src/lib/auth/__tests__/invitations.db.test.ts
@@ -8,7 +8,12 @@ import {
   hasPostgres,
 } from "../../db/__tests__/db-test-helpers";
 import { runMigrations } from "../../db/migrate";
-import { createInvitation, HttpError } from "../invitations";
+import {
+  acceptInvitation,
+  createInvitation,
+  HttpError,
+  hashToken,
+} from "../invitations";
 
 const MIGRATIONS_DIR = join(process.cwd(), "migrations", "auth");
 const LOCK_ID = 1000;
@@ -513,5 +518,313 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
       expect((err as HttpError).statusCode).toBe(404);
       expect((err as HttpError).message).toBe("Customer not found");
     }
+  });
+
+  // =========================================================================
+  // Invitation acceptance (#77)
+  // =========================================================================
+
+  // Helper: create a pending invitation and return raw token + invitation id
+  async function createPendingInvitation(email: string) {
+    return runInTransaction((client) =>
+      createInvitation(client, {
+        accountId: managerAccountId,
+        customerId,
+        email,
+        roleName: "User",
+      }),
+    );
+  }
+
+  // Helper: create an account without any membership
+  async function createBareAccount(sub: string, email: string) {
+    const result = await pool.query<{ id: string }>(
+      `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+       VALUES ('test-issuer', $1, $1, $1, $2)
+       RETURNING id`,
+      [sub, email],
+    );
+    return result.rows[0].id;
+  }
+
+  // Verification item 35-13: invited new user → membership created
+  it("accepts invitation and creates membership", async () => {
+    const email = "accept-test@example.com";
+    const inv = await createPendingInvitation(email);
+    const accountId = await createBareAccount("accept-001", email);
+
+    const result = await acceptInvitation(pool, {
+      token: inv.token,
+      accountId,
+      email,
+      emailVerified: true,
+    });
+
+    expect(result.deny).toBeNull();
+    expect(result).toMatchObject({
+      invitationId: inv.id,
+      customerId,
+    });
+
+    // Verify membership was created
+    const membership = await pool.query(
+      `SELECT 1 FROM account_customer_memberships
+       WHERE account_id = $1 AND customer_id = $2`,
+      [accountId, customerId],
+    );
+    expect(membership.rows).toHaveLength(1);
+
+    // Verify invitation is consumed
+    const invRow = await pool.query<{ status: string }>(
+      `SELECT status FROM invitations WHERE id = $1`,
+      [inv.id],
+    );
+    expect(invRow.rows[0].status).toBe("accepted");
+  });
+
+  // Verification item 35-8: token one-time use
+  it("rejects already-accepted invitation token", async () => {
+    const email = "one-time-use@example.com";
+    const inv = await createPendingInvitation(email);
+    const accountId = await createBareAccount("onetime-001", email);
+
+    // First acceptance
+    const first = await acceptInvitation(pool, {
+      token: inv.token,
+      accountId,
+      email,
+      emailVerified: true,
+    });
+    expect(first.deny).toBeNull();
+
+    // Second attempt with same token → expired (status is no longer pending)
+    const second = await acceptInvitation(pool, {
+      token: inv.token,
+      accountId,
+      email,
+      emailVerified: true,
+    });
+    expect(second.deny).toBe("invitation_expired");
+  });
+
+  // Verification item 35-9: invitation expiration
+  it("rejects expired invitation", async () => {
+    const email = "expired-test@example.com";
+    const inv = await createPendingInvitation(email);
+    const accountId = await createBareAccount("expired-001", email);
+
+    // Manually expire the invitation
+    await pool.query(
+      `UPDATE invitations SET expires_at = NOW() - INTERVAL '1 second' WHERE id = $1`,
+      [inv.id],
+    );
+
+    const result = await acceptInvitation(pool, {
+      token: inv.token,
+      accountId,
+      email,
+      emailVerified: true,
+    });
+    expect(result.deny).toBe("invitation_expired");
+  });
+
+  // Verification item 35-7 / 35-14: email mismatch rejection
+  it("rejects when OIDC email does not match invited email", async () => {
+    const inv = await createPendingInvitation("invited@example.com");
+    const accountId = await createBareAccount(
+      "mismatch-001",
+      "different@example.com",
+    );
+
+    const result = await acceptInvitation(pool, {
+      token: inv.token,
+      accountId,
+      email: "different@example.com",
+      emailVerified: true,
+    });
+    expect(result.deny).toBe("invitation_email_mismatch");
+
+    // Invitation stays pending for retry (35-26)
+    const invRow = await pool.query<{ status: string }>(
+      `SELECT status FROM invitations WHERE id = $1`,
+      [inv.id],
+    );
+    expect(invRow.rows[0].status).toBe("pending");
+  });
+
+  // Verification item 38-2: email_verified=false rejection
+  it("rejects when email_verified is false", async () => {
+    const email = "unverified@example.com";
+    const inv = await createPendingInvitation(email);
+    const accountId = await createBareAccount("unverified-001", email);
+
+    const result = await acceptInvitation(pool, {
+      token: inv.token,
+      accountId,
+      email,
+      emailVerified: false,
+    });
+    expect(result.deny).toBe("invitation_email_not_verified");
+  });
+
+  // Verification item 38-2: email_verified=undefined rejection (fail-closed)
+  it("rejects when email_verified is undefined (fail-closed)", async () => {
+    const email = "no-claim@example.com";
+    const inv = await createPendingInvitation(email);
+    const accountId = await createBareAccount("noclaim-001", email);
+
+    const result = await acceptInvitation(pool, {
+      token: inv.token,
+      accountId,
+      email,
+      emailVerified: undefined,
+    });
+    expect(result.deny).toBe("invitation_email_not_verified");
+  });
+
+  // Verification item 38-3: case-insensitive email matching
+  it("accepts invitation with different-case email", async () => {
+    const inv = await createPendingInvitation("CaseTest@Example.COM");
+    const accountId = await createBareAccount(
+      "casetest-001",
+      "casetest@example.com",
+    );
+
+    const result = await acceptInvitation(pool, {
+      token: inv.token,
+      accountId,
+      email: "casetest@example.com",
+      emailVerified: true,
+    });
+    expect(result.deny).toBeNull();
+  });
+
+  // Idempotent: accepting when membership already exists
+  it("succeeds idempotently when membership already exists", async () => {
+    const email = "idempotent@example.com";
+    const inv = await createPendingInvitation(email);
+    const accountId = await createBareAccount("idempotent-001", email);
+
+    // Pre-create the membership
+    const userRoleId = (
+      await pool.query<{ id: number }>(
+        `SELECT id FROM roles WHERE name = 'User' AND auth_context = 'general'`,
+      )
+    ).rows[0].id;
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+       VALUES ($1, $2, $3)`,
+      [accountId, customerId, userRoleId],
+    );
+
+    const result = await acceptInvitation(pool, {
+      token: inv.token,
+      accountId,
+      email,
+      emailVerified: true,
+    });
+    expect(result.deny).toBeNull();
+
+    // Still only one membership row (ON CONFLICT DO NOTHING)
+    const count = await pool.query<{ cnt: number }>(
+      `SELECT COUNT(*)::int AS cnt FROM account_customer_memberships
+       WHERE account_id = $1 AND customer_id = $2`,
+      [accountId, customerId],
+    );
+    expect(count.rows[0].cnt).toBe(1);
+  });
+
+  // Verification item 35-26: retry after mismatch with correct account
+  it("allows retry after email mismatch with correct account", async () => {
+    const inv = await createPendingInvitation("retry@example.com");
+    const wrongAccountId = await createBareAccount(
+      "wrong-001",
+      "wrong@example.com",
+    );
+    const correctAccountId = await createBareAccount(
+      "correct-001",
+      "retry@example.com",
+    );
+
+    // First attempt: wrong email
+    const first = await acceptInvitation(pool, {
+      token: inv.token,
+      accountId: wrongAccountId,
+      email: "wrong@example.com",
+      emailVerified: true,
+    });
+    expect(first.deny).toBe("invitation_email_mismatch");
+
+    // Second attempt: correct email → succeeds
+    const second = await acceptInvitation(pool, {
+      token: inv.token,
+      accountId: correctAccountId,
+      email: "retry@example.com",
+      emailVerified: true,
+    });
+    expect(second.deny).toBeNull();
+  });
+
+  // Verification item 35-25: concurrent invitation callback — FOR UPDATE
+  it("handles concurrent acceptance safely (only one succeeds)", async () => {
+    const email = "concurrent@example.com";
+    const inv = await createPendingInvitation(email);
+    const accountId1 = await createBareAccount("conc-001", email);
+    const accountId2 = await createBareAccount("conc-002", email);
+
+    // Run two acceptInvitation calls concurrently
+    const [result1, result2] = await Promise.all([
+      acceptInvitation(pool, {
+        token: inv.token,
+        accountId: accountId1,
+        email,
+        emailVerified: true,
+      }),
+      acceptInvitation(pool, {
+        token: inv.token,
+        accountId: accountId2,
+        email,
+        emailVerified: true,
+      }),
+    ]);
+
+    // Exactly one should succeed, the other should see invitation_expired
+    // (FOR UPDATE serializes: first commits status='accepted', second
+    // re-checks and finds status is no longer 'pending')
+    const results = [result1.deny, result2.deny];
+    expect(results).toContain(null);
+    expect(results).toContain("invitation_expired");
+
+    // Verify only one membership was created
+    const memberships = await pool.query<{ account_id: string }>(
+      `SELECT account_id FROM account_customer_memberships
+       WHERE account_id IN ($1, $2) AND customer_id = $3`,
+      [accountId1, accountId2, customerId],
+    );
+    expect(memberships.rows).toHaveLength(1);
+  });
+
+  // Invalid token → expired
+  it("rejects non-existent token", async () => {
+    const accountId = await createBareAccount(
+      "badtoken-001",
+      "badtoken@example.com",
+    );
+
+    const result = await acceptInvitation(pool, {
+      token: "nonexistent-token-value",
+      accountId,
+      email: "badtoken@example.com",
+      emailVerified: true,
+    });
+    expect(result.deny).toBe("invitation_expired");
+  });
+
+  // hashToken utility
+  it("hashToken produces consistent SHA-256 hex output", () => {
+    const hash = hashToken("test-token");
+    expect(hash).toHaveLength(64);
+    expect(hash).toBe(hashToken("test-token"));
+    expect(hash).not.toBe(hashToken("other-token"));
   });
 });

--- a/src/lib/auth/cookies.ts
+++ b/src/lib/auth/cookies.ts
@@ -70,12 +70,33 @@ export async function clearOidcTempCookies(
 }
 
 // ---------------------------------------------------------------------------
+// Invitation token cookie (SameSite=Lax for cross-site redirect)
+// ---------------------------------------------------------------------------
+
+const INVITATION_TOKEN_MAX_AGE = 300; // 5 minutes
+
+export async function setInvitationTokenCookie(token: string): Promise<void> {
+  const jar = await cookies();
+  jar.set("invitation_token", token, {
+    httpOnly: true,
+    secure: isSecure,
+    sameSite: "lax",
+    path: "/",
+    maxAge: INVITATION_TOKEN_MAX_AGE,
+  });
+}
+
+export async function clearInvitationTokenCookie(): Promise<void> {
+  const jar = await cookies();
+  jar.delete("invitation_token");
+}
+
+// ---------------------------------------------------------------------------
 // Cleanup for temporary flow cookies (prevent stale cookies)
 // ---------------------------------------------------------------------------
 
 export async function clearFlowCookies(): Promise<void> {
   const jar = await cookies();
-  jar.delete("invitation_token");
   jar.delete("connection_id");
 }
 

--- a/src/lib/auth/invitations.ts
+++ b/src/lib/auth/invitations.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes } from "node:crypto";
-import type { PoolClient } from "pg";
+import type { Pool, PoolClient } from "pg";
+import { withTransaction } from "../db/client";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -37,9 +38,13 @@ export class HttpError extends Error {
 // Helpers
 // ---------------------------------------------------------------------------
 
+export function hashToken(raw: string): string {
+  return createHash("sha256").update(raw).digest("hex");
+}
+
 function generateToken(): { raw: string; hash: string } {
   const raw = randomBytes(32).toString("base64url");
-  const hash = createHash("sha256").update(raw).digest("hex");
+  const hash = hashToken(raw);
   return { raw, hash };
 }
 
@@ -183,4 +188,81 @@ export async function createInvitation(
 
     throw err;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Accept invitation (transactional)
+// ---------------------------------------------------------------------------
+
+export interface AcceptInvitationParams {
+  token: string;
+  accountId: string;
+  email: string | undefined;
+  emailVerified: boolean | undefined;
+}
+
+export type AcceptInvitationResult =
+  | { deny: "invitation_expired" }
+  | { deny: "invitation_email_not_verified" }
+  | { deny: "invitation_email_mismatch" }
+  | { deny: null; invitationId: string; customerId: string };
+
+export async function acceptInvitation(
+  pool: Pool,
+  params: AcceptInvitationParams,
+): Promise<AcceptInvitationResult> {
+  const tokenHash = hashToken(params.token);
+
+  return withTransaction(pool, async (client) => {
+    const invRows = await client.query<{
+      id: string;
+      customer_id: string;
+      invited_email: string;
+      role_id: number;
+    }>(
+      `SELECT id, customer_id, invited_email, role_id FROM invitations
+       WHERE token_hash = $1 AND status = 'pending' AND expires_at > NOW()
+       FOR UPDATE`,
+      [tokenHash],
+    );
+
+    if (invRows.rows.length === 0) {
+      return { deny: "invitation_expired" };
+    }
+
+    const inv = invRows.rows[0];
+
+    // email_verified must be true (fail-closed)
+    if (params.emailVerified !== true) {
+      return { deny: "invitation_email_not_verified" };
+    }
+
+    // Email match (case-insensitive)
+    if (
+      !params.email ||
+      params.email.toLowerCase() !== inv.invited_email.toLowerCase()
+    ) {
+      return { deny: "invitation_email_mismatch" };
+    }
+
+    // Idempotent membership creation
+    await client.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (account_id, customer_id) DO NOTHING`,
+      [params.accountId, inv.customer_id, inv.role_id],
+    );
+
+    // Consume invitation
+    await client.query(
+      `UPDATE invitations SET status = 'accepted' WHERE id = $1`,
+      [inv.id],
+    );
+
+    return {
+      deny: null,
+      invitationId: inv.id,
+      customerId: inv.customer_id,
+    };
+  });
 }


### PR DESCRIPTION
## Summary

- Add `GET /api/auth/invite/:token` endpoint that validates the invitation token, sets an `invitation_token` cookie, and redirects to the OIDC sign-in flow
- Process the invitation cookie in the general callback: verify `email_verified`, match email case-insensitively, create membership, and consume the invitation — all within a single `FOR UPDATE` transaction
- Add three deny reasons (`invitation_expired`, `invitation_email_mismatch`, `invitation_email_not_verified`) with EN/KO i18n messages

## Test plan

- [x] 35-7: Email mismatch rejection (DB integration test)
- [x] 35-8: Token one-time use (DB integration test)
- [x] 35-9: Invitation expiration (DB integration test)
- [x] 35-13: New user → membership created (DB integration test)
- [x] 35-14: Token email mismatch (DB integration test)
- [x] 35-25: Concurrent callback — FOR UPDATE serialization (DB integration test)
- [x] 35-26: Retry after mismatch with correct account (DB integration test)
- [x] 38-2: `email_verified=false` and `undefined` rejection (DB integration test)
- [x] 38-3: Case-insensitive email matching (DB integration test)
- [x] E2E: Invite entry endpoint (invalid token, method rejection)
- [x] E2E: Deny page renders new invitation deny reasons

Closes #77