### PR TITLE
Add customer creation API with Manager bootstrap

### DIFF
--- a/e2e/admin-customers-api.spec.ts
+++ b/e2e/admin-customers-api.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "@playwright/test";
+
+// These tests exercise the POST /api/admin/customers HTTP layer without
+// authentication.  They verify that the endpoint exists, enforces admin
+// auth, and rejects malformed requests at the HTTP level.
+//
+// Full authenticated flows are covered by DB integration tests
+// (src/lib/auth/__tests__/customers.db.test.ts) which exercise the
+// business logic directly.
+
+const ENDPOINT = "/api/admin/customers";
+const ORIGIN = "http://localhost:3000";
+
+test.describe("POST /api/admin/customers", () => {
+  // =========================================================================
+  // Auth enforcement
+  // =========================================================================
+
+  test("returns 401 without auth cookie", async ({ request }) => {
+    const res = await request.post(ENDPOINT, {
+      headers: { origin: ORIGIN },
+      data: {
+        name: "Test Corp",
+        externalKey: "test-001",
+        managerAccountId: "00000000-0000-0000-0000-000000000001",
+      },
+    });
+    expect(res.status()).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  test("returns 401 with invalid admin auth cookie", async ({ context }) => {
+    await context.addCookies([
+      {
+        name: "at_admin",
+        value: "invalid-jwt-token",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+
+    const res = await context.request.post(ENDPOINT, {
+      headers: { origin: ORIGIN },
+      data: {
+        name: "Test Corp",
+        externalKey: "test-001",
+        managerAccountId: "00000000-0000-0000-0000-000000000001",
+      },
+    });
+    expect(res.status()).toBe(401);
+  });
+
+  test("returns 401 with general auth cookie (not admin)", async ({
+    context,
+  }) => {
+    // A general-context cookie should not grant admin access
+    await context.addCookies([
+      {
+        name: "at",
+        value: "some-general-jwt-token",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+
+    const res = await context.request.post(ENDPOINT, {
+      headers: { origin: ORIGIN },
+      data: {
+        name: "Test Corp",
+        externalKey: "test-001",
+        managerAccountId: "00000000-0000-0000-0000-000000000001",
+      },
+    });
+    expect(res.status()).toBe(401);
+  });
+
+  // =========================================================================
+  // Method enforcement
+  // =========================================================================
+
+  test("returns 405 for GET method", async ({ request }) => {
+    const res = await request.get(ENDPOINT);
+    expect(res.status()).toBe(405);
+  });
+
+  test("returns 405 for PUT method", async ({ request }) => {
+    const res = await request.put(ENDPOINT, {
+      headers: { origin: ORIGIN },
+      data: {},
+    });
+    expect(res.status()).toBe(405);
+  });
+
+  test("returns 405 for DELETE method", async ({ request }) => {
+    const res = await request.delete(ENDPOINT);
+    expect(res.status()).toBe(405);
+  });
+});

--- a/src/app/api/admin/customers/route.ts
+++ b/src/app/api/admin/customers/route.ts
@@ -1,0 +1,119 @@
+import type { NextRequest } from "next/server";
+import { auditLog } from "@/lib/auth/audit-stub";
+import { createCustomer } from "@/lib/auth/customers";
+import { HttpError } from "@/lib/auth/errors";
+import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
+import { getAuthPool, withTransaction } from "@/lib/db/client";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const POST = withAuth(
+  async (req: NextRequest, auth) => {
+    const originErr = verifyOrigin(req);
+    if (originErr) return originErr;
+
+    const csrfErr = verifyCsrf(req, {
+      ctx: "admin",
+      sid: auth.sessionId,
+      iat: auth.iat,
+    });
+    if (csrfErr) return csrfErr;
+
+    // Parse request body
+    let raw: unknown;
+    try {
+      raw = await req.json();
+    } catch {
+      return Response.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+      return Response.json(
+        { error: "Request body must be a JSON object" },
+        { status: 400 },
+      );
+    }
+
+    const { name, externalKey, description, managerAccountId } = raw as Record<
+      string,
+      unknown
+    >;
+
+    if (
+      typeof name !== "string" ||
+      typeof externalKey !== "string" ||
+      !name.trim() ||
+      !externalKey.trim()
+    ) {
+      return Response.json(
+        { error: "name and externalKey are required non-empty strings" },
+        { status: 400 },
+      );
+    }
+
+    if (typeof managerAccountId !== "string") {
+      return Response.json(
+        { error: "manager_account_id_required" },
+        { status: 400 },
+      );
+    }
+
+    if (!UUID_RE.test(managerAccountId)) {
+      return Response.json(
+        { error: "Invalid managerAccountId format" },
+        { status: 400 },
+      );
+    }
+
+    if (description !== undefined && typeof description !== "string") {
+      return Response.json(
+        { error: "description must be a string" },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const result = await withTransaction(getAuthPool(), (client) =>
+        createCustomer(client, {
+          name,
+          externalKey,
+          description:
+            typeof description === "string" ? description : undefined,
+          managerAccountId,
+        }),
+      );
+
+      await auditLog({
+        actorId: auth.accountId,
+        authContext: "admin",
+        action: "customer.create",
+        targetType: "customer",
+        targetId: result.id,
+        details: { name, externalKey, managerAccountId },
+        ipAddress: auth.meta.ipAddress,
+        sid: auth.sessionId,
+      });
+
+      return Response.json(
+        {
+          id: result.id,
+          name: result.name,
+          externalKey: result.externalKey,
+          status: result.status,
+          databaseStatus: result.databaseStatus,
+        },
+        { status: 201 },
+      );
+    } catch (err: unknown) {
+      if (err instanceof HttpError) {
+        return Response.json(
+          { error: err.message },
+          { status: err.statusCode },
+        );
+      }
+      throw err;
+    }
+  },
+  { ctx: "admin" },
+);

--- a/src/app/api/invitations/route.ts
+++ b/src/app/api/invitations/route.ts
@@ -1,7 +1,8 @@
 import type { NextRequest } from "next/server";
 import { auditLog } from "@/lib/auth/audit-stub";
+import { HttpError } from "@/lib/auth/errors";
 import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
-import { createInvitation, HttpError } from "@/lib/auth/invitations";
+import { createInvitation } from "@/lib/auth/invitations";
 import { getAuthPool, withTransaction } from "@/lib/db/client";
 import { sendInvitationEmail } from "@/lib/email/invitation";
 

--- a/src/lib/auth/__tests__/customers.db.test.ts
+++ b/src/lib/auth/__tests__/customers.db.test.ts
@@ -1,0 +1,357 @@
+import { join } from "node:path";
+import type { Pool, PoolClient } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeAdminPool,
+  createTestDatabase,
+  dropTestDatabase,
+  hasPostgres,
+} from "../../db/__tests__/db-test-helpers";
+import { runMigrations } from "../../db/migrate";
+import { createCustomer } from "../customers";
+import { HttpError } from "../errors";
+
+const MIGRATIONS_DIR = join(process.cwd(), "migrations", "auth");
+const LOCK_ID = 2000;
+
+describe.skipIf(!hasPostgres)("customer creation (DB integration)", () => {
+  let pool: Pool;
+  let dbName: string;
+
+  // Test fixtures
+  let managerAccountId: string;
+  let managerRoleId: number;
+
+  beforeAll(async () => {
+    const result = await createTestDatabase("customers", "auth");
+    pool = result.pool;
+    dbName = result.dbName;
+
+    // Ensure runtime role exists
+    await pool.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'aimer_auth') THEN
+          CREATE ROLE aimer_auth LOGIN PASSWORD 'changeme';
+        END IF;
+      END $$
+    `);
+
+    // Apply auth migrations
+    await runMigrations(pool, MIGRATIONS_DIR, LOCK_ID);
+
+    // Lookup Manager role
+    const roles = await pool.query<{ id: number }>(
+      `SELECT id FROM roles WHERE name = 'Manager' AND auth_context = 'general'`,
+    );
+    managerRoleId = roles.rows[0].id;
+
+    // Create an account to be designated as initial Manager
+    const mgr = await pool.query<{ id: string }>(
+      `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+       VALUES ('test-issuer', 'manager-001', 'manager', 'Manager', 'manager@example.com')
+       RETURNING id`,
+    );
+    managerAccountId = mgr.rows[0].id;
+  });
+
+  afterAll(async () => {
+    await dropTestDatabase(dbName, pool, "auth");
+    await closeAdminPool();
+  });
+
+  async function runInTransaction<T>(
+    fn: (client: PoolClient) => Promise<T>,
+  ): Promise<T> {
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      const result = await fn(client);
+      await client.query("COMMIT");
+      return result;
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  // =========================================================================
+  // Happy path
+  // =========================================================================
+
+  it("creates customer and initial Manager membership atomically", async () => {
+    const result = await runInTransaction((client) =>
+      createCustomer(client, {
+        name: "Acme Corp",
+        externalKey: "acme-001",
+        managerAccountId,
+      }),
+    );
+
+    expect(result.id).toBeDefined();
+    expect(result.name).toBe("Acme Corp");
+    expect(result.externalKey).toBe("acme-001");
+    expect(result.status).toBe("active");
+    expect(result.databaseStatus).toBe("provisioning");
+
+    // Verify customer row
+    const cust = await pool.query<{ name: string; status: string }>(
+      `SELECT name, status FROM customers WHERE id = $1`,
+      [result.id],
+    );
+    expect(cust.rows).toHaveLength(1);
+    expect(cust.rows[0].name).toBe("Acme Corp");
+
+    // Verify Manager membership
+    const membership = await pool.query<{ role_id: number }>(
+      `SELECT role_id FROM account_customer_memberships
+       WHERE account_id = $1 AND customer_id = $2`,
+      [managerAccountId, result.id],
+    );
+    expect(membership.rows).toHaveLength(1);
+    expect(membership.rows[0].role_id).toBe(managerRoleId);
+  });
+
+  it("creates customer with optional description", async () => {
+    const result = await runInTransaction((client) =>
+      createCustomer(client, {
+        name: "Beta Inc",
+        externalKey: "beta-001",
+        description: "A test customer",
+        managerAccountId,
+      }),
+    );
+
+    const cust = await pool.query<{ description: string | null }>(
+      `SELECT description FROM customers WHERE id = $1`,
+      [result.id],
+    );
+    expect(cust.rows[0].description).toBe("A test customer");
+  });
+
+  it("sets database_status to provisioning (not active)", async () => {
+    const result = await runInTransaction((client) =>
+      createCustomer(client, {
+        name: "Gamma Ltd",
+        externalKey: "gamma-001",
+        managerAccountId,
+      }),
+    );
+
+    const cust = await pool.query<{ database_status: string }>(
+      `SELECT database_status FROM customers WHERE id = $1`,
+      [result.id],
+    );
+    expect(cust.rows[0].database_status).toBe("provisioning");
+  });
+
+  // =========================================================================
+  // Error cases
+  // =========================================================================
+
+  it("rejects non-existent manager account (404)", async () => {
+    try {
+      await runInTransaction((client) =>
+        createCustomer(client, {
+          name: "No Manager Corp",
+          externalKey: "no-mgr-001",
+          managerAccountId: "00000000-0000-0000-0000-000000000000",
+        }),
+      );
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).statusCode).toBe(404);
+      expect((err as HttpError).message).toBe("Account not found");
+    }
+  });
+
+  it("rejects duplicate external_key (409)", async () => {
+    await runInTransaction((client) =>
+      createCustomer(client, {
+        name: "Dup Key Corp",
+        externalKey: "dup-key-001",
+        managerAccountId,
+      }),
+    );
+
+    try {
+      await runInTransaction((client) =>
+        createCustomer(client, {
+          name: "Dup Key Corp 2",
+          externalKey: "dup-key-001",
+          managerAccountId,
+        }),
+      );
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).statusCode).toBe(409);
+      expect((err as HttpError).message).toBe("external_key_conflict");
+    }
+  });
+
+  // =========================================================================
+  // Atomicity
+  // =========================================================================
+
+  it("rolls back customer when account does not exist", async () => {
+    const fakeId = "00000000-0000-0000-0000-ffffffffffff";
+
+    await expect(
+      runInTransaction((client) =>
+        createCustomer(client, {
+          name: "Should Not Exist",
+          externalKey: "rollback-test-001",
+          managerAccountId: fakeId,
+        }),
+      ),
+    ).rejects.toThrow("Account not found");
+
+    // Customer must not be left behind
+    const cust = await pool.query(
+      `SELECT 1 FROM customers WHERE external_key = 'rollback-test-001'`,
+    );
+    expect(cust.rows).toHaveLength(0);
+  });
+
+  it("creates exactly one membership per customer", async () => {
+    const result = await runInTransaction((client) =>
+      createCustomer(client, {
+        name: "Single Membership Corp",
+        externalKey: "single-mem-001",
+        managerAccountId,
+      }),
+    );
+
+    const count = await pool.query<{ cnt: number }>(
+      `SELECT COUNT(*)::int AS cnt FROM account_customer_memberships
+       WHERE customer_id = $1`,
+      [result.id],
+    );
+    expect(count.rows[0].cnt).toBe(1);
+  });
+
+  // =========================================================================
+  // Same account as Manager for multiple customers
+  // =========================================================================
+
+  it("allows same account to be Manager of multiple customers", async () => {
+    const cust1 = await runInTransaction((client) =>
+      createCustomer(client, {
+        name: "Multi A",
+        externalKey: "multi-a",
+        managerAccountId,
+      }),
+    );
+    const cust2 = await runInTransaction((client) =>
+      createCustomer(client, {
+        name: "Multi B",
+        externalKey: "multi-b",
+        managerAccountId,
+      }),
+    );
+
+    expect(cust1.id).not.toBe(cust2.id);
+
+    // Both memberships exist
+    const memberships = await pool.query<{ customer_id: string }>(
+      `SELECT customer_id FROM account_customer_memberships
+       WHERE account_id = $1 AND customer_id IN ($2, $3)`,
+      [managerAccountId, cust1.id, cust2.id],
+    );
+    expect(memberships.rows).toHaveLength(2);
+  });
+
+  // =========================================================================
+  // Description defaults to null when omitted
+  // =========================================================================
+
+  it("stores null description when omitted", async () => {
+    const result = await runInTransaction((client) =>
+      createCustomer(client, {
+        name: "No Desc Corp",
+        externalKey: "no-desc-001",
+        managerAccountId,
+      }),
+    );
+
+    const cust = await pool.query<{ description: string | null }>(
+      `SELECT description FROM customers WHERE id = $1`,
+      [result.id],
+    );
+    expect(cust.rows[0].description).toBeNull();
+  });
+
+  // =========================================================================
+  // Unique customer IDs
+  // =========================================================================
+
+  it("generates unique customer IDs", async () => {
+    const cust1 = await runInTransaction((client) =>
+      createCustomer(client, {
+        name: "Unique A",
+        externalKey: "unique-a",
+        managerAccountId,
+      }),
+    );
+    const cust2 = await runInTransaction((client) =>
+      createCustomer(client, {
+        name: "Unique B",
+        externalKey: "unique-b",
+        managerAccountId,
+      }),
+    );
+
+    expect(cust1.id).not.toBe(cust2.id);
+    // UUID format
+    expect(cust1.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  // =========================================================================
+  // Timestamps
+  // =========================================================================
+
+  it("sets created_at and updated_at on customer and membership", async () => {
+    const before = new Date();
+    const result = await runInTransaction((client) =>
+      createCustomer(client, {
+        name: "Timestamp Corp",
+        externalKey: "timestamp-001",
+        managerAccountId,
+      }),
+    );
+    const after = new Date();
+
+    const cust = await pool.query<{
+      created_at: Date;
+      updated_at: Date;
+    }>(`SELECT created_at, updated_at FROM customers WHERE id = $1`, [
+      result.id,
+    ]);
+    expect(cust.rows[0].created_at.getTime()).toBeGreaterThanOrEqual(
+      before.getTime() - 1000,
+    );
+    expect(cust.rows[0].created_at.getTime()).toBeLessThanOrEqual(
+      after.getTime() + 1000,
+    );
+    expect(cust.rows[0].updated_at.getTime()).toBe(
+      cust.rows[0].created_at.getTime(),
+    );
+
+    const mem = await pool.query<{
+      created_at: Date;
+      updated_at: Date;
+    }>(
+      `SELECT created_at, updated_at FROM account_customer_memberships
+       WHERE account_id = $1 AND customer_id = $2`,
+      [managerAccountId, result.id],
+    );
+    expect(mem.rows[0].created_at.getTime()).toBeGreaterThanOrEqual(
+      before.getTime() - 1000,
+    );
+  });
+});

--- a/src/lib/auth/__tests__/invitation-errors.unit.test.ts
+++ b/src/lib/auth/__tests__/invitation-errors.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { HttpError } from "../invitations";
+import { HttpError } from "../errors";
 
 describe("HttpError", () => {
   it("carries statusCode and message", () => {

--- a/src/lib/auth/__tests__/invitations.db.test.ts
+++ b/src/lib/auth/__tests__/invitations.db.test.ts
@@ -8,12 +8,8 @@ import {
   hasPostgres,
 } from "../../db/__tests__/db-test-helpers";
 import { runMigrations } from "../../db/migrate";
-import {
-  acceptInvitation,
-  createInvitation,
-  HttpError,
-  hashToken,
-} from "../invitations";
+import { HttpError } from "../errors";
+import { acceptInvitation, createInvitation, hashToken } from "../invitations";
 
 const MIGRATIONS_DIR = join(process.cwd(), "migrations", "auth");
 const LOCK_ID = 1000;

--- a/src/lib/auth/customers.ts
+++ b/src/lib/auth/customers.ts
@@ -1,0 +1,103 @@
+import type { PoolClient } from "pg";
+import { HttpError } from "./errors";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CreateCustomerParams {
+  name: string;
+  externalKey: string;
+  description?: string;
+  managerAccountId: string;
+}
+
+export interface CreatedCustomer {
+  id: string;
+  name: string;
+  externalKey: string;
+  status: string;
+  databaseStatus: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function assertAccountExists(
+  client: PoolClient,
+  accountId: string,
+): Promise<void> {
+  const result = await client.query(`SELECT 1 FROM accounts WHERE id = $1`, [
+    accountId,
+  ]);
+  if (result.rows.length === 0) {
+    throw new HttpError("Account not found", 404);
+  }
+}
+
+async function resolveManagerRoleId(client: PoolClient): Promise<number> {
+  const result = await client.query<{ id: number }>(
+    `SELECT id FROM roles WHERE name = 'Manager' AND auth_context = 'general'`,
+  );
+  if (result.rows.length === 0) {
+    throw new HttpError("Manager role not found", 500);
+  }
+  return result.rows[0].id;
+}
+
+// ---------------------------------------------------------------------------
+// Create customer with initial Manager (transactional)
+// ---------------------------------------------------------------------------
+
+export async function createCustomer(
+  client: PoolClient,
+  params: CreateCustomerParams,
+): Promise<CreatedCustomer> {
+  await assertAccountExists(client, params.managerAccountId);
+
+  const roleId = await resolveManagerRoleId(client);
+
+  // Insert customer
+  let customerId: string;
+  try {
+    const custResult = await client.query<{
+      id: string;
+      status: string;
+      database_status: string;
+    }>(
+      `INSERT INTO customers (external_key, name, description)
+       VALUES ($1, $2, $3)
+       RETURNING id, status, database_status`,
+      [params.externalKey, params.name, params.description ?? null],
+    );
+    customerId = custResult.rows[0].id;
+
+    // Insert initial Manager membership
+    await client.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+       VALUES ($1, $2, $3)`,
+      [params.managerAccountId, customerId, roleId],
+    );
+
+    return {
+      id: customerId,
+      name: params.name,
+      externalKey: params.externalKey,
+      status: custResult.rows[0].status,
+      databaseStatus: custResult.rows[0].database_status,
+    };
+  } catch (err: unknown) {
+    const pgErr = err as { code?: string; constraint?: string };
+
+    // Unique constraint on external_key
+    if (
+      pgErr.code === "23505" &&
+      pgErr.constraint === "customers_external_key_key"
+    ) {
+      throw new HttpError("external_key_conflict", 409);
+    }
+
+    throw err;
+  }
+}

--- a/src/lib/auth/errors.ts
+++ b/src/lib/auth/errors.ts
@@ -1,0 +1,9 @@
+export class HttpError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+  ) {
+    super(message);
+    this.name = "HttpError";
+  }
+}

--- a/src/lib/auth/invitations.ts
+++ b/src/lib/auth/invitations.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import type { Pool, PoolClient } from "pg";
 import { withTransaction } from "../db/client";
+import { HttpError } from "./errors";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -18,20 +19,6 @@ export interface CreatedInvitation {
   token: string;
   expiresAt: Date;
   customerName: string;
-}
-
-// ---------------------------------------------------------------------------
-// Errors
-// ---------------------------------------------------------------------------
-
-export class HttpError extends Error {
-  constructor(
-    message: string,
-    public readonly statusCode: number,
-  ) {
-    super(message);
-    this.name = "HttpError";
-  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `POST /api/admin/customers` endpoint for System Admins to create customer organizations with an initial Manager
- Customer and Manager membership are created atomically in a single transaction (`manager_account_id` required)
- Extract `HttpError` into shared `src/lib/auth/errors.ts` module, decoupling it from invitations

## Test plan

- [x] DB integration tests (11 cases): happy path, atomicity, error handling, edge cases
- [x] E2E tests (6 cases): admin auth enforcement (401), method enforcement (405)
- [x] Verify existing invitation tests still pass after `HttpError` extraction

Closes #78