### PR TITLE
Add member management API with last Manager protection

### DIFF
--- a/e2e/members-api.spec.ts
+++ b/e2e/members-api.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test } from "@playwright/test";
+
+// These tests exercise the /api/members HTTP layer without authentication.
+// They verify that the endpoints exist, enforce auth, reject malformed
+// requests, and return correct HTTP status codes.
+//
+// Full authenticated flows (permission checks, last Manager protection,
+// concurrency) are covered by DB integration tests
+// (src/lib/auth/__tests__/members.db.test.ts).
+
+const ORIGIN = "http://localhost:3000";
+const DUMMY_UUID = "00000000-0000-0000-0000-000000000001";
+
+// ==========================================================================
+// GET /api/members
+// ==========================================================================
+
+test.describe("GET /api/members", () => {
+  test("returns 401 without auth cookie", async ({ request }) => {
+    const res = await request.get(`/api/members?customer_id=${DUMMY_UUID}`);
+    expect(res.status()).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  test("returns 401 with invalid auth cookie", async ({ context }) => {
+    await context.addCookies([
+      {
+        name: "at",
+        value: "invalid-jwt-token",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+
+    const res = await context.request.get(
+      `/api/members?customer_id=${DUMMY_UUID}`,
+    );
+    expect(res.status()).toBe(401);
+  });
+
+  test("returns 400 without customer_id", async ({ context }) => {
+    await context.addCookies([
+      {
+        name: "at",
+        value: "invalid-jwt-token",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+
+    // Even though auth will fail first (401), test validates the param
+    // requirement independently when auth is bypassed in integration tests.
+    const res = await context.request.get("/api/members");
+    // 401 takes precedence over 400 in the middleware chain
+    expect(res.status()).toBe(401);
+  });
+
+  test("returns 405 for POST method", async ({ request }) => {
+    const res = await request.post("/api/members", {
+      headers: { origin: ORIGIN },
+      data: {},
+    });
+    expect(res.status()).toBe(405);
+  });
+});
+
+// ==========================================================================
+// DELETE /api/members/:accountId
+// ==========================================================================
+
+test.describe("DELETE /api/members/:accountId", () => {
+  test("returns 401 without auth cookie", async ({ request }) => {
+    const res = await request.delete(
+      `/api/members/${DUMMY_UUID}?customer_id=${DUMMY_UUID}`,
+    );
+    expect(res.status()).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  test("returns 401 with invalid auth cookie", async ({ context }) => {
+    await context.addCookies([
+      {
+        name: "at",
+        value: "invalid-jwt-token",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+
+    const res = await context.request.delete(
+      `/api/members/${DUMMY_UUID}?customer_id=${DUMMY_UUID}`,
+      { headers: { origin: ORIGIN } },
+    );
+    expect(res.status()).toBe(401);
+  });
+
+  test("returns 405 for GET method", async ({ request }) => {
+    const res = await request.get(`/api/members/${DUMMY_UUID}`);
+    expect(res.status()).toBe(405);
+  });
+});
+
+// ==========================================================================
+// PATCH /api/members/:accountId
+// ==========================================================================
+
+test.describe("PATCH /api/members/:accountId", () => {
+  test("returns 401 without auth cookie", async ({ request }) => {
+    const res = await request.patch(`/api/members/${DUMMY_UUID}`, {
+      headers: { origin: ORIGIN },
+      data: { customerId: DUMMY_UUID, roleId: 1 },
+    });
+    expect(res.status()).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  test("returns 401 with invalid auth cookie", async ({ context }) => {
+    await context.addCookies([
+      {
+        name: "at",
+        value: "invalid-jwt-token",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+
+    const res = await context.request.patch(`/api/members/${DUMMY_UUID}`, {
+      headers: { origin: ORIGIN },
+      data: { customerId: DUMMY_UUID, roleId: 1 },
+    });
+    expect(res.status()).toBe(401);
+  });
+
+  test("returns 405 for PUT method", async ({ request }) => {
+    const res = await request.put(`/api/members/${DUMMY_UUID}`, {
+      headers: { origin: ORIGIN },
+      data: {},
+    });
+    expect(res.status()).toBe(405);
+  });
+});

--- a/src/app/api/members/[accountId]/route.ts
+++ b/src/app/api/members/[accountId]/route.ts
@@ -1,0 +1,141 @@
+import type { NextRequest } from "next/server";
+import { auditLog } from "@/lib/auth/audit-stub";
+import { HttpError } from "@/lib/auth/errors";
+import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
+import { changeMemberRole, removeMember } from "@/lib/auth/members";
+import { getAuthPool } from "@/lib/db/client";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const DELETE = withAuth(async (req: NextRequest, auth) => {
+  const originErr = verifyOrigin(req);
+  if (originErr) return originErr;
+
+  const csrfErr = verifyCsrf(req, {
+    ctx: "general",
+    sid: auth.sessionId,
+    iat: auth.iat,
+  });
+  if (csrfErr) return csrfErr;
+
+  const accountId = req.nextUrl.pathname.split("/").pop();
+  if (!accountId || !UUID_RE.test(accountId)) {
+    return Response.json(
+      { error: "Invalid accountId format" },
+      { status: 400 },
+    );
+  }
+
+  const customerId = req.nextUrl.searchParams.get("customer_id");
+  if (!customerId || !UUID_RE.test(customerId)) {
+    return Response.json(
+      { error: "customer_id query parameter is required (UUID)" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    await removeMember(getAuthPool(), {
+      actorId: auth.accountId,
+      targetAccountId: accountId,
+      customerId,
+    });
+
+    await auditLog({
+      actorId: auth.accountId,
+      authContext: "general",
+      action: "member.remove",
+      targetType: "membership",
+      targetId: accountId,
+      details: { customerId },
+      ipAddress: auth.meta.ipAddress,
+      sid: auth.sessionId,
+      customerId,
+    });
+
+    return new Response(null, { status: 204 });
+  } catch (err: unknown) {
+    if (err instanceof HttpError) {
+      return Response.json({ error: err.message }, { status: err.statusCode });
+    }
+    throw err;
+  }
+});
+
+export const PATCH = withAuth(async (req: NextRequest, auth) => {
+  const originErr = verifyOrigin(req);
+  if (originErr) return originErr;
+
+  const csrfErr = verifyCsrf(req, {
+    ctx: "general",
+    sid: auth.sessionId,
+    iat: auth.iat,
+  });
+  if (csrfErr) return csrfErr;
+
+  const accountId = req.nextUrl.pathname.split("/").pop();
+  if (!accountId || !UUID_RE.test(accountId)) {
+    return Response.json(
+      { error: "Invalid accountId format" },
+      { status: 400 },
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return Response.json(
+      { error: "Request body must be a JSON object" },
+      { status: 400 },
+    );
+  }
+
+  const { customerId, roleId } = raw as Record<string, unknown>;
+  if (typeof customerId !== "string" || !UUID_RE.test(customerId)) {
+    return Response.json(
+      { error: "customerId is required (UUID)" },
+      { status: 400 },
+    );
+  }
+
+  if (typeof roleId !== "number" || !Number.isInteger(roleId)) {
+    return Response.json(
+      { error: "roleId is required (integer)" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    await changeMemberRole(getAuthPool(), {
+      actorId: auth.accountId,
+      targetAccountId: accountId,
+      customerId,
+      roleId,
+    });
+
+    await auditLog({
+      actorId: auth.accountId,
+      authContext: "general",
+      action: "member.role_change",
+      targetType: "membership",
+      targetId: accountId,
+      details: { customerId, roleId },
+      ipAddress: auth.meta.ipAddress,
+      sid: auth.sessionId,
+      customerId,
+    });
+
+    return new Response(null, { status: 204 });
+  } catch (err: unknown) {
+    if (err instanceof HttpError) {
+      return Response.json({ error: err.message }, { status: err.statusCode });
+    }
+    throw err;
+  }
+});

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -1,0 +1,35 @@
+import type { NextRequest } from "next/server";
+import { HttpError } from "@/lib/auth/errors";
+import { withAuth } from "@/lib/auth/guards";
+import { listMembers } from "@/lib/auth/members";
+import { getAuthPool } from "@/lib/db/client";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const GET = withAuth(async (req: NextRequest, auth) => {
+  const customerId = req.nextUrl.searchParams.get("customer_id");
+  if (!customerId || !UUID_RE.test(customerId)) {
+    return Response.json(
+      { error: "customer_id query parameter is required (UUID)" },
+      { status: 400 },
+    );
+  }
+
+  const pool = getAuthPool();
+  const client = await pool.connect();
+  try {
+    const members = await listMembers(client, {
+      actorId: auth.accountId,
+      customerId,
+    });
+    return Response.json(members);
+  } catch (err: unknown) {
+    if (err instanceof HttpError) {
+      return Response.json({ error: err.message }, { status: err.statusCode });
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
+});

--- a/src/lib/auth/__tests__/members.db.test.ts
+++ b/src/lib/auth/__tests__/members.db.test.ts
@@ -1,0 +1,631 @@
+import { join } from "node:path";
+import type { Pool, PoolClient } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeAdminPool,
+  createTestDatabase,
+  dropTestDatabase,
+  hasPostgres,
+} from "../../db/__tests__/db-test-helpers";
+import { runMigrations } from "../../db/migrate";
+import { HttpError } from "../errors";
+import { changeMemberRole, listMembers, removeMember } from "../members";
+
+const MIGRATIONS_DIR = join(process.cwd(), "migrations", "auth");
+const LOCK_ID = 1003;
+
+describe.skipIf(!hasPostgres)("member management (DB integration)", () => {
+  let pool: Pool;
+  let dbName: string;
+
+  // Test fixtures
+  let managerAccountId: string;
+  let manager2AccountId: string;
+  let userAccountId: string;
+  let nonMemberAccountId: string;
+  let customerId: string;
+  let managerRoleId: number;
+  let userRoleId: number;
+
+  beforeAll(async () => {
+    const result = await createTestDatabase("members", "auth");
+    pool = result.pool;
+    dbName = result.dbName;
+
+    await pool.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'aimer_auth') THEN
+          CREATE ROLE aimer_auth LOGIN PASSWORD 'changeme';
+        END IF;
+      END $$
+    `);
+
+    await runMigrations(pool, MIGRATIONS_DIR, LOCK_ID);
+
+    // Lookup built-in roles
+    const roles = await pool.query<{ id: number; name: string }>(
+      `SELECT id, name FROM roles
+       WHERE auth_context = 'general' AND name IN ('User', 'Manager')`,
+    );
+    for (const r of roles.rows) {
+      if (r.name === "User") userRoleId = r.id;
+      if (r.name === "Manager") managerRoleId = r.id;
+    }
+
+    // Create customer
+    const cust = await pool.query<{ id: string }>(
+      `INSERT INTO customers (external_key, name)
+       VALUES ('members-test-cust', 'Members Test Customer')
+       RETURNING id`,
+    );
+    customerId = cust.rows[0].id;
+
+    // Manager account
+    const mgr = await pool.query<{ id: string }>(
+      `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+       VALUES ('test-issuer', 'mgr-m-001', 'manager1', 'Manager One', 'manager1@example.com')
+       RETURNING id`,
+    );
+    managerAccountId = mgr.rows[0].id;
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+       VALUES ($1, $2, $3)`,
+      [managerAccountId, customerId, managerRoleId],
+    );
+
+    // Second Manager account
+    const mgr2 = await pool.query<{ id: string }>(
+      `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+       VALUES ('test-issuer', 'mgr-m-002', 'manager2', 'Manager Two', 'manager2@example.com')
+       RETURNING id`,
+    );
+    manager2AccountId = mgr2.rows[0].id;
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+       VALUES ($1, $2, $3)`,
+      [manager2AccountId, customerId, managerRoleId],
+    );
+
+    // Regular User account
+    const usr = await pool.query<{ id: string }>(
+      `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+       VALUES ('test-issuer', 'usr-m-001', 'user1', 'User One', 'user1@example.com')
+       RETURNING id`,
+    );
+    userAccountId = usr.rows[0].id;
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+       VALUES ($1, $2, $3)`,
+      [userAccountId, customerId, userRoleId],
+    );
+
+    // Non-member account (no membership)
+    const nm = await pool.query<{ id: string }>(
+      `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+       VALUES ('test-issuer', 'nm-m-001', 'nonmember', 'Non Member', 'nonmember@example.com')
+       RETURNING id`,
+    );
+    nonMemberAccountId = nm.rows[0].id;
+  });
+
+  afterAll(async () => {
+    await dropTestDatabase(dbName, pool, "auth");
+    await closeAdminPool();
+  });
+
+  async function withClient<T>(
+    fn: (client: PoolClient) => Promise<T>,
+  ): Promise<T> {
+    const client = await pool.connect();
+    try {
+      return await fn(client);
+    } finally {
+      client.release();
+    }
+  }
+
+  // =========================================================================
+  // listMembers
+  // =========================================================================
+
+  describe("listMembers", () => {
+    it("returns all members of a customer", async () => {
+      const members = await withClient((client) =>
+        listMembers(client, {
+          actorId: managerAccountId,
+          customerId,
+        }),
+      );
+
+      expect(members).toHaveLength(3);
+
+      const usernames = members.map((m) => m.username).sort();
+      expect(usernames).toEqual(["manager1", "manager2", "user1"]);
+
+      const manager = members.find((m) => m.username === "manager1");
+      expect(manager).toBeDefined();
+      expect(manager?.roleName).toBe("Manager");
+      expect(manager?.email).toBe("manager1@example.com");
+    });
+
+    it("rejects non-Manager actors", async () => {
+      await expect(
+        withClient((client) =>
+          listMembers(client, {
+            actorId: userAccountId,
+            customerId,
+          }),
+        ),
+      ).rejects.toThrow(HttpError);
+
+      try {
+        await withClient((client) =>
+          listMembers(client, {
+            actorId: userAccountId,
+            customerId,
+          }),
+        );
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpError);
+        expect((err as HttpError).statusCode).toBe(403);
+      }
+    });
+
+    it("rejects non-member actors", async () => {
+      await expect(
+        withClient((client) =>
+          listMembers(client, {
+            actorId: nonMemberAccountId,
+            customerId,
+          }),
+        ),
+      ).rejects.toThrow(HttpError);
+    });
+
+    it("returns all expected fields per member", async () => {
+      // Set a known last_sign_in_at for verification
+      await pool.query(
+        `UPDATE accounts SET last_sign_in_at = '2026-01-15T10:00:00Z'
+         WHERE id = $1`,
+        [userAccountId],
+      );
+
+      const members = await withClient((client) =>
+        listMembers(client, {
+          actorId: managerAccountId,
+          customerId,
+        }),
+      );
+
+      const user = members.find((m) => m.username === "user1");
+      expect(user).toBeDefined();
+      expect(user?.accountId).toBe(userAccountId);
+      expect(user?.displayName).toBe("User One");
+      expect(user?.email).toBe("user1@example.com");
+      expect(user?.roleName).toBe("User");
+      expect(user?.roleId).toBe(userRoleId);
+      expect(user?.lastSignInAt).toBe("2026-01-15T10:00:00.000Z");
+
+      // Clean up
+      await pool.query(
+        `UPDATE accounts SET last_sign_in_at = NULL WHERE id = $1`,
+        [userAccountId],
+      );
+    });
+  });
+
+  // =========================================================================
+  // removeMember
+  // =========================================================================
+
+  describe("removeMember", () => {
+    it("allows Manager to remove a User member", async () => {
+      // Add a temporary user to remove
+      const tmp = await pool.query<{ id: string }>(
+        `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+         VALUES ('test-issuer', 'tmp-rm-001', 'tmpremove', 'Tmp Remove', 'tmpremove@example.com')
+         RETURNING id`,
+      );
+      await pool.query(
+        `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+         VALUES ($1, $2, $3)`,
+        [tmp.rows[0].id, customerId, userRoleId],
+      );
+
+      await removeMember(pool, {
+        actorId: managerAccountId,
+        targetAccountId: tmp.rows[0].id,
+        customerId,
+      });
+
+      const check = await pool.query(
+        `SELECT 1 FROM account_customer_memberships
+         WHERE account_id = $1 AND customer_id = $2`,
+        [tmp.rows[0].id, customerId],
+      );
+      expect(check.rows).toHaveLength(0);
+    });
+
+    it("allows Manager to remove themselves if other Managers exist", async () => {
+      // Add a third manager to remove self safely
+      const tmp = await pool.query<{ id: string }>(
+        `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+         VALUES ('test-issuer', 'mgr-self-rm', 'selfremovemgr', 'Self Remove Mgr', 'selfremovemgr@example.com')
+         RETURNING id`,
+      );
+      await pool.query(
+        `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+         VALUES ($1, $2, $3)`,
+        [tmp.rows[0].id, customerId, managerRoleId],
+      );
+
+      await removeMember(pool, {
+        actorId: tmp.rows[0].id,
+        targetAccountId: tmp.rows[0].id,
+        customerId,
+      });
+
+      const check = await pool.query(
+        `SELECT 1 FROM account_customer_memberships
+         WHERE account_id = $1 AND customer_id = $2`,
+        [tmp.rows[0].id, customerId],
+      );
+      expect(check.rows).toHaveLength(0);
+    });
+
+    it("blocks removal of non-existent membership", async () => {
+      try {
+        await removeMember(pool, {
+          actorId: managerAccountId,
+          targetAccountId: nonMemberAccountId,
+          customerId,
+        });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpError);
+        expect((err as HttpError).statusCode).toBe(404);
+      }
+    });
+
+    it("blocks non-Manager from removing members", async () => {
+      try {
+        await removeMember(pool, {
+          actorId: userAccountId,
+          targetAccountId: userAccountId,
+          customerId,
+        });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpError);
+        expect((err as HttpError).statusCode).toBe(403);
+      }
+    });
+  });
+
+  // =========================================================================
+  // Last Manager protection
+  // =========================================================================
+
+  describe("last Manager protection", () => {
+    let soloCustomerId: string;
+    let soloManagerId: string;
+    let soloUserId: string;
+
+    beforeAll(async () => {
+      // Create a customer with a single Manager
+      const cust = await pool.query<{ id: string }>(
+        `INSERT INTO customers (external_key, name)
+         VALUES ('solo-mgr-cust', 'Solo Manager Customer')
+         RETURNING id`,
+      );
+      soloCustomerId = cust.rows[0].id;
+
+      const mgr = await pool.query<{ id: string }>(
+        `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+         VALUES ('test-issuer', 'solo-mgr-001', 'solomgr', 'Solo Manager', 'solomgr@example.com')
+         RETURNING id`,
+      );
+      soloManagerId = mgr.rows[0].id;
+      await pool.query(
+        `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+         VALUES ($1, $2, $3)`,
+        [soloManagerId, soloCustomerId, managerRoleId],
+      );
+
+      const usr = await pool.query<{ id: string }>(
+        `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+         VALUES ('test-issuer', 'solo-usr-001', 'solousr', 'Solo User', 'solousr@example.com')
+         RETURNING id`,
+      );
+      soloUserId = usr.rows[0].id;
+      await pool.query(
+        `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+         VALUES ($1, $2, $3)`,
+        [soloUserId, soloCustomerId, userRoleId],
+      );
+    });
+
+    it("blocks removal of the last Manager", async () => {
+      try {
+        await removeMember(pool, {
+          actorId: soloManagerId,
+          targetAccountId: soloManagerId,
+          customerId: soloCustomerId,
+        });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpError);
+        expect((err as HttpError).statusCode).toBe(409);
+        expect((err as HttpError).message).toBe(
+          "last_manager_cannot_be_removed",
+        );
+      }
+    });
+
+    it("blocks demotion of the last Manager to User", async () => {
+      try {
+        await changeMemberRole(pool, {
+          actorId: soloManagerId,
+          targetAccountId: soloManagerId,
+          customerId: soloCustomerId,
+          roleId: userRoleId,
+        });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpError);
+        expect((err as HttpError).statusCode).toBe(409);
+        expect((err as HttpError).message).toBe(
+          "last_manager_cannot_be_removed",
+        );
+      }
+    });
+
+    it("allows promoting User to Manager (no last-Manager concern)", async () => {
+      await changeMemberRole(pool, {
+        actorId: soloManagerId,
+        targetAccountId: soloUserId,
+        customerId: soloCustomerId,
+        roleId: managerRoleId,
+      });
+
+      const check = await pool.query<{ role_id: number }>(
+        `SELECT role_id FROM account_customer_memberships
+         WHERE account_id = $1 AND customer_id = $2`,
+        [soloUserId, soloCustomerId],
+      );
+      expect(check.rows[0].role_id).toBe(managerRoleId);
+
+      // Restore to User for subsequent tests
+      await changeMemberRole(pool, {
+        actorId: soloManagerId,
+        targetAccountId: soloUserId,
+        customerId: soloCustomerId,
+        roleId: userRoleId,
+      });
+    });
+  });
+
+  // =========================================================================
+  // changeMemberRole
+  // =========================================================================
+
+  describe("changeMemberRole", () => {
+    it("changes a User to Manager", async () => {
+      // Add a temp user
+      const tmp = await pool.query<{ id: string }>(
+        `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+         VALUES ('test-issuer', 'role-chg-001', 'rolechg', 'Role Change', 'rolechg@example.com')
+         RETURNING id`,
+      );
+      await pool.query(
+        `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+         VALUES ($1, $2, $3)`,
+        [tmp.rows[0].id, customerId, userRoleId],
+      );
+
+      await changeMemberRole(pool, {
+        actorId: managerAccountId,
+        targetAccountId: tmp.rows[0].id,
+        customerId,
+        roleId: managerRoleId,
+      });
+
+      const check = await pool.query<{ role_id: number }>(
+        `SELECT role_id FROM account_customer_memberships
+         WHERE account_id = $1 AND customer_id = $2`,
+        [tmp.rows[0].id, customerId],
+      );
+      expect(check.rows[0].role_id).toBe(managerRoleId);
+
+      // Clean up
+      await pool.query(
+        `DELETE FROM account_customer_memberships
+         WHERE account_id = $1 AND customer_id = $2`,
+        [tmp.rows[0].id, customerId],
+      );
+    });
+
+    it("no-ops when setting the same role", async () => {
+      await changeMemberRole(pool, {
+        actorId: managerAccountId,
+        targetAccountId: userAccountId,
+        customerId,
+        roleId: userRoleId,
+      });
+
+      const check = await pool.query<{ role_id: number }>(
+        `SELECT role_id FROM account_customer_memberships
+         WHERE account_id = $1 AND customer_id = $2`,
+        [userAccountId, customerId],
+      );
+      expect(check.rows[0].role_id).toBe(userRoleId);
+    });
+
+    it("rejects invalid role ID", async () => {
+      try {
+        await changeMemberRole(pool, {
+          actorId: managerAccountId,
+          targetAccountId: userAccountId,
+          customerId,
+          roleId: 99999,
+        });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpError);
+        expect((err as HttpError).statusCode).toBe(400);
+      }
+    });
+
+    it("rejects non-Manager actors", async () => {
+      try {
+        await changeMemberRole(pool, {
+          actorId: userAccountId,
+          targetAccountId: userAccountId,
+          customerId,
+          roleId: managerRoleId,
+        });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpError);
+        expect((err as HttpError).statusCode).toBe(403);
+      }
+    });
+
+    it("allows Manager to demote themselves when other Managers exist", async () => {
+      // manager2 demotes themselves to User (manager1 still exists)
+      await changeMemberRole(pool, {
+        actorId: manager2AccountId,
+        targetAccountId: manager2AccountId,
+        customerId,
+        roleId: userRoleId,
+      });
+
+      const check = await pool.query<{ role_id: number }>(
+        `SELECT role_id FROM account_customer_memberships
+         WHERE account_id = $1 AND customer_id = $2`,
+        [manager2AccountId, customerId],
+      );
+      expect(check.rows[0].role_id).toBe(userRoleId);
+
+      // Restore to Manager for subsequent tests
+      await pool.query(
+        `UPDATE account_customer_memberships
+         SET role_id = $1 WHERE account_id = $2 AND customer_id = $3`,
+        [managerRoleId, manager2AccountId, customerId],
+      );
+    });
+
+    it("rejects admin-context role (DB trigger)", async () => {
+      // Look up System Administrator role (admin context)
+      const adminRole = await pool.query<{ id: number }>(
+        `SELECT id FROM roles WHERE name = 'System Administrator'`,
+      );
+      const adminRoleId = adminRole.rows[0].id;
+
+      // The assertValidGeneralRole check should reject before the
+      // DB trigger fires, since it only accepts general-context roles.
+      try {
+        await changeMemberRole(pool, {
+          actorId: managerAccountId,
+          targetAccountId: userAccountId,
+          customerId,
+          roleId: adminRoleId,
+        });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpError);
+        expect((err as HttpError).statusCode).toBe(400);
+        expect((err as HttpError).message).toBe("Invalid role");
+      }
+    });
+
+    it("rejects changing role of non-member", async () => {
+      try {
+        await changeMemberRole(pool, {
+          actorId: managerAccountId,
+          targetAccountId: nonMemberAccountId,
+          customerId,
+          roleId: userRoleId,
+        });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpError);
+        expect((err as HttpError).statusCode).toBe(404);
+      }
+    });
+  });
+
+  // =========================================================================
+  // Concurrency: FOR UPDATE prevents double removal of last Manager
+  // =========================================================================
+
+  describe("concurrent last Manager removal", () => {
+    it("only one concurrent removal succeeds when two Managers exist", async () => {
+      // Create customer with exactly 2 managers
+      const cust = await pool.query<{ id: string }>(
+        `INSERT INTO customers (external_key, name)
+         VALUES ('conc-mgr-cust', 'Concurrent Manager Customer')
+         RETURNING id`,
+      );
+      const concCustomerId = cust.rows[0].id;
+
+      const m1 = await pool.query<{ id: string }>(
+        `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+         VALUES ('test-issuer', 'conc-mgr-001', 'concmgr1', 'Conc Mgr 1', 'concmgr1@example.com')
+         RETURNING id`,
+      );
+      const m2 = await pool.query<{ id: string }>(
+        `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+         VALUES ('test-issuer', 'conc-mgr-002', 'concmgr2', 'Conc Mgr 2', 'concmgr2@example.com')
+         RETURNING id`,
+      );
+
+      await pool.query(
+        `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+         VALUES ($1, $3, $5), ($2, $4, $6)`,
+        [
+          m1.rows[0].id,
+          m2.rows[0].id,
+          concCustomerId,
+          concCustomerId,
+          managerRoleId,
+          managerRoleId,
+        ],
+      );
+
+      // Both try to remove the other concurrently
+      const results = await Promise.allSettled([
+        removeMember(pool, {
+          actorId: m1.rows[0].id,
+          targetAccountId: m2.rows[0].id,
+          customerId: concCustomerId,
+        }),
+        removeMember(pool, {
+          actorId: m2.rows[0].id,
+          targetAccountId: m1.rows[0].id,
+          customerId: concCustomerId,
+        }),
+      ]);
+
+      const successes = results.filter((r) => r.status === "fulfilled");
+      const failures = results.filter((r) => r.status === "rejected");
+
+      // Exactly one must succeed, one must fail (403 or 409 depending
+      // on serialization order — the loser may fail at permission check
+      // because their membership was deleted by the winner).
+      expect(successes).toHaveLength(1);
+      expect(failures).toHaveLength(1);
+      const err = (failures[0] as PromiseRejectedResult).reason;
+      expect(err).toBeInstanceOf(HttpError);
+      expect([403, 409]).toContain((err as HttpError).statusCode);
+
+      // Invariant: exactly one Manager remains
+      const remaining = await pool.query(
+        `SELECT account_id FROM account_customer_memberships
+         WHERE customer_id = $1`,
+        [concCustomerId],
+      );
+      expect(remaining.rows).toHaveLength(1);
+    });
+  });
+});

--- a/src/lib/auth/invitations.ts
+++ b/src/lib/auth/invitations.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes } from "node:crypto";
 import type { Pool, PoolClient } from "pg";
 import { withTransaction } from "../db/client";
 import { HttpError } from "./errors";
+import { assertManagerPermission } from "./permissions";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -33,28 +34,6 @@ function generateToken(): { raw: string; hash: string } {
   const raw = randomBytes(32).toString("base64url");
   const hash = hashToken(raw);
   return { raw, hash };
-}
-
-// ---------------------------------------------------------------------------
-// Permission check
-// ---------------------------------------------------------------------------
-
-async function assertManagerPermission(
-  client: PoolClient,
-  accountId: string,
-  customerId: string,
-): Promise<void> {
-  const result = await client.query<{ permission: string }>(
-    `SELECT rp.permission
-     FROM account_customer_memberships acm
-     JOIN role_permissions rp ON rp.role_id = acm.role_id
-     WHERE acm.account_id = $1 AND acm.customer_id = $2
-       AND rp.permission = 'customer-members:write'`,
-    [accountId, customerId],
-  );
-  if (result.rows.length === 0) {
-    throw new HttpError("Forbidden", 403);
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/auth/members.ts
+++ b/src/lib/auth/members.ts
@@ -36,22 +36,27 @@ export interface ChangeMemberRoleParams {
 }
 
 // ---------------------------------------------------------------------------
-// Membership existence check
+// Membership lock
+//
+// Locks the target membership row with FOR UPDATE to prevent concurrent
+// modification (TOCTOU). Returns the current role_id for use by callers.
 // ---------------------------------------------------------------------------
 
-async function assertMembershipExists(
+async function lockMembership(
   client: PoolClient,
   accountId: string,
   customerId: string,
-): Promise<void> {
-  const result = await client.query(
-    `SELECT 1 FROM account_customer_memberships
-     WHERE account_id = $1 AND customer_id = $2`,
+): Promise<{ roleId: number }> {
+  const result = await client.query<{ role_id: number }>(
+    `SELECT role_id FROM account_customer_memberships
+     WHERE account_id = $1 AND customer_id = $2
+     FOR UPDATE`,
     [accountId, customerId],
   );
   if (result.rows.length === 0) {
     throw new HttpError("Membership not found", 404);
   }
+  return { roleId: result.rows[0].role_id };
 }
 
 // ---------------------------------------------------------------------------
@@ -158,22 +163,21 @@ export async function removeMember(
 ): Promise<void> {
   await withTransaction(pool, async (client) => {
     await assertManagerPermission(client, params.actorId, params.customerId);
-    await assertMembershipExists(
-      client,
-      params.targetAccountId,
-      params.customerId,
-    );
+    await lockMembership(client, params.targetAccountId, params.customerId);
     await assertNotLastManager(
       client,
       params.targetAccountId,
       params.customerId,
     );
 
-    await client.query(
+    const result = await client.query(
       `DELETE FROM account_customer_memberships
        WHERE account_id = $1 AND customer_id = $2`,
       [params.targetAccountId, params.customerId],
     );
+    if (result.rowCount === 0) {
+      throw new HttpError("Membership not found", 404);
+    }
   });
 }
 
@@ -187,26 +191,18 @@ export async function changeMemberRole(
 ): Promise<void> {
   await withTransaction(pool, async (client) => {
     await assertManagerPermission(client, params.actorId, params.customerId);
-    await assertMembershipExists(
+    const { roleId: currentRoleId } = await lockMembership(
       client,
       params.targetAccountId,
       params.customerId,
     );
     await assertValidGeneralRole(client, params.roleId);
 
-    // If demoting from Manager, check last-Manager protection
-    const current = await client.query<{ role_id: number }>(
-      `SELECT role_id FROM account_customer_memberships
-       WHERE account_id = $1 AND customer_id = $2`,
-      [params.targetAccountId, params.customerId],
-    );
-
-    const currentRoleId = current.rows[0].role_id;
     if (currentRoleId === params.roleId) {
       return; // No-op: same role
     }
 
-    // Check if current role is Manager
+    // If demoting from Manager, check last-Manager protection
     const currentRoleName = await client.query<{ name: string }>(
       `SELECT name FROM roles WHERE id = $1`,
       [currentRoleId],
@@ -220,11 +216,14 @@ export async function changeMemberRole(
       );
     }
 
-    await client.query(
+    const result = await client.query(
       `UPDATE account_customer_memberships
        SET role_id = $1, updated_at = NOW()
        WHERE account_id = $2 AND customer_id = $3`,
       [params.roleId, params.targetAccountId, params.customerId],
     );
+    if (result.rowCount === 0) {
+      throw new HttpError("Membership not found", 404);
+    }
   });
 }

--- a/src/lib/auth/members.ts
+++ b/src/lib/auth/members.ts
@@ -89,6 +89,16 @@ function findTarget(
   return target;
 }
 
+function assertActorIsManager(
+  members: LockedMembership[],
+  actorId: string,
+): void {
+  const actor = members.find((m) => m.accountId === actorId);
+  if (!actor || actor.roleName !== "Manager") {
+    throw new HttpError("Forbidden", 403);
+  }
+}
+
 function assertNotLastManager(
   members: LockedMembership[],
   targetAccountId: string,
@@ -177,6 +187,7 @@ export async function removeMember(
   await withTransaction(pool, async (client) => {
     await assertManagerPermission(client, params.actorId, params.customerId);
     const members = await lockAllMemberships(client, params.customerId);
+    assertActorIsManager(members, params.actorId);
     findTarget(members, params.targetAccountId);
     assertNotLastManager(members, params.targetAccountId);
 
@@ -202,6 +213,7 @@ export async function changeMemberRole(
   await withTransaction(pool, async (client) => {
     await assertManagerPermission(client, params.actorId, params.customerId);
     const members = await lockAllMemberships(client, params.customerId);
+    assertActorIsManager(members, params.actorId);
     const target = findTarget(members, params.targetAccountId);
     await assertValidGeneralRole(client, params.roleId);
 

--- a/src/lib/auth/members.ts
+++ b/src/lib/auth/members.ts
@@ -36,54 +36,67 @@ export interface ChangeMemberRoleParams {
 }
 
 // ---------------------------------------------------------------------------
-// Membership lock
+// Lock all memberships for a customer
 //
-// Locks the target membership row with FOR UPDATE to prevent concurrent
-// modification (TOCTOU). Returns the current role_id for use by callers.
+// Acquires FOR UPDATE locks on every membership row for the customer in
+// deterministic order (account_id). A single lock step eliminates the
+// deadlock that would occur if the target row and the Manager rows were
+// locked separately (A locks B's row then waits for A's Manager lock,
+// while B locks A's row then waits for B's Manager lock).
+//
+// Returns the locked rows joined with role name so callers can derive
+// target existence, current role, and Manager count from one result set.
 // ---------------------------------------------------------------------------
 
-async function lockMembership(
-  client: PoolClient,
-  accountId: string,
-  customerId: string,
-): Promise<{ roleId: number }> {
-  const result = await client.query<{ role_id: number }>(
-    `SELECT role_id FROM account_customer_memberships
-     WHERE account_id = $1 AND customer_id = $2
-     FOR UPDATE`,
-    [accountId, customerId],
-  );
-  if (result.rows.length === 0) {
-    throw new HttpError("Membership not found", 404);
-  }
-  return { roleId: result.rows[0].role_id };
+interface LockedMembership {
+  accountId: string;
+  roleId: number;
+  roleName: string;
 }
 
-// ---------------------------------------------------------------------------
-// Last Manager protection
-//
-// Uses SELECT ... FOR UPDATE to lock Manager rows and prevent concurrent
-// removal/demotion of the last Manager.
-// ---------------------------------------------------------------------------
-
-async function assertNotLastManager(
+async function lockAllMemberships(
   client: PoolClient,
-  targetAccountId: string,
   customerId: string,
-): Promise<void> {
-  const result = await client.query<{ account_id: string }>(
-    `SELECT acm.account_id
+): Promise<LockedMembership[]> {
+  const result = await client.query<{
+    account_id: string;
+    role_id: number;
+    role_name: string;
+  }>(
+    `SELECT acm.account_id, acm.role_id, r.name AS role_name
      FROM account_customer_memberships acm
      JOIN roles r ON r.id = acm.role_id
-     WHERE acm.customer_id = $1 AND r.name = 'Manager'
-     FOR UPDATE`,
+     WHERE acm.customer_id = $1
+     ORDER BY acm.account_id
+     FOR UPDATE OF acm`,
     [customerId],
   );
+  return result.rows.map((r) => ({
+    accountId: r.account_id,
+    roleId: r.role_id,
+    roleName: r.role_name,
+  }));
+}
 
-  const managerIds = result.rows.map((r) => r.account_id);
+function findTarget(
+  members: LockedMembership[],
+  targetAccountId: string,
+): LockedMembership {
+  const target = members.find((m) => m.accountId === targetAccountId);
+  if (!target) {
+    throw new HttpError("Membership not found", 404);
+  }
+  return target;
+}
+
+function assertNotLastManager(
+  members: LockedMembership[],
+  targetAccountId: string,
+): void {
+  const managers = members.filter((m) => m.roleName === "Manager");
   if (
-    managerIds.length <= 1 &&
-    managerIds.some((id) => id === targetAccountId)
+    managers.length <= 1 &&
+    managers.some((m) => m.accountId === targetAccountId)
   ) {
     throw new HttpError("last_manager_cannot_be_removed", 409);
   }
@@ -163,12 +176,9 @@ export async function removeMember(
 ): Promise<void> {
   await withTransaction(pool, async (client) => {
     await assertManagerPermission(client, params.actorId, params.customerId);
-    await lockMembership(client, params.targetAccountId, params.customerId);
-    await assertNotLastManager(
-      client,
-      params.targetAccountId,
-      params.customerId,
-    );
+    const members = await lockAllMemberships(client, params.customerId);
+    findTarget(members, params.targetAccountId);
+    assertNotLastManager(members, params.targetAccountId);
 
     const result = await client.query(
       `DELETE FROM account_customer_memberships
@@ -191,29 +201,17 @@ export async function changeMemberRole(
 ): Promise<void> {
   await withTransaction(pool, async (client) => {
     await assertManagerPermission(client, params.actorId, params.customerId);
-    const { roleId: currentRoleId } = await lockMembership(
-      client,
-      params.targetAccountId,
-      params.customerId,
-    );
+    const members = await lockAllMemberships(client, params.customerId);
+    const target = findTarget(members, params.targetAccountId);
     await assertValidGeneralRole(client, params.roleId);
 
-    if (currentRoleId === params.roleId) {
+    if (target.roleId === params.roleId) {
       return; // No-op: same role
     }
 
     // If demoting from Manager, check last-Manager protection
-    const currentRoleName = await client.query<{ name: string }>(
-      `SELECT name FROM roles WHERE id = $1`,
-      [currentRoleId],
-    );
-
-    if (currentRoleName.rows[0].name === "Manager") {
-      await assertNotLastManager(
-        client,
-        params.targetAccountId,
-        params.customerId,
-      );
+    if (target.roleName === "Manager") {
+      assertNotLastManager(members, params.targetAccountId);
     }
 
     const result = await client.query(

--- a/src/lib/auth/members.ts
+++ b/src/lib/auth/members.ts
@@ -1,0 +1,230 @@
+import type { Pool, PoolClient } from "pg";
+import { withTransaction } from "../db/client";
+import { HttpError } from "./errors";
+import { assertManagerPermission } from "./permissions";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface Member {
+  accountId: string;
+  username: string;
+  displayName: string;
+  email: string | null;
+  roleName: string;
+  roleId: number;
+  lastSignInAt: string | null;
+}
+
+export interface ListMembersParams {
+  actorId: string;
+  customerId: string;
+}
+
+export interface RemoveMemberParams {
+  actorId: string;
+  targetAccountId: string;
+  customerId: string;
+}
+
+export interface ChangeMemberRoleParams {
+  actorId: string;
+  targetAccountId: string;
+  customerId: string;
+  roleId: number;
+}
+
+// ---------------------------------------------------------------------------
+// Membership existence check
+// ---------------------------------------------------------------------------
+
+async function assertMembershipExists(
+  client: PoolClient,
+  accountId: string,
+  customerId: string,
+): Promise<void> {
+  const result = await client.query(
+    `SELECT 1 FROM account_customer_memberships
+     WHERE account_id = $1 AND customer_id = $2`,
+    [accountId, customerId],
+  );
+  if (result.rows.length === 0) {
+    throw new HttpError("Membership not found", 404);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Last Manager protection
+//
+// Uses SELECT ... FOR UPDATE to lock Manager rows and prevent concurrent
+// removal/demotion of the last Manager.
+// ---------------------------------------------------------------------------
+
+async function assertNotLastManager(
+  client: PoolClient,
+  targetAccountId: string,
+  customerId: string,
+): Promise<void> {
+  const result = await client.query<{ account_id: string }>(
+    `SELECT acm.account_id
+     FROM account_customer_memberships acm
+     JOIN roles r ON r.id = acm.role_id
+     WHERE acm.customer_id = $1 AND r.name = 'Manager'
+     FOR UPDATE`,
+    [customerId],
+  );
+
+  const managerIds = result.rows.map((r) => r.account_id);
+  if (
+    managerIds.length <= 1 &&
+    managerIds.some((id) => id === targetAccountId)
+  ) {
+    throw new HttpError("last_manager_cannot_be_removed", 409);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Role validation
+// ---------------------------------------------------------------------------
+
+async function assertValidGeneralRole(
+  client: PoolClient,
+  roleId: number,
+): Promise<string> {
+  const result = await client.query<{ name: string }>(
+    `SELECT name FROM roles WHERE id = $1 AND auth_context = 'general'`,
+    [roleId],
+  );
+  if (result.rows.length === 0) {
+    throw new HttpError("Invalid role", 400);
+  }
+  return result.rows[0].name;
+}
+
+// ---------------------------------------------------------------------------
+// List members
+// ---------------------------------------------------------------------------
+
+export async function listMembers(
+  client: PoolClient,
+  params: ListMembersParams,
+): Promise<Member[]> {
+  await assertManagerPermission(client, params.actorId, params.customerId);
+
+  const result = await client.query<{
+    account_id: string;
+    username: string;
+    display_name: string;
+    email: string | null;
+    role_name: string;
+    role_id: number;
+    last_sign_in_at: Date | null;
+  }>(
+    `SELECT
+       acm.account_id,
+       a.username,
+       a.display_name,
+       a.email,
+       r.name AS role_name,
+       acm.role_id,
+       a.last_sign_in_at
+     FROM account_customer_memberships acm
+     JOIN accounts a ON a.id = acm.account_id
+     JOIN roles r ON r.id = acm.role_id
+     WHERE acm.customer_id = $1
+     ORDER BY a.display_name`,
+    [params.customerId],
+  );
+
+  return result.rows.map((row) => ({
+    accountId: row.account_id,
+    username: row.username,
+    displayName: row.display_name,
+    email: row.email,
+    roleName: row.role_name,
+    roleId: row.role_id,
+    lastSignInAt: row.last_sign_in_at?.toISOString() ?? null,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Remove member (transactional — uses pool)
+// ---------------------------------------------------------------------------
+
+export async function removeMember(
+  pool: Pool,
+  params: RemoveMemberParams,
+): Promise<void> {
+  await withTransaction(pool, async (client) => {
+    await assertManagerPermission(client, params.actorId, params.customerId);
+    await assertMembershipExists(
+      client,
+      params.targetAccountId,
+      params.customerId,
+    );
+    await assertNotLastManager(
+      client,
+      params.targetAccountId,
+      params.customerId,
+    );
+
+    await client.query(
+      `DELETE FROM account_customer_memberships
+       WHERE account_id = $1 AND customer_id = $2`,
+      [params.targetAccountId, params.customerId],
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Change member role (transactional — uses pool)
+// ---------------------------------------------------------------------------
+
+export async function changeMemberRole(
+  pool: Pool,
+  params: ChangeMemberRoleParams,
+): Promise<void> {
+  await withTransaction(pool, async (client) => {
+    await assertManagerPermission(client, params.actorId, params.customerId);
+    await assertMembershipExists(
+      client,
+      params.targetAccountId,
+      params.customerId,
+    );
+    await assertValidGeneralRole(client, params.roleId);
+
+    // If demoting from Manager, check last-Manager protection
+    const current = await client.query<{ role_id: number }>(
+      `SELECT role_id FROM account_customer_memberships
+       WHERE account_id = $1 AND customer_id = $2`,
+      [params.targetAccountId, params.customerId],
+    );
+
+    const currentRoleId = current.rows[0].role_id;
+    if (currentRoleId === params.roleId) {
+      return; // No-op: same role
+    }
+
+    // Check if current role is Manager
+    const currentRoleName = await client.query<{ name: string }>(
+      `SELECT name FROM roles WHERE id = $1`,
+      [currentRoleId],
+    );
+
+    if (currentRoleName.rows[0].name === "Manager") {
+      await assertNotLastManager(
+        client,
+        params.targetAccountId,
+        params.customerId,
+      );
+    }
+
+    await client.query(
+      `UPDATE account_customer_memberships
+       SET role_id = $1, updated_at = NOW()
+       WHERE account_id = $2 AND customer_id = $3`,
+      [params.roleId, params.targetAccountId, params.customerId],
+    );
+  });
+}

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -1,0 +1,42 @@
+import type { PoolClient } from "pg";
+import { HttpError } from "./errors";
+
+/**
+ * Assert that the given account holds a specific permission for a customer.
+ * Throws 403 if the permission is missing.
+ */
+export async function assertCustomerPermission(
+  client: PoolClient,
+  accountId: string,
+  customerId: string,
+  permission: string,
+): Promise<void> {
+  const result = await client.query<{ permission: string }>(
+    `SELECT rp.permission
+     FROM account_customer_memberships acm
+     JOIN role_permissions rp ON rp.role_id = acm.role_id
+     WHERE acm.account_id = $1 AND acm.customer_id = $2
+       AND rp.permission = $3`,
+    [accountId, customerId, permission],
+  );
+  if (result.rows.length === 0) {
+    throw new HttpError("Forbidden", 403);
+  }
+}
+
+/**
+ * Assert `customer-members:write` permission.
+ * Convenience wrapper used by invitation and member management flows.
+ */
+export async function assertManagerPermission(
+  client: PoolClient,
+  accountId: string,
+  customerId: string,
+): Promise<void> {
+  return assertCustomerPermission(
+    client,
+    accountId,
+    customerId,
+    "customer-members:write",
+  );
+}


### PR DESCRIPTION
## Summary

- Add `GET /api/members?customer_id=...` to list members (name, email, role, last sign-in)
- Add `DELETE /api/members/:account_id?customer_id=...` to remove a member
- Add `PATCH /api/members/:account_id` to change a member's role (`{ customerId, roleId }`)
- All endpoints require `customer-members:write` permission (Manager role)
- Last Manager of a customer cannot be removed or demoted → `409 last_manager_cannot_be_removed`
- Concurrency-safe: deterministic `SELECT ... FOR UPDATE` locks all membership rows per customer (`ORDER BY account_id`) to prevent deadlocks, with post-lock Manager revalidation to close stale-authorization windows
- Extract shared `assertManagerPermission` into `permissions.ts` to deduplicate with invitations

## New files

- `src/lib/auth/permissions.ts` — shared permission assertion
- `src/lib/auth/members.ts` — member management logic (list, remove, change role)
- `src/app/api/members/route.ts` — GET endpoint
- `src/app/api/members/[accountId]/route.ts` — DELETE, PATCH endpoints
- `src/lib/auth/__tests__/members.db.test.ts` — 19 DB integration tests
- `e2e/members-api.spec.ts` — 10 E2E tests (auth enforcement, method validation)

## Test plan

- [ ] DB tests: `DATABASE_ADMIN_URL=... pnpm vitest run src/lib/auth/__tests__/members.db.test.ts`
- [x] E2E tests: `pnpm playwright test --config e2e/playwright.config.ts e2e/members-api.spec.ts`
- [x] Type check: `pnpm tsc --noEmit`
- [x] Lint: `pnpm biome check`

Closes #79