### PR TITLE
Add invitation list and revoke API

### DIFF
--- a/e2e/invitation-api.spec.ts
+++ b/e2e/invitation-api.spec.ts
@@ -1,23 +1,31 @@
 import { expect, test } from "@playwright/test";
 
-// These tests exercise the POST /api/invitations HTTP layer without
-// authentication.  They verify that the endpoint exists, enforces auth,
-// and rejects malformed requests at the HTTP level.
+// These tests exercise the /api/invitations HTTP layer without
+// authentication.  They verify that the endpoints exist, enforce auth,
+// and reject malformed requests at the HTTP level.
 //
-// Full authenticated flows are covered by DB integration tests
-// (src/lib/auth/__tests__/invitations.db.test.ts) which exercise the
-// business logic directly.
+// Full authenticated flows (permission checks, listing, revocation,
+// concurrency) are covered by DB integration tests
+// (src/lib/auth/__tests__/invitation-management.db.test.ts and
+//  src/lib/auth/__tests__/invitations.db.test.ts).
 //
 // Email delivery is verified by the Mailpit integration test
 // (src/lib/email/__tests__/invitation-delivery.integration.test.ts)
 // which sends real SMTP and checks content via Mailpit API.
 
+const ORIGIN = "http://localhost:3000";
+const DUMMY_UUID = "00000000-0000-0000-0000-000000000001";
+
+// ==========================================================================
+// POST /api/invitations
+// ==========================================================================
+
 test.describe("POST /api/invitations", () => {
   test("returns 401 without auth cookie", async ({ request }) => {
     const res = await request.post("/api/invitations", {
-      headers: { origin: "http://localhost:3000" },
+      headers: { origin: ORIGIN },
       data: {
-        customerId: "00000000-0000-0000-0000-000000000001",
+        customerId: DUMMY_UUID,
         email: "test@example.com",
         role: "User",
       },
@@ -38,19 +46,84 @@ test.describe("POST /api/invitations", () => {
     ]);
 
     const res = await context.request.post("/api/invitations", {
-      headers: { origin: "http://localhost:3000" },
+      headers: { origin: ORIGIN },
       data: {
-        customerId: "00000000-0000-0000-0000-000000000001",
+        customerId: DUMMY_UUID,
         email: "test@example.com",
         role: "User",
       },
     });
     expect(res.status()).toBe(401);
   });
+});
+
+// ==========================================================================
+// GET /api/invitations
+// ==========================================================================
+
+test.describe("GET /api/invitations", () => {
+  test("returns 401 without auth cookie", async ({ request }) => {
+    const res = await request.get(`/api/invitations?customer_id=${DUMMY_UUID}`);
+    expect(res.status()).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  test("returns 401 with invalid auth cookie", async ({ context }) => {
+    await context.addCookies([
+      {
+        name: "at",
+        value: "invalid-jwt-token",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+
+    const res = await context.request.get(
+      `/api/invitations?customer_id=${DUMMY_UUID}`,
+    );
+    expect(res.status()).toBe(401);
+  });
+
+  test("returns 405 for PUT method", async ({ request }) => {
+    const res = await request.put("/api/invitations", {
+      headers: { origin: ORIGIN },
+      data: {},
+    });
+    expect(res.status()).toBe(405);
+  });
+});
+
+// ==========================================================================
+// DELETE /api/invitations/:id
+// ==========================================================================
+
+test.describe("DELETE /api/invitations/:id", () => {
+  test("returns 401 without auth cookie", async ({ request }) => {
+    const res = await request.delete(`/api/invitations/${DUMMY_UUID}`);
+    expect(res.status()).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  test("returns 401 with invalid auth cookie", async ({ context }) => {
+    await context.addCookies([
+      {
+        name: "at",
+        value: "invalid-jwt-token",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+
+    const res = await context.request.delete(`/api/invitations/${DUMMY_UUID}`, {
+      headers: { origin: ORIGIN },
+    });
+    expect(res.status()).toBe(401);
+  });
 
   test("returns 405 for GET method", async ({ request }) => {
-    const res = await request.get("/api/invitations");
-    // Next.js returns 405 for unimplemented methods on route handlers
+    const res = await request.get(`/api/invitations/${DUMMY_UUID}`);
     expect(res.status()).toBe(405);
   });
 });

--- a/migrations/auth/0013_invitation_revoked_status.sql
+++ b/migrations/auth/0013_invitation_revoked_status.sql
@@ -1,0 +1,8 @@
+-- Add 'revoked' as a valid invitation status for soft-delete revocation (#83).
+-- The check constraint is replaced (not altered) because PostgreSQL does not
+-- support ADD VALUE on plain CHECK constraints.
+
+ALTER TABLE invitations
+  DROP CONSTRAINT invitations_status_check,
+  ADD CONSTRAINT invitations_status_check
+    CHECK (status IN ('pending', 'accepted', 'expired', 'revoked'));

--- a/src/app/api/invitations/[id]/route.ts
+++ b/src/app/api/invitations/[id]/route.ts
@@ -1,0 +1,57 @@
+import type { NextRequest } from "next/server";
+import { auditLog } from "@/lib/auth/audit-stub";
+import { HttpError } from "@/lib/auth/errors";
+import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
+import { revokeInvitation } from "@/lib/auth/invitation-management";
+import { getAuthPool, withTransaction } from "@/lib/db/client";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const DELETE = withAuth(async (req: NextRequest, auth) => {
+  const originErr = verifyOrigin(req);
+  if (originErr) return originErr;
+
+  const csrfErr = verifyCsrf(req, {
+    ctx: "general",
+    sid: auth.sessionId,
+    iat: auth.iat,
+  });
+  if (csrfErr) return csrfErr;
+
+  // Extract the invitation ID from the URL pathname
+  const segments = req.nextUrl.pathname.split("/");
+  const id = segments[segments.length - 1];
+  if (!id || !UUID_RE.test(id)) {
+    return Response.json(
+      { error: "Invalid invitation ID format" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    await withTransaction(getAuthPool(), (client) =>
+      revokeInvitation(client, {
+        accountId: auth.accountId,
+        invitationId: id,
+      }),
+    );
+
+    await auditLog({
+      actorId: auth.accountId,
+      authContext: "general",
+      action: "invitation.revoke",
+      targetType: "invitation",
+      targetId: id,
+      ipAddress: auth.meta.ipAddress,
+      sid: auth.sessionId,
+    });
+
+    return new Response(null, { status: 204 });
+  } catch (err: unknown) {
+    if (err instanceof HttpError) {
+      return Response.json({ error: err.message }, { status: err.statusCode });
+    }
+    throw err;
+  }
+});

--- a/src/app/api/invitations/__tests__/invitations-route.unit.test.ts
+++ b/src/app/api/invitations/__tests__/invitations-route.unit.test.ts
@@ -1,0 +1,174 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PendingInvitation } from "@/lib/auth/invitation-management";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const listPendingInvitationsMock = vi.fn<() => Promise<PendingInvitation[]>>();
+const revokeInvitationMock = vi.fn<() => Promise<void>>();
+
+vi.mock("@/lib/auth/invitation-management", () => ({
+  listPendingInvitations: () => listPendingInvitationsMock(),
+  revokeInvitation: () => revokeInvitationMock(),
+}));
+
+vi.mock("@/lib/auth/invitations", () => ({
+  createInvitation: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/audit-stub", () => ({
+  auditLog: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/email/invitation", () => ({
+  sendInvitationEmail: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  getAuthPool: vi.fn(() => ({})),
+  // biome-ignore lint/complexity/noBannedTypes: test mock needs generic callable
+  withTransaction: vi.fn(async (_pool: unknown, fn: Function) => fn({})),
+}));
+
+// Mock withAuth to bypass authentication and inject test auth context
+vi.mock("@/lib/auth/guards", () => ({
+  withAuth: vi.fn(
+    (handler: (...args: unknown[]) => Promise<Response>) =>
+      (req: NextRequest) =>
+        handler(req, {
+          accountId: "account-001",
+          sessionId: "session-001",
+          authContext: "general",
+          tokenVersion: 1,
+          iat: 1000,
+          meta: { ipAddress: "127.0.0.1" },
+        }),
+  ),
+  verifyOrigin: vi.fn(() => null),
+  verifyCsrf: vi.fn(() => null),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests — GET /api/invitations
+// ---------------------------------------------------------------------------
+
+describe("GET /api/invitations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function callGET(url: string) {
+    const { GET } = await import("../route");
+    return GET(new NextRequest(url));
+  }
+
+  it("returns 400 when customer_id is missing", async () => {
+    const res = await callGET("http://localhost:3000/api/invitations");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("customer_id");
+  });
+
+  it("returns 400 when customer_id is not a valid UUID", async () => {
+    const res = await callGET(
+      "http://localhost:3000/api/invitations?customer_id=not-a-uuid",
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns invitations on success", async () => {
+    const mockInvitations: PendingInvitation[] = [
+      {
+        id: "inv-001",
+        email: "user@example.com",
+        role: "User",
+        createdAt: "2025-01-01T00:00:00.000Z",
+        expiresAt: "2025-01-08T00:00:00.000Z",
+      },
+    ];
+    listPendingInvitationsMock.mockResolvedValue(mockInvitations);
+
+    const res = await callGET(
+      "http://localhost:3000/api/invitations?customer_id=00000000-0000-0000-0000-000000000001",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.invitations).toHaveLength(1);
+    expect(body.invitations[0].email).toBe("user@example.com");
+  });
+
+  it("forwards HttpError as JSON response", async () => {
+    const { HttpError } = await import("@/lib/auth/errors");
+    listPendingInvitationsMock.mockRejectedValue(
+      new HttpError("Forbidden", 403),
+    );
+
+    const res = await callGET(
+      "http://localhost:3000/api/invitations?customer_id=00000000-0000-0000-0000-000000000001",
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Forbidden");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — DELETE /api/invitations/:id
+// ---------------------------------------------------------------------------
+
+describe("DELETE /api/invitations/:id", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function callDELETE(url: string) {
+    const { DELETE } = await import("../[id]/route");
+    return DELETE(new NextRequest(url, { method: "DELETE" }));
+  }
+
+  it("returns 400 when id is not a valid UUID", async () => {
+    const res = await callDELETE(
+      "http://localhost:3000/api/invitations/not-a-uuid",
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid invitation ID");
+  });
+
+  it("returns 204 on successful revocation", async () => {
+    revokeInvitationMock.mockResolvedValue(undefined);
+
+    const res = await callDELETE(
+      "http://localhost:3000/api/invitations/00000000-0000-0000-0000-000000000001",
+    );
+    expect(res.status).toBe(204);
+  });
+
+  it("forwards HttpError 404 as JSON response", async () => {
+    const { HttpError } = await import("@/lib/auth/errors");
+    revokeInvitationMock.mockRejectedValue(
+      new HttpError("Invitation not found", 404),
+    );
+
+    const res = await callDELETE(
+      "http://localhost:3000/api/invitations/00000000-0000-0000-0000-000000000001",
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Invitation not found");
+  });
+
+  it("forwards HttpError 403 as JSON response", async () => {
+    const { HttpError } = await import("@/lib/auth/errors");
+    revokeInvitationMock.mockRejectedValue(new HttpError("Forbidden", 403));
+
+    const res = await callDELETE(
+      "http://localhost:3000/api/invitations/00000000-0000-0000-0000-000000000001",
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Forbidden");
+  });
+});

--- a/src/app/api/invitations/route.ts
+++ b/src/app/api/invitations/route.ts
@@ -2,9 +2,47 @@ import type { NextRequest } from "next/server";
 import { auditLog } from "@/lib/auth/audit-stub";
 import { HttpError } from "@/lib/auth/errors";
 import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
+import { listPendingInvitations } from "@/lib/auth/invitation-management";
 import { createInvitation } from "@/lib/auth/invitations";
 import { getAuthPool, withTransaction } from "@/lib/db/client";
 import { sendInvitationEmail } from "@/lib/email/invitation";
+
+// ---------------------------------------------------------------------------
+// GET /api/invitations?customer_id=...
+// ---------------------------------------------------------------------------
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const GET = withAuth(async (req: NextRequest, auth) => {
+  const customerId = req.nextUrl.searchParams.get("customer_id");
+  if (!customerId || !UUID_RE.test(customerId)) {
+    return Response.json(
+      { error: "customer_id query parameter is required (UUID)" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const invitations = await withTransaction(getAuthPool(), (client) =>
+      listPendingInvitations(client, {
+        accountId: auth.accountId,
+        customerId,
+      }),
+    );
+
+    return Response.json({ invitations });
+  } catch (err: unknown) {
+    if (err instanceof HttpError) {
+      return Response.json({ error: err.message }, { status: err.statusCode });
+    }
+    throw err;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/invitations
+// ---------------------------------------------------------------------------
 
 export const POST = withAuth(async (req: NextRequest, auth) => {
   const originErr = verifyOrigin(req);
@@ -44,8 +82,6 @@ export const POST = withAuth(async (req: NextRequest, auth) => {
     );
   }
 
-  const UUID_RE =
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   if (!UUID_RE.test(customerId)) {
     return Response.json(
       { error: "Invalid customerId format" },

--- a/src/lib/auth/__tests__/invitation-management.db.test.ts
+++ b/src/lib/auth/__tests__/invitation-management.db.test.ts
@@ -489,6 +489,14 @@ describe.skipIf(!hasPostgres)("invitation management (DB integration)", () => {
       [inv.id],
     );
     expect(row.rows[0].status).toBe("revoked");
+
+    // Clean up: remove otherManager's membership in this customer so
+    // subsequent cross-tenant tests are not polluted.
+    await pool.query(
+      `DELETE FROM account_customer_memberships
+       WHERE account_id = $1 AND customer_id = $2`,
+      [otherManagerAccountId, customerId],
+    );
   });
 
   it("returns 404 when User role revokes (no permission leak)", async () => {

--- a/src/lib/auth/__tests__/invitation-management.db.test.ts
+++ b/src/lib/auth/__tests__/invitation-management.db.test.ts
@@ -419,7 +419,7 @@ describe.skipIf(!hasPostgres)("invitation management (DB integration)", () => {
     }
   });
 
-  it("allows revoking a pending invitation whose expiry has passed", async () => {
+  it("returns 404 when revoking an expired pending invitation", async () => {
     const inv = await seedInvitation("expired-revoke@example.com");
 
     await pool.query(
@@ -427,22 +427,18 @@ describe.skipIf(!hasPostgres)("invitation management (DB integration)", () => {
       [inv.id],
     );
 
-    // Status is still 'pending' but expires_at has passed.
-    // Revoking is valid because the row hasn't been cleaned up yet —
-    // the Manager may want to explicitly revoke before a batch job
-    // transitions it to 'expired'.
-    await txn((client) =>
-      revokeInvitation(client, {
-        accountId: managerAccountId,
-        invitationId: inv.id,
-      }),
-    );
-
-    const row = await pool.query<{ status: string }>(
-      `SELECT status FROM invitations WHERE id = $1`,
-      [inv.id],
-    );
-    expect(row.rows[0].status).toBe("revoked");
+    try {
+      await txn((client) =>
+        revokeInvitation(client, {
+          accountId: managerAccountId,
+          invitationId: inv.id,
+        }),
+      );
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).statusCode).toBe(404);
+    }
   });
 
   it("handles concurrent revocation safely (only one succeeds)", async () => {
@@ -495,7 +491,7 @@ describe.skipIf(!hasPostgres)("invitation management (DB integration)", () => {
     expect(row.rows[0].status).toBe("revoked");
   });
 
-  it("rejects revocation by User role of the same customer (403)", async () => {
+  it("returns 404 when User role revokes (no permission leak)", async () => {
     const inv = await seedInvitation("no-perm-revoke@example.com");
 
     try {
@@ -508,11 +504,11 @@ describe.skipIf(!hasPostgres)("invitation management (DB integration)", () => {
       expect.unreachable("should have thrown");
     } catch (err) {
       expect(err).toBeInstanceOf(HttpError);
-      expect((err as HttpError).statusCode).toBe(403);
+      expect((err as HttpError).statusCode).toBe(404);
     }
   });
 
-  it("rejects revocation by Manager of a different customer (403)", async () => {
+  it("returns 404 when Manager of different customer revokes (no tenant leak)", async () => {
     const inv = await seedInvitation("cross-revoke@example.com");
 
     try {
@@ -525,7 +521,7 @@ describe.skipIf(!hasPostgres)("invitation management (DB integration)", () => {
       expect.unreachable("should have thrown");
     } catch (err) {
       expect(err).toBeInstanceOf(HttpError);
-      expect((err as HttpError).statusCode).toBe(403);
+      expect((err as HttpError).statusCode).toBe(404);
     }
   });
 });

--- a/src/lib/auth/__tests__/invitation-management.db.test.ts
+++ b/src/lib/auth/__tests__/invitation-management.db.test.ts
@@ -1,0 +1,531 @@
+import { join } from "node:path";
+import type { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeAdminPool,
+  createTestDatabase,
+  dropTestDatabase,
+  hasPostgres,
+  runInTransaction,
+} from "../../db/__tests__/db-test-helpers";
+import { runMigrations } from "../../db/migrate";
+import { HttpError } from "../errors";
+import {
+  listPendingInvitations,
+  revokeInvitation,
+} from "../invitation-management";
+import { createInvitation } from "../invitations";
+
+const MIGRATIONS_DIR = join(process.cwd(), "migrations", "auth");
+const LOCK_ID = 1003;
+
+describe.skipIf(!hasPostgres)("invitation management (DB integration)", () => {
+  let pool: Pool;
+  let dbName: string;
+
+  let managerAccountId: string;
+  let userAccountId: string;
+  let customerId: string;
+  let otherCustomerId: string;
+  let otherManagerAccountId: string;
+
+  beforeAll(async () => {
+    const result = await createTestDatabase("inv_mgmt", "auth");
+    pool = result.pool;
+    dbName = result.dbName;
+
+    await pool.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'aimer_auth') THEN
+          CREATE ROLE aimer_auth LOGIN PASSWORD 'changeme';
+        END IF;
+      END $$
+    `);
+
+    await runMigrations(pool, MIGRATIONS_DIR, LOCK_ID);
+
+    // Create test customers
+    const cust = await pool.query<{ id: string }>(
+      `INSERT INTO customers (external_key, name)
+       VALUES ('mgmt-cust', 'Mgmt Customer')
+       RETURNING id`,
+    );
+    customerId = cust.rows[0].id;
+
+    const otherCust = await pool.query<{ id: string }>(
+      `INSERT INTO customers (external_key, name)
+       VALUES ('mgmt-other', 'Other Mgmt Customer')
+       RETURNING id`,
+    );
+    otherCustomerId = otherCust.rows[0].id;
+
+    // Lookup roles
+    const roles = await pool.query<{ id: number; name: string }>(
+      `SELECT id, name FROM roles
+       WHERE auth_context = 'general' AND name IN ('User', 'Manager')`,
+    );
+    let userRoleId: number | undefined;
+    let managerRoleId: number | undefined;
+    for (const r of roles.rows) {
+      if (r.name === "User") userRoleId = r.id;
+      if (r.name === "Manager") managerRoleId = r.id;
+    }
+
+    // Manager account (member of customerId)
+    const mgr = await pool.query<{ id: string }>(
+      `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+       VALUES ('test-issuer', 'mgmt-manager-001', 'mgmt-manager', 'Mgmt Manager', 'mgmt-manager@example.com')
+       RETURNING id`,
+    );
+    managerAccountId = mgr.rows[0].id;
+
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+       VALUES ($1, $2, $3)`,
+      [managerAccountId, customerId, managerRoleId],
+    );
+
+    // User account (member of customerId with User role — no read/write permission)
+    const usr = await pool.query<{ id: string }>(
+      `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+       VALUES ('test-issuer', 'mgmt-user-001', 'mgmt-user', 'Mgmt User', 'mgmt-user@example.com')
+       RETURNING id`,
+    );
+    userAccountId = usr.rows[0].id;
+
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+       VALUES ($1, $2, $3)`,
+      [userAccountId, customerId, userRoleId],
+    );
+
+    // Manager of otherCustomer (for cross-customer isolation tests)
+    const otherMgr = await pool.query<{ id: string }>(
+      `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+       VALUES ('test-issuer', 'mgmt-other-mgr-001', 'other-mgr', 'Other Manager', 'other-mgr@example.com')
+       RETURNING id`,
+    );
+    otherManagerAccountId = otherMgr.rows[0].id;
+
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+       VALUES ($1, $2, $3)`,
+      [otherManagerAccountId, otherCustomerId, managerRoleId],
+    );
+  });
+
+  afterAll(async () => {
+    await dropTestDatabase(dbName, pool, "auth");
+    await closeAdminPool();
+  });
+
+  const txn = <T>(fn: Parameters<typeof runInTransaction<T>>[1]) =>
+    runInTransaction<T>(pool, fn);
+
+  // Helper: create a pending invitation in the primary customer
+  async function seedInvitation(email: string, role = "User") {
+    return txn((client) =>
+      createInvitation(client, {
+        accountId: managerAccountId,
+        customerId,
+        email,
+        roleName: role,
+      }),
+    );
+  }
+
+  // Helper: create a pending invitation in the other customer
+  async function seedOtherInvitation(email: string) {
+    return txn((client) =>
+      createInvitation(client, {
+        accountId: otherManagerAccountId,
+        customerId: otherCustomerId,
+        email,
+        roleName: "User",
+      }),
+    );
+  }
+
+  // =========================================================================
+  // listPendingInvitations
+  // =========================================================================
+
+  it("lists pending invitations for a customer", async () => {
+    await seedInvitation("list-a@example.com");
+    await seedInvitation("list-b@example.com", "Manager");
+
+    const list = await txn((client) =>
+      listPendingInvitations(client, {
+        accountId: managerAccountId,
+        customerId,
+      }),
+    );
+
+    const emails = list.map((i) => i.email);
+    expect(emails).toContain("list-a@example.com");
+    expect(emails).toContain("list-b@example.com");
+
+    // Check shape
+    const item = list.find((i) => i.email === "list-b@example.com");
+    expect(item).toBeDefined();
+    expect(item?.role).toBe("Manager");
+    expect(item?.id).toBeDefined();
+    expect(item?.createdAt).toBeDefined();
+    expect(item?.expiresAt).toBeDefined();
+  });
+
+  it("returns empty array when no pending invitations exist", async () => {
+    // Create a fresh customer with no invitations
+    const fresh = await pool.query<{ id: string }>(
+      `INSERT INTO customers (external_key, name)
+       VALUES ('mgmt-empty', 'Empty Customer')
+       RETURNING id`,
+    );
+    const roles = await pool.query<{ id: number }>(
+      `SELECT id FROM roles WHERE name = 'Manager' AND auth_context = 'general'`,
+    );
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+       VALUES ($1, $2, $3)`,
+      [managerAccountId, fresh.rows[0].id, roles.rows[0].id],
+    );
+
+    const list = await txn((client) =>
+      listPendingInvitations(client, {
+        accountId: managerAccountId,
+        customerId: fresh.rows[0].id,
+      }),
+    );
+
+    expect(list).toEqual([]);
+  });
+
+  it("lists invitations ordered by created_at descending", async () => {
+    const inv1 = await seedInvitation("order-a@example.com");
+
+    // Backdate the first invitation so the second is newer
+    await pool.query(
+      `UPDATE invitations SET created_at = NOW() - INTERVAL '1 hour' WHERE id = $1`,
+      [inv1.id],
+    );
+
+    await seedInvitation("order-b@example.com");
+
+    const list = await txn((client) =>
+      listPendingInvitations(client, {
+        accountId: managerAccountId,
+        customerId,
+      }),
+    );
+
+    const orderA = list.findIndex((i) => i.email === "order-a@example.com");
+    const orderB = list.findIndex((i) => i.email === "order-b@example.com");
+    expect(orderA).toBeGreaterThan(-1);
+    expect(orderB).toBeGreaterThan(-1);
+    // B (newer) should appear before A (older) in DESC order
+    expect(orderB).toBeLessThan(orderA);
+  });
+
+  it("excludes expired invitations from listing", async () => {
+    const inv = await seedInvitation("expired-list@example.com");
+
+    await pool.query(
+      `UPDATE invitations SET expires_at = NOW() - INTERVAL '1 second' WHERE id = $1`,
+      [inv.id],
+    );
+
+    const list = await txn((client) =>
+      listPendingInvitations(client, {
+        accountId: managerAccountId,
+        customerId,
+      }),
+    );
+
+    expect(list.map((i) => i.email)).not.toContain("expired-list@example.com");
+  });
+
+  it("excludes accepted invitations from listing", async () => {
+    const inv = await seedInvitation("accepted-list@example.com");
+
+    await pool.query(
+      `UPDATE invitations SET status = 'accepted' WHERE id = $1`,
+      [inv.id],
+    );
+
+    const list = await txn((client) =>
+      listPendingInvitations(client, {
+        accountId: managerAccountId,
+        customerId,
+      }),
+    );
+
+    expect(list.map((i) => i.email)).not.toContain("accepted-list@example.com");
+  });
+
+  it("excludes revoked invitations from listing", async () => {
+    const inv = await seedInvitation("revoked-list@example.com");
+
+    await pool.query(
+      `UPDATE invitations SET status = 'revoked' WHERE id = $1`,
+      [inv.id],
+    );
+
+    const list = await txn((client) =>
+      listPendingInvitations(client, {
+        accountId: managerAccountId,
+        customerId,
+      }),
+    );
+
+    expect(list.map((i) => i.email)).not.toContain("revoked-list@example.com");
+  });
+
+  it("does not include invitations from other customers", async () => {
+    await seedOtherInvitation("cross-cust-isolation@example.com");
+
+    const list = await txn((client) =>
+      listPendingInvitations(client, {
+        accountId: managerAccountId,
+        customerId,
+      }),
+    );
+
+    expect(list.map((i) => i.email)).not.toContain(
+      "cross-cust-isolation@example.com",
+    );
+  });
+
+  it("rejects listing by User role of the same customer (403)", async () => {
+    await expect(
+      txn((client) =>
+        listPendingInvitations(client, {
+          accountId: userAccountId,
+          customerId,
+        }),
+      ),
+    ).rejects.toThrow("Forbidden");
+  });
+
+  it("rejects listing without any membership (403)", async () => {
+    await expect(
+      txn((client) =>
+        listPendingInvitations(client, {
+          accountId: userAccountId,
+          customerId: otherCustomerId,
+        }),
+      ),
+    ).rejects.toThrow("Forbidden");
+  });
+
+  // =========================================================================
+  // revokeInvitation
+  // =========================================================================
+
+  it("revokes a pending invitation", async () => {
+    const inv = await seedInvitation("revoke-me@example.com");
+
+    await txn((client) =>
+      revokeInvitation(client, {
+        accountId: managerAccountId,
+        invitationId: inv.id,
+      }),
+    );
+
+    const row = await pool.query<{ status: string }>(
+      `SELECT status FROM invitations WHERE id = $1`,
+      [inv.id],
+    );
+    expect(row.rows[0].status).toBe("revoked");
+  });
+
+  it("revoked invitation no longer appears in listing", async () => {
+    const inv = await seedInvitation("revoke-list@example.com");
+
+    await txn((client) =>
+      revokeInvitation(client, {
+        accountId: managerAccountId,
+        invitationId: inv.id,
+      }),
+    );
+
+    const list = await txn((client) =>
+      listPendingInvitations(client, {
+        accountId: managerAccountId,
+        customerId,
+      }),
+    );
+
+    expect(list.map((i) => i.email)).not.toContain("revoke-list@example.com");
+  });
+
+  it("returns 404 when revoking non-existent invitation", async () => {
+    try {
+      await txn((client) =>
+        revokeInvitation(client, {
+          accountId: managerAccountId,
+          invitationId: "00000000-0000-0000-0000-000000000000",
+        }),
+      );
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).statusCode).toBe(404);
+    }
+  });
+
+  it("returns 404 when revoking already accepted invitation", async () => {
+    const inv = await seedInvitation("already-accepted@example.com");
+
+    await pool.query(
+      `UPDATE invitations SET status = 'accepted' WHERE id = $1`,
+      [inv.id],
+    );
+
+    try {
+      await txn((client) =>
+        revokeInvitation(client, {
+          accountId: managerAccountId,
+          invitationId: inv.id,
+        }),
+      );
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).statusCode).toBe(404);
+    }
+  });
+
+  it("returns 404 when revoking already revoked invitation", async () => {
+    const inv = await seedInvitation("already-revoked@example.com");
+
+    await txn((client) =>
+      revokeInvitation(client, {
+        accountId: managerAccountId,
+        invitationId: inv.id,
+      }),
+    );
+
+    try {
+      await txn((client) =>
+        revokeInvitation(client, {
+          accountId: managerAccountId,
+          invitationId: inv.id,
+        }),
+      );
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).statusCode).toBe(404);
+    }
+  });
+
+  it("allows revoking a pending invitation whose expiry has passed", async () => {
+    const inv = await seedInvitation("expired-revoke@example.com");
+
+    await pool.query(
+      `UPDATE invitations SET expires_at = NOW() - INTERVAL '1 second' WHERE id = $1`,
+      [inv.id],
+    );
+
+    // Status is still 'pending' but expires_at has passed.
+    // Revoking is valid because the row hasn't been cleaned up yet —
+    // the Manager may want to explicitly revoke before a batch job
+    // transitions it to 'expired'.
+    await txn((client) =>
+      revokeInvitation(client, {
+        accountId: managerAccountId,
+        invitationId: inv.id,
+      }),
+    );
+
+    const row = await pool.query<{ status: string }>(
+      `SELECT status FROM invitations WHERE id = $1`,
+      [inv.id],
+    );
+    expect(row.rows[0].status).toBe("revoked");
+  });
+
+  it("handles concurrent revocation safely (only one succeeds)", async () => {
+    const inv = await seedInvitation("concurrent-revoke@example.com");
+
+    // Give otherManager write permission on this customer too
+    const roles = await pool.query<{ id: number }>(
+      `SELECT id FROM roles WHERE name = 'Manager' AND auth_context = 'general'`,
+    );
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (account_id, customer_id) DO NOTHING`,
+      [otherManagerAccountId, customerId, roles.rows[0].id],
+    );
+
+    const results = await Promise.allSettled([
+      txn((client) =>
+        revokeInvitation(client, {
+          accountId: managerAccountId,
+          invitationId: inv.id,
+        }),
+      ),
+      txn((client) =>
+        revokeInvitation(client, {
+          accountId: otherManagerAccountId,
+          invitationId: inv.id,
+        }),
+      ),
+    ]);
+
+    // One succeeds, the other gets 404 (status is no longer 'pending')
+    const statuses = results.map((r) =>
+      r.status === "fulfilled" ? "ok" : "rejected",
+    );
+    expect(statuses).toContain("ok");
+    expect(statuses).toContain("rejected");
+
+    const rejected = results.find((r) => r.status === "rejected") as
+      | PromiseRejectedResult
+      | undefined;
+    expect(rejected?.reason).toBeInstanceOf(HttpError);
+    expect((rejected?.reason as HttpError).statusCode).toBe(404);
+
+    // Verify row is revoked
+    const row = await pool.query<{ status: string }>(
+      `SELECT status FROM invitations WHERE id = $1`,
+      [inv.id],
+    );
+    expect(row.rows[0].status).toBe("revoked");
+  });
+
+  it("rejects revocation by User role of the same customer (403)", async () => {
+    const inv = await seedInvitation("no-perm-revoke@example.com");
+
+    try {
+      await txn((client) =>
+        revokeInvitation(client, {
+          accountId: userAccountId,
+          invitationId: inv.id,
+        }),
+      );
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).statusCode).toBe(403);
+    }
+  });
+
+  it("rejects revocation by Manager of a different customer (403)", async () => {
+    const inv = await seedInvitation("cross-revoke@example.com");
+
+    try {
+      await txn((client) =>
+        revokeInvitation(client, {
+          accountId: otherManagerAccountId,
+          invitationId: inv.id,
+        }),
+      );
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).statusCode).toBe(403);
+    }
+  });
+});

--- a/src/lib/auth/__tests__/invitations.db.test.ts
+++ b/src/lib/auth/__tests__/invitations.db.test.ts
@@ -1,11 +1,12 @@
 import { join } from "node:path";
-import type { Pool, PoolClient } from "pg";
+import type { Pool } from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   closeAdminPool,
   createTestDatabase,
   dropTestDatabase,
   hasPostgres,
+  runInTransaction,
 } from "../../db/__tests__/db-test-helpers";
 import { runMigrations } from "../../db/migrate";
 import { HttpError } from "../errors";
@@ -102,30 +103,16 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
     await closeAdminPool();
   });
 
-  // Helper: run createInvitation in a transaction
-  async function runInTransaction<T>(
-    fn: (client: PoolClient) => Promise<T>,
-  ): Promise<T> {
-    const client = await pool.connect();
-    try {
-      await client.query("BEGIN");
-      const result = await fn(client);
-      await client.query("COMMIT");
-      return result;
-    } catch (err) {
-      await client.query("ROLLBACK");
-      throw err;
-    } finally {
-      client.release();
-    }
-  }
+  // Helper: run a function in a transaction using the shared helper
+  const txn = <T>(fn: Parameters<typeof runInTransaction<T>>[1]) =>
+    runInTransaction<T>(pool, fn);
 
   // =========================================================================
   // Happy path
   // =========================================================================
 
   it("creates an invitation with a valid token and expiry", async () => {
-    const result = await runInTransaction((client) =>
+    const result = await txn((client) =>
       createInvitation(client, {
         accountId: managerAccountId,
         customerId,
@@ -152,7 +139,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
   });
 
   it("stores SHA-256 hash, not the raw token", async () => {
-    const result = await runInTransaction((client) =>
+    const result = await txn((client) =>
       createInvitation(client, {
         accountId: managerAccountId,
         customerId,
@@ -174,7 +161,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
 
   it("sets expiry approximately 7 days from now", async () => {
     const before = Date.now();
-    const result = await runInTransaction((client) =>
+    const result = await txn((client) =>
       createInvitation(client, {
         accountId: managerAccountId,
         customerId,
@@ -196,7 +183,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
   });
 
   it("generates unique tokens for different invitations", async () => {
-    const result1 = await runInTransaction((client) =>
+    const result1 = await txn((client) =>
       createInvitation(client, {
         accountId: managerAccountId,
         customerId,
@@ -204,7 +191,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
         roleName: "User",
       }),
     );
-    const result2 = await runInTransaction((client) =>
+    const result2 = await txn((client) =>
       createInvitation(client, {
         accountId: managerAccountId,
         customerId,
@@ -218,7 +205,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
   });
 
   it("allows inviting with Manager role", async () => {
-    const result = await runInTransaction((client) =>
+    const result = await txn((client) =>
       createInvitation(client, {
         accountId: managerAccountId,
         customerId,
@@ -235,7 +222,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
   });
 
   it("records the inviting account as invited_by", async () => {
-    const result = await runInTransaction((client) =>
+    const result = await txn((client) =>
       createInvitation(client, {
         accountId: managerAccountId,
         customerId,
@@ -257,7 +244,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
 
   it("rejects invitation when email already has membership (409)", async () => {
     try {
-      await runInTransaction((client) =>
+      await txn((client) =>
         createInvitation(client, {
           accountId: managerAccountId,
           customerId,
@@ -275,7 +262,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
 
   it("rejects existing member with different-case email (409)", async () => {
     await expect(
-      runInTransaction((client) =>
+      txn((client) =>
         createInvitation(client, {
           accountId: managerAccountId,
           customerId,
@@ -291,7 +278,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
   // =========================================================================
 
   it("refreshes duplicate pending invitation with new token and expiry", async () => {
-    const first = await runInTransaction((client) =>
+    const first = await txn((client) =>
       createInvitation(client, {
         accountId: managerAccountId,
         customerId,
@@ -300,7 +287,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
       }),
     );
 
-    const second = await runInTransaction((client) =>
+    const second = await txn((client) =>
       createInvitation(client, {
         accountId: managerAccountId,
         customerId,
@@ -331,7 +318,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
   });
 
   it("refreshes duplicate pending invitation with different-case email", async () => {
-    const first = await runInTransaction((client) =>
+    const first = await txn((client) =>
       createInvitation(client, {
         accountId: managerAccountId,
         customerId,
@@ -341,7 +328,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
     );
 
     // Same email, different case → should refresh, not insert new row
-    const second = await runInTransaction((client) =>
+    const second = await txn((client) =>
       createInvitation(client, {
         accountId: managerAccountId,
         customerId,
@@ -355,7 +342,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
   });
 
   it("refresh updates role when re-invited with different role", async () => {
-    const first = await runInTransaction((client) =>
+    const first = await txn((client) =>
       createInvitation(client, {
         accountId: managerAccountId,
         customerId,
@@ -364,7 +351,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
       }),
     );
 
-    const second = await runInTransaction((client) =>
+    const second = await txn((client) =>
       createInvitation(client, {
         accountId: managerAccountId,
         customerId,
@@ -388,7 +375,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
 
   it("rejects non-Manager accounts (403)", async () => {
     try {
-      await runInTransaction((client) =>
+      await txn((client) =>
         createInvitation(client, {
           accountId: userAccountId,
           customerId,
@@ -411,7 +398,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
     );
 
     await expect(
-      runInTransaction((client) =>
+      txn((client) =>
         createInvitation(client, {
           accountId: acct.rows[0].id,
           customerId,
@@ -425,7 +412,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
   it("rejects Manager of a different customer (403)", async () => {
     // managerAccountId is Manager of customerId, NOT otherCustomerId
     await expect(
-      runInTransaction((client) =>
+      txn((client) =>
         createInvitation(client, {
           accountId: managerAccountId,
           customerId: otherCustomerId,
@@ -442,7 +429,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
 
   it("rejects admin-context role (400)", async () => {
     try {
-      await runInTransaction((client) =>
+      await txn((client) =>
         createInvitation(client, {
           accountId: managerAccountId,
           customerId,
@@ -464,7 +451,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
 
   it("rejects unknown role name (400)", async () => {
     try {
-      await runInTransaction((client) =>
+      await txn((client) =>
         createInvitation(client, {
           accountId: managerAccountId,
           customerId,
@@ -482,7 +469,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
 
   it("rejects Analyst role (400) — separate flow per Discussion #5", async () => {
     try {
-      await runInTransaction((client) =>
+      await txn((client) =>
         createInvitation(client, {
           accountId: managerAccountId,
           customerId,
@@ -500,7 +487,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
 
   it("rejects non-existent customerId (404)", async () => {
     try {
-      await runInTransaction((client) =>
+      await txn((client) =>
         createInvitation(client, {
           accountId: managerAccountId,
           customerId: "00000000-0000-0000-0000-000000000000",
@@ -522,7 +509,7 @@ describe.skipIf(!hasPostgres)("invitation creation (DB integration)", () => {
 
   // Helper: create a pending invitation and return raw token + invitation id
   async function createPendingInvitation(email: string) {
-    return runInTransaction((client) =>
+    return txn((client) =>
       createInvitation(client, {
         accountId: managerAccountId,
         customerId,

--- a/src/lib/auth/invitation-management.ts
+++ b/src/lib/auth/invitation-management.ts
@@ -67,14 +67,17 @@ export async function revokeInvitation(
   client: PoolClient,
   params: { accountId: string; invitationId: string },
 ): Promise<void> {
-  // Look up the invitation and lock the row
+  // Look up the invitation and lock the row.
+  // The WHERE clause enforces pending + not-expired so that expired
+  // invitations are treated as 404 per the issue spec.
   const result = await client.query<{
     id: string;
     customer_id: string;
-    status: string;
   }>(
-    `SELECT id, customer_id, status FROM invitations
+    `SELECT id, customer_id FROM invitations
      WHERE id = $1
+       AND status = 'pending'
+       AND expires_at > NOW()
      FOR UPDATE`,
     [params.invitationId],
   );
@@ -85,11 +88,17 @@ export async function revokeInvitation(
 
   const inv = result.rows[0];
 
-  if (inv.status !== "pending") {
-    throw new HttpError("Invitation not found", 404);
+  // Return 404 (not 403) when the caller lacks permission so that
+  // cross-tenant callers cannot distinguish "exists but forbidden"
+  // from "does not exist".
+  try {
+    await assertManagerPermission(client, params.accountId, inv.customer_id);
+  } catch (err) {
+    if (err instanceof HttpError && err.statusCode === 403) {
+      throw new HttpError("Invitation not found", 404);
+    }
+    throw err;
   }
-
-  await assertManagerPermission(client, params.accountId, inv.customer_id);
 
   await client.query(
     `UPDATE invitations SET status = 'revoked' WHERE id = $1`,

--- a/src/lib/auth/invitation-management.ts
+++ b/src/lib/auth/invitation-management.ts
@@ -1,0 +1,98 @@
+import type { PoolClient } from "pg";
+import { HttpError } from "./errors";
+import {
+  assertCustomerPermission,
+  assertManagerPermission,
+} from "./permissions";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PendingInvitation {
+  id: string;
+  email: string;
+  role: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// List pending invitations
+// ---------------------------------------------------------------------------
+
+export async function listPendingInvitations(
+  client: PoolClient,
+  params: { accountId: string; customerId: string },
+): Promise<PendingInvitation[]> {
+  await assertCustomerPermission(
+    client,
+    params.accountId,
+    params.customerId,
+    "customer-members:read",
+  );
+
+  const result = await client.query<{
+    id: string;
+    invited_email: string;
+    role_name: string;
+    created_at: Date;
+    expires_at: Date;
+  }>(
+    `SELECT i.id, i.invited_email, r.name AS role_name,
+            i.created_at, i.expires_at
+     FROM invitations i
+     JOIN roles r ON r.id = i.role_id
+     WHERE i.customer_id = $1
+       AND i.status = 'pending'
+       AND i.expires_at > NOW()
+     ORDER BY i.created_at DESC`,
+    [params.customerId],
+  );
+
+  return result.rows.map((row) => ({
+    id: row.id,
+    email: row.invited_email,
+    role: row.role_name,
+    createdAt: row.created_at.toISOString(),
+    expiresAt: row.expires_at.toISOString(),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Revoke invitation
+// ---------------------------------------------------------------------------
+
+export async function revokeInvitation(
+  client: PoolClient,
+  params: { accountId: string; invitationId: string },
+): Promise<void> {
+  // Look up the invitation and lock the row
+  const result = await client.query<{
+    id: string;
+    customer_id: string;
+    status: string;
+  }>(
+    `SELECT id, customer_id, status FROM invitations
+     WHERE id = $1
+     FOR UPDATE`,
+    [params.invitationId],
+  );
+
+  if (result.rows.length === 0) {
+    throw new HttpError("Invitation not found", 404);
+  }
+
+  const inv = result.rows[0];
+
+  if (inv.status !== "pending") {
+    throw new HttpError("Invitation not found", 404);
+  }
+
+  await assertManagerPermission(client, params.accountId, inv.customer_id);
+
+  await client.query(
+    `UPDATE invitations SET status = 'revoked' WHERE id = $1`,
+    [params.invitationId],
+  );
+}

--- a/src/lib/db/__tests__/db-test-helpers.ts
+++ b/src/lib/db/__tests__/db-test-helpers.ts
@@ -1,4 +1,4 @@
-import { Pool } from "pg";
+import { Pool, type PoolClient } from "pg";
 
 // Prefer the superuser admin URL for CREATE/DROP DATABASE operations.
 // Fall back to DATABASE_URL for CI environments where only the
@@ -110,4 +110,26 @@ export function createRolePool(
   parsed.password = password;
   parsed.pathname = `/${dbName}`;
   return new Pool({ connectionString: parsed.toString() });
+}
+
+/**
+ * Run a function inside a transaction. Commits on success, rolls back on
+ * error. Useful for DB integration tests that need transactional isolation.
+ */
+export async function runInTransaction<T>(
+  pool: Pool,
+  fn: (client: PoolClient) => Promise<T>,
+): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await fn(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
 }

--- a/src/lib/db/__tests__/schema.db.test.ts
+++ b/src/lib/db/__tests__/schema.db.test.ts
@@ -31,11 +31,11 @@ describe.skipIf(!hasPostgres)("Schema verification (auth_db)", () => {
     await dropTestDatabase(dbName, pool);
   });
 
-  it("applies all 15 auth migrations cleanly", async () => {
+  it("applies all 16 auth migrations cleanly", async () => {
     const { rows } = await pool.query(
       "SELECT version FROM _migrations ORDER BY version",
     );
-    expect(rows).toHaveLength(15);
+    expect(rows).toHaveLength(16);
   });
 
   // -- Built-in roles --


### PR DESCRIPTION
## Summary

- Add `GET /api/invitations?customer_id=...` to list pending invitations for a customer organization
- Add `DELETE /api/invitations/:id` to revoke a pending invitation via soft delete (`status = 'revoked'`)
- Migration adds `'revoked'` to the `invitations.status` check constraint
- Permission checks via `assertCustomerPermission` (`customer-members:read` for listing, `customer-members:write` for revocation)
- `FOR UPDATE` row locking prevents concurrent double-revocation
- Expired invitations return 404 on revoke (not silently accepted)
- Permission failures return 404 (not 403) to prevent cross-tenant invitation existence leakage

## Test plan

- [x] 8 route-level unit tests (input validation, success, HttpError forwarding for GET and DELETE)
- [x] 20 DB integration tests covering: happy paths, ordering, expired/accepted/revoked exclusion, cross-customer isolation, permission leak prevention, concurrent revocation serialization
- [x] E2E tests for GET/DELETE auth enforcement and method rejection
- [x] `pnpm biome check` passes
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm vitest run` passes

Closes #83