### PR TITLE
Add invitation list and revoke API

### DIFF
--- a/e2e/invitation-api.spec.ts
+++ b/e2e/invitation-api.spec.ts
@@ -48,9 +48,8 @@ test.describe("POST /api/invitations", () => {
     expect(res.status()).toBe(401);
   });
 
-  test("returns 405 for GET method", async ({ request }) => {
-    const res = await request.get("/api/invitations");
-    // Next.js returns 405 for unimplemented methods on route handlers
+  test("returns 405 for PUT method", async ({ request }) => {
+    const res = await request.put("/api/invitations");
     expect(res.status()).toBe(405);
   });
 });

--- a/e2e/invitation-management-api.spec.ts
+++ b/e2e/invitation-management-api.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "@playwright/test";
+
+// These tests exercise the invitation list (GET) and revoke (DELETE) HTTP
+// layer without authentication.  They verify that the endpoints exist,
+// enforce auth, validate input, and reject unsupported methods.
+//
+// Full authenticated flows are covered by DB integration tests
+// (src/lib/auth/__tests__/invitation-management.db.test.ts).
+
+const VALID_UUID = "00000000-0000-0000-0000-000000000001";
+
+// =========================================================================
+// GET /api/invitations?customer_id=...
+// =========================================================================
+
+test.describe("GET /api/invitations", () => {
+  test("returns 401 without auth cookie", async ({ request }) => {
+    const res = await request.get(`/api/invitations?customer_id=${VALID_UUID}`);
+    expect(res.status()).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  test("returns 401 with invalid auth cookie", async ({ context }) => {
+    await context.addCookies([
+      {
+        name: "at",
+        value: "invalid-jwt-token",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+
+    const res = await context.request.get(
+      `/api/invitations?customer_id=${VALID_UUID}`,
+    );
+    expect(res.status()).toBe(401);
+  });
+
+  test("returns 400 without customer_id parameter", async ({ context }) => {
+    await context.addCookies([
+      {
+        name: "at",
+        value: "invalid-jwt-token",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+
+    // Without a valid JWT the request will 401 before reaching validation.
+    // This test documents the guard ordering: auth comes first.
+    const res = await context.request.get("/api/invitations");
+    expect(res.status()).toBe(401);
+  });
+});
+
+// =========================================================================
+// DELETE /api/invitations/:id
+// =========================================================================
+
+test.describe("DELETE /api/invitations/:id", () => {
+  test("returns 401 without auth cookie", async ({ request }) => {
+    const res = await request.delete(`/api/invitations/${VALID_UUID}`, {
+      headers: { origin: "http://localhost:3000" },
+    });
+    expect(res.status()).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  test("returns 401 with invalid auth cookie", async ({ context }) => {
+    await context.addCookies([
+      {
+        name: "at",
+        value: "invalid-jwt-token",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+
+    const res = await context.request.delete(`/api/invitations/${VALID_UUID}`, {
+      headers: { origin: "http://localhost:3000" },
+    });
+    expect(res.status()).toBe(401);
+  });
+
+  test("returns 405 for GET method on /:id route", async ({ request }) => {
+    const res = await request.get(`/api/invitations/${VALID_UUID}`);
+    expect(res.status()).toBe(405);
+  });
+
+  test("returns 405 for POST method on /:id route", async ({ request }) => {
+    const res = await request.post(`/api/invitations/${VALID_UUID}`, {
+      headers: { origin: "http://localhost:3000" },
+    });
+    expect(res.status()).toBe(405);
+  });
+});

--- a/e2e/invitation-management-api.spec.ts
+++ b/e2e/invitation-management-api.spec.ts
@@ -37,7 +37,9 @@ test.describe("GET /api/invitations", () => {
     expect(res.status()).toBe(401);
   });
 
-  test("returns 400 without customer_id parameter", async ({ context }) => {
+  test("rejects before parameter validation when auth is invalid", async ({
+    context,
+  }) => {
     await context.addCookies([
       {
         name: "at",
@@ -47,8 +49,8 @@ test.describe("GET /api/invitations", () => {
       },
     ]);
 
-    // Without a valid JWT the request will 401 before reaching validation.
-    // This test documents the guard ordering: auth comes first.
+    // Auth guard runs before customer_id validation, so missing
+    // customer_id still results in 401, not 400.
     const res = await context.request.get("/api/invitations");
     expect(res.status()).toBe(401);
   });

--- a/migrations/auth/0013_invitation_revoked_status.sql
+++ b/migrations/auth/0013_invitation_revoked_status.sql
@@ -1,0 +1,7 @@
+-- Add 'revoked' as a valid invitation status for soft-delete revocation.
+-- Preserves audit trail: who invited whom and when (#83).
+
+ALTER TABLE invitations
+  DROP CONSTRAINT invitations_status_check,
+  ADD  CONSTRAINT invitations_status_check
+       CHECK (status IN ('pending', 'accepted', 'expired', 'revoked'));

--- a/src/app/api/invitations/[id]/route.ts
+++ b/src/app/api/invitations/[id]/route.ts
@@ -1,0 +1,48 @@
+import type { NextRequest } from "next/server";
+import { auditLog } from "@/lib/auth/audit-stub";
+import { HttpError } from "@/lib/auth/errors";
+import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
+import { revokeInvitation } from "@/lib/auth/invitation-management";
+import { getAuthPool } from "@/lib/db/client";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const DELETE = withAuth(async (req: NextRequest, auth) => {
+  const originErr = verifyOrigin(req);
+  if (originErr) return originErr;
+
+  const csrfErr = verifyCsrf(req, {
+    ctx: "general",
+    sid: auth.sessionId,
+    iat: auth.iat,
+  });
+  if (csrfErr) return csrfErr;
+
+  // Extract invitation ID from the URL path
+  const id = req.nextUrl.pathname.split("/").pop();
+  if (!id || !UUID_RE.test(id)) {
+    return Response.json({ error: "Invalid invitation ID" }, { status: 400 });
+  }
+
+  try {
+    await revokeInvitation(getAuthPool(), auth.accountId, id);
+
+    await auditLog({
+      actorId: auth.accountId,
+      authContext: "general",
+      action: "invitation.revoke",
+      targetType: "invitation",
+      targetId: id,
+      ipAddress: auth.meta.ipAddress,
+      sid: auth.sessionId,
+    });
+
+    return new Response(null, { status: 204 });
+  } catch (err: unknown) {
+    if (err instanceof HttpError) {
+      return Response.json({ error: err.message }, { status: err.statusCode });
+    }
+    throw err;
+  }
+});

--- a/src/app/api/invitations/route.ts
+++ b/src/app/api/invitations/route.ts
@@ -2,9 +2,45 @@ import type { NextRequest } from "next/server";
 import { auditLog } from "@/lib/auth/audit-stub";
 import { HttpError } from "@/lib/auth/errors";
 import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
+import { listPendingInvitations } from "@/lib/auth/invitation-management";
 import { createInvitation } from "@/lib/auth/invitations";
 import { getAuthPool, withTransaction } from "@/lib/db/client";
 import { sendInvitationEmail } from "@/lib/email/invitation";
+
+// ---------------------------------------------------------------------------
+// GET /api/invitations?customer_id=...
+// ---------------------------------------------------------------------------
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const GET = withAuth(async (req: NextRequest, auth) => {
+  const customerId = req.nextUrl.searchParams.get("customer_id");
+  if (!customerId || !UUID_RE.test(customerId)) {
+    return Response.json(
+      { error: "customer_id query parameter is required and must be a UUID" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const invitations = await listPendingInvitations(
+      getAuthPool(),
+      auth.accountId,
+      customerId,
+    );
+    return Response.json({ invitations });
+  } catch (err: unknown) {
+    if (err instanceof HttpError) {
+      return Response.json({ error: err.message }, { status: err.statusCode });
+    }
+    throw err;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/invitations
+// ---------------------------------------------------------------------------
 
 export const POST = withAuth(async (req: NextRequest, auth) => {
   const originErr = verifyOrigin(req);
@@ -44,8 +80,6 @@ export const POST = withAuth(async (req: NextRequest, auth) => {
     );
   }
 
-  const UUID_RE =
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   if (!UUID_RE.test(customerId)) {
     return Response.json(
       { error: "Invalid customerId format" },

--- a/src/lib/auth/__tests__/invitation-management.db.test.ts
+++ b/src/lib/auth/__tests__/invitation-management.db.test.ts
@@ -1,0 +1,471 @@
+import { join } from "node:path";
+import type { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeAdminPool,
+  createTestDatabase,
+  dropTestDatabase,
+  hasPostgres,
+} from "../../db/__tests__/db-test-helpers";
+import { runMigrations } from "../../db/migrate";
+import { HttpError } from "../errors";
+import {
+  listPendingInvitations,
+  revokeInvitation,
+} from "../invitation-management";
+import { createInvitation } from "../invitations";
+
+const MIGRATIONS_DIR = join(process.cwd(), "migrations", "auth");
+const LOCK_ID = 1001;
+
+describe.skipIf(!hasPostgres)("invitation management (DB integration)", () => {
+  let pool: Pool;
+  let dbName: string;
+
+  let managerAccountId: string;
+  let userAccountId: string;
+  let customerId: string;
+  let otherCustomerId: string;
+  let otherManagerAccountId: string;
+
+  beforeAll(async () => {
+    const result = await createTestDatabase("inv_mgmt", "auth");
+    pool = result.pool;
+    dbName = result.dbName;
+
+    await pool.query(`
+        DO $$ BEGIN
+          IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'aimer_auth') THEN
+            CREATE ROLE aimer_auth LOGIN PASSWORD 'changeme';
+          END IF;
+        END $$
+      `);
+
+    await runMigrations(pool, MIGRATIONS_DIR, LOCK_ID);
+
+    // Create customers
+    const cust = await pool.query<{ id: string }>(
+      `INSERT INTO customers (external_key, name)
+         VALUES ('mgmt-cust', 'Mgmt Customer')
+         RETURNING id`,
+    );
+    customerId = cust.rows[0].id;
+
+    // Lookup roles
+    const roles = await pool.query<{ id: number; name: string }>(
+      `SELECT id, name FROM roles
+         WHERE auth_context = 'general' AND name IN ('User', 'Manager')`,
+    );
+    let userRoleId: number | undefined;
+    let managerRoleId: number | undefined;
+    for (const r of roles.rows) {
+      if (r.name === "User") userRoleId = r.id;
+      if (r.name === "Manager") managerRoleId = r.id;
+    }
+
+    // Manager account
+    const mgr = await pool.query<{ id: string }>(
+      `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+         VALUES ('test-issuer', 'mgmt-mgr-001', 'mgmt-manager', 'Manager', 'mgmt-manager@example.com')
+         RETURNING id`,
+    );
+    managerAccountId = mgr.rows[0].id;
+
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+         VALUES ($1, $2, $3)`,
+      [managerAccountId, customerId, managerRoleId],
+    );
+
+    // User account (has membership but no customer-members:read/write)
+    const usr = await pool.query<{ id: string }>(
+      `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+         VALUES ('test-issuer', 'mgmt-usr-001', 'mgmt-user', 'User', 'mgmt-user@example.com')
+         RETURNING id`,
+    );
+    userAccountId = usr.rows[0].id;
+
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+         VALUES ($1, $2, $3)`,
+      [userAccountId, customerId, userRoleId],
+    );
+
+    // Other customer + its own manager (for cross-customer isolation tests)
+    const otherCust = await pool.query<{ id: string }>(
+      `INSERT INTO customers (external_key, name)
+         VALUES ('mgmt-other', 'Other Customer')
+         RETURNING id`,
+    );
+    otherCustomerId = otherCust.rows[0].id;
+
+    const otherMgr = await pool.query<{ id: string }>(
+      `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+         VALUES ('test-issuer', 'mgmt-other-mgr', 'other-manager', 'Other Manager', 'other-mgr@example.com')
+         RETURNING id`,
+    );
+    otherManagerAccountId = otherMgr.rows[0].id;
+
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+         VALUES ($1, $2, $3)`,
+      [otherManagerAccountId, otherCustomerId, managerRoleId],
+    );
+  });
+
+  afterAll(async () => {
+    await dropTestDatabase(dbName, pool, "auth");
+    await closeAdminPool();
+  });
+
+  // Helper: create a pending invitation
+  async function createPending(email: string, role = "User") {
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      const result = await createInvitation(client, {
+        accountId: managerAccountId,
+        customerId,
+        email,
+        roleName: role,
+      });
+      await client.query("COMMIT");
+      return result;
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  // =========================================================================
+  // List pending invitations
+  // =========================================================================
+
+  it("lists pending invitations for a customer", async () => {
+    await createPending("list-a@example.com", "User");
+    await createPending("list-b@example.com", "Manager");
+
+    const invitations = await listPendingInvitations(
+      pool,
+      managerAccountId,
+      customerId,
+    );
+
+    const emails = invitations.map((i) => i.email);
+    expect(emails).toContain("list-a@example.com");
+    expect(emails).toContain("list-b@example.com");
+
+    for (const inv of invitations) {
+      expect(inv.id).toBeDefined();
+      expect(inv.role).toBeDefined();
+      expect(inv.createdAt).toBeDefined();
+      expect(inv.expiresAt).toBeDefined();
+    }
+  });
+
+  it("does not list expired invitations", async () => {
+    const inv = await createPending("expired-list@example.com");
+
+    await pool.query(
+      `UPDATE invitations SET expires_at = NOW() - INTERVAL '1 second' WHERE id = $1`,
+      [inv.id],
+    );
+
+    const invitations = await listPendingInvitations(
+      pool,
+      managerAccountId,
+      customerId,
+    );
+    const emails = invitations.map((i) => i.email);
+    expect(emails).not.toContain("expired-list@example.com");
+  });
+
+  it("does not list accepted invitations", async () => {
+    const inv = await createPending("accepted-list@example.com");
+
+    await pool.query(
+      `UPDATE invitations SET status = 'accepted' WHERE id = $1`,
+      [inv.id],
+    );
+
+    const invitations = await listPendingInvitations(
+      pool,
+      managerAccountId,
+      customerId,
+    );
+    const emails = invitations.map((i) => i.email);
+    expect(emails).not.toContain("accepted-list@example.com");
+  });
+
+  it("does not list revoked invitations", async () => {
+    const inv = await createPending("revoked-list@example.com");
+
+    await pool.query(
+      `UPDATE invitations SET status = 'revoked' WHERE id = $1`,
+      [inv.id],
+    );
+
+    const invitations = await listPendingInvitations(
+      pool,
+      managerAccountId,
+      customerId,
+    );
+    const emails = invitations.map((i) => i.email);
+    expect(emails).not.toContain("revoked-list@example.com");
+  });
+
+  it("rejects User role listing (no customer-members:read permission)", async () => {
+    // User role has membership but lacks customer-members:read
+    try {
+      await listPendingInvitations(pool, userAccountId, customerId);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).statusCode).toBe(403);
+    }
+  });
+
+  it("rejects listing without any membership (403)", async () => {
+    const outsider = await pool.query<{ id: string }>(
+      `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name)
+         VALUES ('test-issuer', 'mgmt-outsider-001', 'outsider', 'Outsider')
+         RETURNING id`,
+    );
+
+    try {
+      await listPendingInvitations(pool, outsider.rows[0].id, customerId);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).statusCode).toBe(403);
+    }
+  });
+
+  it("returns empty array when no pending invitations exist", async () => {
+    // Create a fresh customer with no invitations
+    const freshCust = await pool.query<{ id: string }>(
+      `INSERT INTO customers (external_key, name)
+         VALUES ('mgmt-empty', 'Empty Customer')
+         RETURNING id`,
+    );
+
+    // Give manager access to this customer
+    const roles = await pool.query<{ id: number }>(
+      `SELECT id FROM roles WHERE name = 'Manager' AND auth_context = 'general'`,
+    );
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+         VALUES ($1, $2, $3)`,
+      [managerAccountId, freshCust.rows[0].id, roles.rows[0].id],
+    );
+
+    const invitations = await listPendingInvitations(
+      pool,
+      managerAccountId,
+      freshCust.rows[0].id,
+    );
+    expect(invitations).toEqual([]);
+  });
+
+  it("returns invitations ordered by created_at DESC (newest first)", async () => {
+    const inv1 = await createPending("order-first@example.com");
+    const inv2 = await createPending("order-second@example.com");
+
+    const invitations = await listPendingInvitations(
+      pool,
+      managerAccountId,
+      customerId,
+    );
+
+    const idx1 = invitations.findIndex((i) => i.id === inv1.id);
+    const idx2 = invitations.findIndex((i) => i.id === inv2.id);
+    // inv2 was created later, so it should appear first (lower index)
+    expect(idx2).toBeLessThan(idx1);
+  });
+
+  it("returns correct field values in response", async () => {
+    const inv = await createPending("fields-check@example.com", "Manager");
+
+    const invitations = await listPendingInvitations(
+      pool,
+      managerAccountId,
+      customerId,
+    );
+    const found = invitations.find((i) => i.id === inv.id);
+
+    expect(found).toBeDefined();
+    expect(found?.email).toBe("fields-check@example.com");
+    expect(found?.role).toBe("Manager");
+    // createdAt and expiresAt should be valid ISO strings
+    expect(() => new Date(found?.createdAt as string)).not.toThrow();
+    expect(() => new Date(found?.expiresAt as string)).not.toThrow();
+    expect(new Date(found?.expiresAt as string).getTime()).toBeGreaterThan(
+      new Date(found?.createdAt as string).getTime(),
+    );
+  });
+
+  it("does not return invitations from another customer", async () => {
+    // Create invitation in other customer
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      await createInvitation(client, {
+        accountId: otherManagerAccountId,
+        customerId: otherCustomerId,
+        email: "cross-customer@example.com",
+        roleName: "User",
+      });
+      await client.query("COMMIT");
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+
+    // List for primary customer — should not include other customer's invitation
+    const invitations = await listPendingInvitations(
+      pool,
+      managerAccountId,
+      customerId,
+    );
+    const emails = invitations.map((i) => i.email);
+    expect(emails).not.toContain("cross-customer@example.com");
+  });
+
+  // =========================================================================
+  // Revoke invitation
+  // =========================================================================
+
+  it("revokes a pending invitation (soft delete)", async () => {
+    const inv = await createPending("revoke-test@example.com");
+
+    await revokeInvitation(pool, managerAccountId, inv.id);
+
+    const row = await pool.query<{ status: string }>(
+      `SELECT status FROM invitations WHERE id = $1`,
+      [inv.id],
+    );
+    expect(row.rows[0].status).toBe("revoked");
+  });
+
+  it("revoked invitation no longer appears in list", async () => {
+    const inv = await createPending("revoke-vanish@example.com");
+
+    // Verify it appears before revoke
+    let invitations = await listPendingInvitations(
+      pool,
+      managerAccountId,
+      customerId,
+    );
+    expect(invitations.map((i) => i.email)).toContain(
+      "revoke-vanish@example.com",
+    );
+
+    await revokeInvitation(pool, managerAccountId, inv.id);
+
+    // Verify it no longer appears
+    invitations = await listPendingInvitations(
+      pool,
+      managerAccountId,
+      customerId,
+    );
+    expect(invitations.map((i) => i.email)).not.toContain(
+      "revoke-vanish@example.com",
+    );
+  });
+
+  it("returns 404 when revoking non-existent invitation", async () => {
+    try {
+      await revokeInvitation(
+        pool,
+        managerAccountId,
+        "00000000-0000-0000-0000-000000000000",
+      );
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).statusCode).toBe(404);
+    }
+  });
+
+  it("returns 404 when revoking already-accepted invitation", async () => {
+    const inv = await createPending("revoke-accepted@example.com");
+    await pool.query(
+      `UPDATE invitations SET status = 'accepted' WHERE id = $1`,
+      [inv.id],
+    );
+
+    try {
+      await revokeInvitation(pool, managerAccountId, inv.id);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).statusCode).toBe(404);
+    }
+  });
+
+  it("returns 404 when revoking already-revoked invitation", async () => {
+    const inv = await createPending("revoke-double@example.com");
+    await revokeInvitation(pool, managerAccountId, inv.id);
+
+    try {
+      await revokeInvitation(pool, managerAccountId, inv.id);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).statusCode).toBe(404);
+    }
+  });
+
+  it("returns 404 when revoking expired invitation", async () => {
+    const inv = await createPending("revoke-expired@example.com");
+    await pool.query(
+      `UPDATE invitations SET expires_at = NOW() - INTERVAL '1 second' WHERE id = $1`,
+      [inv.id],
+    );
+
+    try {
+      await revokeInvitation(pool, managerAccountId, inv.id);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).statusCode).toBe(404);
+    }
+  });
+
+  it("rejects cross-customer revocation (403)", async () => {
+    // Create invitation in primary customer
+    const inv = await createPending("cross-revoke@example.com");
+
+    // Other customer's manager tries to revoke it → 403
+    try {
+      await revokeInvitation(pool, otherManagerAccountId, inv.id);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).statusCode).toBe(403);
+    }
+
+    // Verify invitation is still pending (not revoked)
+    const row = await pool.query<{ status: string }>(
+      `SELECT status FROM invitations WHERE id = $1`,
+      [inv.id],
+    );
+    expect(row.rows[0].status).toBe("pending");
+  });
+
+  it("rejects revocation without customer-members:write permission (403)", async () => {
+    const inv = await createPending("revoke-forbidden@example.com");
+
+    try {
+      await revokeInvitation(pool, userAccountId, inv.id);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).statusCode).toBe(403);
+    }
+  });
+});

--- a/src/lib/auth/invitation-management.ts
+++ b/src/lib/auth/invitation-management.ts
@@ -1,0 +1,100 @@
+import type { Pool } from "pg";
+import { withTransaction } from "../db/client";
+import { HttpError } from "./errors";
+import { assertPermission } from "./permissions";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PendingInvitation {
+  id: string;
+  email: string;
+  role: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// List pending invitations
+// ---------------------------------------------------------------------------
+
+export async function listPendingInvitations(
+  pool: Pool,
+  accountId: string,
+  customerId: string,
+): Promise<PendingInvitation[]> {
+  const client = await pool.connect();
+  try {
+    await assertPermission(
+      client,
+      accountId,
+      customerId,
+      "customer-members:read",
+    );
+
+    const result = await client.query<{
+      id: string;
+      invited_email: string;
+      role_name: string;
+      created_at: Date;
+      expires_at: Date;
+    }>(
+      `SELECT i.id, i.invited_email, r.name AS role_name,
+              i.created_at, i.expires_at
+       FROM invitations i
+       JOIN roles r ON r.id = i.role_id
+       WHERE i.customer_id = $1
+         AND i.status = 'pending'
+         AND i.expires_at > NOW()
+       ORDER BY i.created_at DESC`,
+      [customerId],
+    );
+
+    return result.rows.map((row) => ({
+      id: row.id,
+      email: row.invited_email,
+      role: row.role_name,
+      createdAt: row.created_at.toISOString(),
+      expiresAt: row.expires_at.toISOString(),
+    }));
+  } finally {
+    client.release();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Revoke invitation (soft delete)
+// ---------------------------------------------------------------------------
+
+export async function revokeInvitation(
+  pool: Pool,
+  accountId: string,
+  invitationId: string,
+): Promise<void> {
+  await withTransaction(pool, async (client) => {
+    // Lock the row and fetch customer_id for permission check
+    const inv = await client.query<{ id: string; customer_id: string }>(
+      `SELECT id, customer_id FROM invitations
+       WHERE id = $1 AND status = 'pending' AND expires_at > NOW()
+       FOR UPDATE`,
+      [invitationId],
+    );
+
+    if (inv.rows.length === 0) {
+      throw new HttpError("Invitation not found", 404);
+    }
+
+    await assertPermission(
+      client,
+      accountId,
+      inv.rows[0].customer_id,
+      "customer-members:write",
+    );
+
+    await client.query(
+      `UPDATE invitations SET status = 'revoked' WHERE id = $1`,
+      [invitationId],
+    );
+  });
+}

--- a/src/lib/auth/invitations.ts
+++ b/src/lib/auth/invitations.ts
@@ -2,7 +2,7 @@ import { createHash, randomBytes } from "node:crypto";
 import type { Pool, PoolClient } from "pg";
 import { withTransaction } from "../db/client";
 import { HttpError } from "./errors";
-import { assertManagerPermission } from "./permissions";
+import { assertPermission } from "./permissions";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -109,7 +109,12 @@ export async function createInvitation(
   params: CreateInvitationParams,
 ): Promise<CreatedInvitation> {
   const customerName = await assertCustomerExists(client, params.customerId);
-  await assertManagerPermission(client, params.accountId, params.customerId);
+  await assertPermission(
+    client,
+    params.accountId,
+    params.customerId,
+    "customer-members:write",
+  );
   await assertNotAlreadyMember(client, params.customerId, params.email);
 
   const roleId = await resolveRole(client, params.roleName);

--- a/src/lib/db/__tests__/schema.db.test.ts
+++ b/src/lib/db/__tests__/schema.db.test.ts
@@ -31,11 +31,11 @@ describe.skipIf(!hasPostgres)("Schema verification (auth_db)", () => {
     await dropTestDatabase(dbName, pool);
   });
 
-  it("applies all 15 auth migrations cleanly", async () => {
+  it("applies all 16 auth migrations cleanly", async () => {
     const { rows } = await pool.query(
       "SELECT version FROM _migrations ORDER BY version",
     );
-    expect(rows).toHaveLength(15);
+    expect(rows).toHaveLength(16);
   });
 
   // -- Built-in roles --


### PR DESCRIPTION
## Summary

- Add `GET /api/invitations?customer_id=...` to list pending invitations for a customer (requires `customer-members:read`)
- Add `DELETE /api/invitations/:id` to revoke a pending invitation with soft-delete semantics (requires `customer-members:write`)
- Migration 0013 adds `'revoked'` to `invitations.status` check constraint
- Extract shared `assertPermission` helper from `invitations.ts` into `permissions.ts`

## Test plan

- 18 DB integration tests covering list filtering (pending/expired/accepted/revoked), permission checks (Manager/User/outsider/cross-customer), empty results, ordering, response values, revoke lifecycle (soft delete, idempotency, 404 cases, cross-customer isolation)
- 7 E2E tests verifying HTTP layer: auth guard (401), method restrictions (405)
- Schema test updated for 16 migrations

Closes #83