### PR TITLE
Add Playwright auth fixture and UI E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,9 @@ jobs:
         env:
           CI: "true"
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/auth_db
+          DATABASE_MIGRATION_URL: postgres://postgres:postgres@localhost:5432/auth_db
           AUDIT_DATABASE_URL: postgres://postgres:postgres@localhost:5432/audit_db
+          CSRF_SECRET: e2e-test-csrf-secret
       - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:

--- a/e2e/auth-smoke.spec.ts
+++ b/e2e/auth-smoke.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "./fixtures";
+
+// ---------------------------------------------------------------------------
+// Authenticated smoke tests — verify that authenticated pages load
+// correctly and that API-backed pages enforce auth.
+//
+// NOTE: In non-production without KEYCLOAK_URL / KEYCLOAK_REALM the
+// middleware skips auth entirely, so page-level redirects cannot be
+// tested here. Instead we focus on API-backed pages where the server
+// action / API route performs its own JWT + session verification.
+//
+// Admin pages are excluded because admin auth requires MFA ACR
+// verification and Keycloak realm roles that cannot be replicated by
+// simple JWT injection.
+// ---------------------------------------------------------------------------
+
+test.describe("Authenticated smoke — API-backed pages", () => {
+  test("members page loads for authenticated Manager", async ({
+    managerPage,
+  }) => {
+    await managerPage.goto("/en/settings/members");
+
+    await expect(
+      managerPage.getByRole("heading", { name: "Members", level: 1 }),
+    ).toBeVisible();
+    // Should see the member table (API returned 200)
+    await expect(managerPage.locator("table").first()).toBeVisible();
+  });
+
+  test("members page shows error for authenticated User (403)", async ({
+    userPage,
+  }) => {
+    await userPage.goto("/en/settings/members");
+
+    // The API returns 403 for User role → UI shows error
+    await expect(
+      userPage.getByText("An error occurred. Please try again."),
+    ).toBeVisible();
+    await expect(userPage.locator("table")).toBeHidden();
+  });
+});

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,0 +1,126 @@
+import { createHmac } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+import type { BrowserContext } from "@playwright/test";
+
+// jose is ESM-only — use dynamic import() to avoid CJS/ESM conflicts
+// when Playwright transpiles test files.
+async function loadJose() {
+  return import("jose");
+}
+
+// ---------------------------------------------------------------------------
+// Key pair (cached, auto-generated if missing)
+// ---------------------------------------------------------------------------
+
+interface KeyPair {
+  privateKey: CryptoKey;
+  kid: string;
+}
+
+let cached: KeyPair | null = null;
+
+function keysDir(): string {
+  const dataDir = process.env.DATA_DIR ?? "./data";
+  // Use process.cwd() instead of import.meta.dirname because Playwright's
+  // esbuild transform outputs CJS — import.meta is not available in CJS and
+  // triggers "exports is not defined" under Node 24's module detection.
+  const resolvedDataDir = isAbsolute(dataDir)
+    ? dataDir
+    : join(process.cwd(), dataDir);
+  return join(resolvedDataDir, "keys");
+}
+
+/**
+ * Load or generate the ES256 key pair used for JWT signing.
+ * Mirrors the auto-generation logic in src/lib/auth/jwt-keys.ts so that
+ * the fixture works even when keys have not been pre-provisioned (e.g. CI).
+ * The dev server will later load the same files.
+ */
+async function getKeyPair(): Promise<KeyPair> {
+  if (cached) return cached;
+
+  const dir = keysDir();
+  const privatePath = join(dir, "ec-private.pem");
+  const publicPath = join(dir, "ec-public.pem");
+
+  const jose = await loadJose();
+
+  if (!existsSync(privatePath) || !existsSync(publicPath)) {
+    mkdirSync(dir, { recursive: true });
+    const kp = await jose.generateKeyPair("ES256", { extractable: true });
+    writeFileSync(privatePath, await jose.exportPKCS8(kp.privateKey), "utf-8");
+    writeFileSync(publicPath, await jose.exportSPKI(kp.publicKey), "utf-8");
+  }
+
+  const privatePem = readFileSync(privatePath, "utf-8");
+  const publicPem = readFileSync(publicPath, "utf-8");
+
+  const privateKey = (await jose.importPKCS8(privatePem, "ES256")) as CryptoKey;
+  const publicKey = (await jose.importSPKI(publicPem, "ES256")) as CryptoKey;
+  const jwk = await jose.exportJWK(publicKey);
+  const kid = await jose.calculateJwkThumbprint(jwk);
+
+  cached = { privateKey, kid };
+  return cached;
+}
+
+// ---------------------------------------------------------------------------
+// CSRF generation (mirrors src/lib/auth/csrf.ts)
+// ---------------------------------------------------------------------------
+
+function generateCsrf(ctx: string, sid: string, iat: number): string {
+  const secret = process.env.CSRF_SECRET;
+  if (!secret) throw new Error("CSRF_SECRET must be set for E2E fixtures");
+  return createHmac("sha256", secret)
+    .update(`${ctx}:${sid}:${iat}`)
+    .digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Cookie injection
+// ---------------------------------------------------------------------------
+
+export type AuthContext = "general" | "admin";
+
+export async function injectAuthCookies(
+  context: BrowserContext,
+  params: { accountId: string; sessionId: string },
+  authContext: AuthContext = "general",
+): Promise<void> {
+  const jose = await loadJose();
+  const { privateKey, kid } = await getKeyPair();
+  const iss = authContext === "general" ? "aimer-web" : "aimer-web-admin";
+  const expMinutes = Number(process.env.JWT_EXPIRATION_MINUTES) || 15;
+  const iat = Math.floor(Date.now() / 1000);
+  const exp = iat + expMinutes * 60;
+
+  const token = await new jose.SignJWT({
+    sid: params.sessionId,
+    ctx: authContext,
+    tv: 0,
+  })
+    .setProtectedHeader({ alg: "ES256", kid })
+    .setSubject(params.accountId)
+    .setIssuer(iss)
+    .setAudience(iss)
+    .setIssuedAt(iat)
+    .setExpirationTime(exp)
+    .sign(privateKey);
+
+  const csrf = generateCsrf(authContext, params.sessionId, iat);
+
+  const names =
+    authContext === "general"
+      ? { at: "at", csrf: "csrf", tokenExp: "token_exp" }
+      : { at: "at_admin", csrf: "csrf_admin", tokenExp: "token_exp_admin" };
+
+  const baseUrl = process.env.BASE_URL ?? "http://localhost:3000";
+  const domain = new URL(baseUrl).hostname;
+
+  await context.addCookies([
+    { name: names.at, value: token, domain, path: "/" },
+    { name: names.csrf, value: csrf, domain, path: "/" },
+    { name: names.tokenExp, value: String(exp), domain, path: "/" },
+  ]);
+}

--- a/e2e/fixtures/db.ts
+++ b/e2e/fixtures/db.ts
@@ -1,0 +1,158 @@
+import { randomUUID } from "node:crypto";
+import { Pool } from "pg";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TestAccount {
+  accountId: string;
+  sessionId: string;
+  displayName: string;
+  email: string;
+}
+
+export interface TestData {
+  customer: { id: string; name: string; externalKey: string };
+  manager: TestAccount;
+  user: TestAccount;
+  roles: { managerId: number; userId: number };
+}
+
+// ---------------------------------------------------------------------------
+// Pool management
+// ---------------------------------------------------------------------------
+
+let pool: Pool | null = null;
+
+function getPool(): Pool {
+  if (!pool) {
+    const url = process.env.DATABASE_MIGRATION_URL ?? process.env.DATABASE_URL;
+    if (!url) {
+      throw new Error(
+        "DATABASE_MIGRATION_URL or DATABASE_URL must be set for E2E fixtures",
+      );
+    }
+    pool = new Pool({ connectionString: url });
+  }
+  return pool;
+}
+
+export async function closePool(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Seed & cleanup
+// ---------------------------------------------------------------------------
+
+export async function seedTestData(): Promise<TestData> {
+  const p = getPool();
+  const suffix = randomUUID().slice(0, 8);
+
+  // Look up built-in role IDs
+  const roles = await p.query<{ id: number; name: string }>(
+    `SELECT id, name FROM roles
+     WHERE name IN ('Manager', 'User') AND auth_context = 'general'`,
+  );
+  const managerRole = roles.rows.find((r) => r.name === "Manager");
+  const userRole = roles.rows.find((r) => r.name === "User");
+  if (!managerRole || !userRole) {
+    throw new Error("Built-in Manager/User roles not found in database");
+  }
+  const managerRoleId = managerRole.id;
+  const userRoleId = userRole.id;
+
+  // Customer
+  const customerId = randomUUID();
+  const customerName = `E2E Customer ${suffix}`;
+  const externalKey = `e2e-${suffix}`;
+  await p.query(
+    `INSERT INTO customers (id, external_key, name, status, database_status)
+     VALUES ($1, $2, $3, 'active', 'active')`,
+    [customerId, externalKey, customerName],
+  );
+
+  // Manager account
+  const mgrAccountId = randomUUID();
+  const mgrDisplayName = `E2E Manager ${suffix}`;
+  const mgrEmail = `mgr-${suffix}@e2e.test`;
+  await p.query(
+    `INSERT INTO accounts
+       (id, oidc_issuer, oidc_subject, username, display_name, email, status)
+     VALUES ($1, 'e2e-issuer', $2, $3, $4, $5, 'active')`,
+    [mgrAccountId, `mgr-${suffix}`, `mgr-${suffix}`, mgrDisplayName, mgrEmail],
+  );
+
+  // User account
+  const usrAccountId = randomUUID();
+  const usrDisplayName = `E2E User ${suffix}`;
+  const usrEmail = `usr-${suffix}@e2e.test`;
+  await p.query(
+    `INSERT INTO accounts
+       (id, oidc_issuer, oidc_subject, username, display_name, email, status)
+     VALUES ($1, 'e2e-issuer', $2, $3, $4, $5, 'active')`,
+    [usrAccountId, `usr-${suffix}`, `usr-${suffix}`, usrDisplayName, usrEmail],
+  );
+
+  // Memberships
+  await p.query(
+    `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+     VALUES ($1, $2, $3), ($4, $2, $5)`,
+    [mgrAccountId, customerId, managerRoleId, usrAccountId, userRoleId],
+  );
+
+  // Sessions
+  const mgrSession = await p.query<{ sid: string }>(
+    `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent)
+     VALUES ($1, 'general', '127.0.0.1', 'Playwright E2E')
+     RETURNING sid`,
+    [mgrAccountId],
+  );
+  const usrSession = await p.query<{ sid: string }>(
+    `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent)
+     VALUES ($1, 'general', '127.0.0.1', 'Playwright E2E')
+     RETURNING sid`,
+    [usrAccountId],
+  );
+
+  return {
+    customer: { id: customerId, name: customerName, externalKey },
+    manager: {
+      accountId: mgrAccountId,
+      sessionId: mgrSession.rows[0].sid,
+      displayName: mgrDisplayName,
+      email: mgrEmail,
+    },
+    user: {
+      accountId: usrAccountId,
+      sessionId: usrSession.rows[0].sid,
+      displayName: usrDisplayName,
+      email: usrEmail,
+    },
+    roles: { managerId: managerRoleId, userId: userRoleId },
+  };
+}
+
+export async function cleanupTestData(data: TestData): Promise<void> {
+  const p = getPool();
+  const accountIds = [data.manager.accountId, data.user.accountId];
+
+  // Delete in reverse dependency order.
+  // Invitations may have been created during tests (e.g. invite dialog test).
+  await p.query(`DELETE FROM invitations WHERE customer_id = $1`, [
+    data.customer.id,
+  ]);
+  await p.query(`DELETE FROM sessions WHERE account_id = ANY($1)`, [
+    accountIds,
+  ]);
+  await p.query(
+    `DELETE FROM account_customer_memberships WHERE customer_id = $1`,
+    [data.customer.id],
+  );
+  await p.query(`DELETE FROM accounts WHERE id = ANY($1)`, [accountIds]);
+  await p.query(`DELETE FROM customers WHERE id = $1`, [data.customer.id]);
+}

--- a/e2e/fixtures/env.ts
+++ b/e2e/fixtures/env.ts
@@ -1,0 +1,26 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Lightweight .env loader for Playwright fixtures.
+ * Does not override existing environment variables.
+ */
+export function loadEnv(): void {
+  // Use process.cwd() instead of import.meta.dirname because Playwright's
+  // esbuild transform outputs CJS — import.meta is not available in CJS.
+  const envPath = join(process.cwd(), ".env");
+  if (!existsSync(envPath)) return;
+
+  const content = readFileSync(envPath, "utf-8");
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx < 0) continue;
+    const key = trimmed.slice(0, eqIdx);
+    const value = trimmed.slice(eqIdx + 1);
+    if (!process.env[key]) {
+      process.env[key] = value;
+    }
+  }
+}

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -1,0 +1,51 @@
+import { test as base, type Page } from "@playwright/test";
+import { injectAuthCookies } from "./auth";
+import { cleanupTestData, closePool, seedTestData, type TestData } from "./db";
+import { loadEnv } from "./env";
+
+// Load .env so fixture code can read DATABASE_URL, CSRF_SECRET, etc.
+loadEnv();
+
+export { expect } from "@playwright/test";
+export type { TestAccount, TestData } from "./db";
+
+// ---------------------------------------------------------------------------
+// Extended test with auth fixtures
+// ---------------------------------------------------------------------------
+
+export const test = base.extend<{
+  /** Seeded test data (customer, accounts, sessions, roles). */
+  testData: TestData;
+  /** Browser page authenticated as a Manager. */
+  managerPage: Page;
+  /** Browser page authenticated as a User. */
+  userPage: Page;
+}>({
+  // biome-ignore lint/correctness/noEmptyPattern: Playwright fixture API requires destructuring
+  testData: async ({}, use) => {
+    const data = await seedTestData();
+    await use(data);
+    await cleanupTestData(data);
+  },
+
+  managerPage: async ({ browser, baseURL, testData }, use) => {
+    const context = await browser.newContext({ baseURL: baseURL ?? undefined });
+    await injectAuthCookies(context, testData.manager, "general");
+    const page = await context.newPage();
+    await use(page);
+    await context.close();
+  },
+
+  userPage: async ({ browser, baseURL, testData }, use) => {
+    const context = await browser.newContext({ baseURL: baseURL ?? undefined });
+    await injectAuthCookies(context, testData.user, "general");
+    const page = await context.newPage();
+    await use(page);
+    await context.close();
+  },
+});
+
+// Close the shared DB pool when the worker exits.
+base.afterAll(async () => {
+  await closePool();
+});

--- a/e2e/members-ui.spec.ts
+++ b/e2e/members-ui.spec.ts
@@ -1,0 +1,482 @@
+import { expect, test } from "./fixtures";
+
+// ---------------------------------------------------------------------------
+// Helper: navigate and wait for data load
+// ---------------------------------------------------------------------------
+
+async function gotoMembers(
+  page: import("@playwright/test").Page,
+  locale: "en" | "ko" = "en",
+) {
+  const path =
+    locale === "en" ? "/en/settings/members" : "/ko/settings/members";
+  await page.goto(path);
+  await expect(page.locator("table").first()).toBeVisible();
+}
+
+// ---------------------------------------------------------------------------
+// Manager view — rendering
+// ---------------------------------------------------------------------------
+
+test.describe("Members page — Manager", () => {
+  test("renders member list with both members", async ({
+    managerPage,
+    testData,
+  }) => {
+    await gotoMembers(managerPage);
+
+    const table = managerPage.locator("table").first();
+    await expect(table.getByText(testData.manager.displayName)).toBeVisible();
+    await expect(table.getByText(testData.user.displayName)).toBeVisible();
+  });
+
+  test("shows Invite Member button", async ({ managerPage }) => {
+    await gotoMembers(managerPage);
+
+    await expect(
+      managerPage.getByRole("button", { name: "Invite Member" }),
+    ).toBeVisible();
+  });
+
+  test("shows pending invitations section with empty state", async ({
+    managerPage,
+  }) => {
+    await gotoMembers(managerPage);
+
+    await expect(
+      managerPage.getByRole("heading", { name: "Pending Invitations" }),
+    ).toBeVisible();
+    await expect(
+      managerPage.getByText("No pending invitations."),
+    ).toBeVisible();
+  });
+
+  test("shows Change Role and Remove buttons for other member", async ({
+    managerPage,
+    testData,
+  }) => {
+    await gotoMembers(managerPage);
+
+    const userRow = managerPage
+      .locator("tr")
+      .filter({ hasText: testData.user.displayName });
+    await expect(
+      userRow.getByRole("button", { name: "Change Role" }),
+    ).toBeVisible();
+    await expect(userRow.getByRole("button", { name: "Remove" })).toBeVisible();
+  });
+
+  test("shows Last Manager badge when only one Manager exists", async ({
+    managerPage,
+  }) => {
+    await gotoMembers(managerPage);
+    await expect(managerPage.getByText("Last Manager")).toBeVisible();
+  });
+
+  test("disables actions for the last Manager", async ({
+    managerPage,
+    testData,
+  }) => {
+    await gotoMembers(managerPage);
+
+    const managerRow = managerPage
+      .locator("tr")
+      .filter({ hasText: testData.manager.displayName });
+    await expect(
+      managerRow.getByRole("button", { name: "Change Role" }),
+    ).toBeDisabled();
+    await expect(
+      managerRow.getByRole("button", { name: "Remove" }),
+    ).toBeDisabled();
+  });
+
+  test("marks the current user with (you) label", async ({
+    managerPage,
+    testData,
+  }) => {
+    await gotoMembers(managerPage);
+
+    const managerRow = managerPage
+      .locator("tr")
+      .filter({ hasText: testData.manager.displayName });
+    await expect(managerRow.getByText("(you)")).toBeVisible();
+
+    // Other member should not have the (you) label
+    const userRow = managerPage
+      .locator("tr")
+      .filter({ hasText: testData.user.displayName });
+    await expect(userRow.getByText("(you)")).toBeHidden();
+  });
+
+  test("displays role labels for each member", async ({
+    managerPage,
+    testData,
+  }) => {
+    await gotoMembers(managerPage);
+
+    const managerRow = managerPage
+      .locator("tr")
+      .filter({ hasText: testData.manager.displayName });
+    // Use nth(2) to target the role column (3rd td), avoiding the
+    // displayName cell which also contains "Manager" in the name.
+    await expect(managerRow.locator("td").nth(2)).toContainText("Manager");
+
+    const userRow = managerPage
+      .locator("tr")
+      .filter({ hasText: testData.user.displayName });
+    await expect(userRow.locator("td").nth(2)).toContainText("User");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dialog interactions
+// ---------------------------------------------------------------------------
+
+test.describe("Members page — invite dialog", () => {
+  test("opens invite dialog and validates empty email", async ({
+    managerPage,
+  }) => {
+    await gotoMembers(managerPage);
+
+    await managerPage.getByRole("button", { name: "Invite Member" }).click();
+
+    // Dialog should be open
+    await expect(
+      managerPage.getByRole("heading", { name: "Invite Member" }),
+    ).toBeVisible();
+    await expect(
+      managerPage.getByText("Send an invitation email to add a new member."),
+    ).toBeVisible();
+
+    // Submit without entering email
+    await managerPage.getByRole("button", { name: "Send Invitation" }).click();
+
+    // Validation error
+    await expect(managerPage.getByText("This field is required")).toBeVisible();
+  });
+
+  test("validates invalid email format in invite dialog", async ({
+    managerPage,
+  }) => {
+    await gotoMembers(managerPage);
+
+    await managerPage.getByRole("button", { name: "Invite Member" }).click();
+
+    // "user@host" passes HTML5 type="email" validation but fails the
+    // app's stricter regex which requires a dot in the domain part.
+    await managerPage.getByLabel("Email address").fill("user@host");
+    await managerPage.getByRole("button", { name: "Send Invitation" }).click();
+
+    await expect(
+      managerPage.getByText("Please enter a valid email address"),
+    ).toBeVisible();
+  });
+
+  test("closes invite dialog with Cancel button", async ({ managerPage }) => {
+    await gotoMembers(managerPage);
+
+    await managerPage.getByRole("button", { name: "Invite Member" }).click();
+    await expect(
+      managerPage.getByRole("heading", { name: "Invite Member" }),
+    ).toBeVisible();
+
+    await managerPage.getByRole("button", { name: "Cancel" }).click();
+
+    // Dialog should be closed
+    await expect(
+      managerPage.getByRole("heading", { name: "Invite Member" }),
+    ).toBeHidden();
+  });
+
+  test("sends invitation and shows success toast", async ({ managerPage }) => {
+    await gotoMembers(managerPage);
+
+    await managerPage.getByRole("button", { name: "Invite Member" }).click();
+
+    const email = `invite-${Date.now()}@e2e.test`;
+    await managerPage.getByLabel("Email address").fill(email);
+    // Role defaults to User
+    await managerPage.getByRole("button", { name: "Send Invitation" }).click();
+
+    // Success toast
+    await expect(
+      managerPage.getByText(`Invitation sent to ${email}.`),
+    ).toBeVisible();
+
+    // Dialog should close
+    await expect(
+      managerPage.getByRole("heading", { name: "Invite Member" }),
+    ).toBeHidden();
+
+    // Pending invitations section should now list the invitation
+    await expect(
+      managerPage.locator("table").nth(1).getByText(email),
+    ).toBeVisible();
+  });
+});
+
+test.describe("Members page — remove dialog", () => {
+  test("opens remove confirmation dialog and cancels", async ({
+    managerPage,
+    testData,
+  }) => {
+    await gotoMembers(managerPage);
+
+    const userRow = managerPage
+      .locator("tr")
+      .filter({ hasText: testData.user.displayName });
+    await userRow.getByRole("button", { name: "Remove" }).click();
+
+    // Confirmation dialog
+    await expect(
+      managerPage.getByRole("heading", { name: "Remove Member" }),
+    ).toBeVisible();
+    await expect(
+      managerPage.getByText(
+        `Are you sure you want to remove ${testData.user.displayName}`,
+      ),
+    ).toBeVisible();
+
+    // Cancel — member should still exist
+    await managerPage.getByRole("button", { name: "Cancel" }).click();
+    await expect(
+      managerPage.getByRole("heading", { name: "Remove Member" }),
+    ).toBeHidden();
+    await expect(
+      managerPage.getByText(testData.user.displayName),
+    ).toBeVisible();
+  });
+});
+
+test.describe("Members page — change role dialog", () => {
+  test("opens change role confirmation dialog and cancels", async ({
+    managerPage,
+    testData,
+  }) => {
+    await gotoMembers(managerPage);
+
+    const userRow = managerPage
+      .locator("tr")
+      .filter({ hasText: testData.user.displayName });
+    await userRow.getByRole("button", { name: "Change Role" }).click();
+
+    // Confirmation dialog
+    await expect(
+      managerPage.getByRole("heading", { name: "Change Role" }),
+    ).toBeVisible();
+    await expect(
+      managerPage.getByText(
+        `Change the role of ${testData.user.displayName} to Manager?`,
+      ),
+    ).toBeVisible();
+
+    // Cancel
+    await managerPage.getByRole("button", { name: "Cancel" }).click();
+    await expect(
+      managerPage.getByRole("heading", { name: "Change Role" }),
+    ).toBeHidden();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mutation — role change
+// ---------------------------------------------------------------------------
+
+test.describe("Members page — role change", () => {
+  test("confirms role change and updates the member list", async ({
+    managerPage,
+    testData,
+  }) => {
+    await gotoMembers(managerPage);
+
+    const userRow = managerPage
+      .locator("tr")
+      .filter({ hasText: testData.user.displayName });
+    await userRow.getByRole("button", { name: "Change Role" }).click();
+
+    // Confirm dialog
+    await expect(
+      managerPage.getByText(
+        `Change the role of ${testData.user.displayName} to Manager?`,
+      ),
+    ).toBeVisible();
+
+    // Click Change Role button inside dialog (not the table button)
+    await managerPage
+      .getByRole("dialog")
+      .getByRole("button", { name: "Change Role" })
+      .click();
+
+    // Success toast
+    await expect(
+      managerPage.getByText("Action completed successfully."),
+    ).toBeVisible();
+
+    // After refresh, the User should now have the Manager role
+    const updatedRow = managerPage
+      .locator("tr")
+      .filter({ hasText: testData.user.displayName });
+    await expect(updatedRow.getByText("Manager")).toBeVisible();
+
+    // Last Manager badge should disappear since there are now two Managers
+    await expect(managerPage.getByText("Last Manager")).toBeHidden();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mutation — member removal
+// ---------------------------------------------------------------------------
+
+test.describe("Members page — member removal", () => {
+  test("confirms member removal and updates the member list", async ({
+    managerPage,
+    testData,
+  }) => {
+    await gotoMembers(managerPage);
+
+    // Ensure the User member is present
+    await expect(
+      managerPage.getByText(testData.user.displayName),
+    ).toBeVisible();
+
+    const userRow = managerPage
+      .locator("tr")
+      .filter({ hasText: testData.user.displayName });
+    await userRow.getByRole("button", { name: "Remove" }).click();
+
+    // Confirm dialog
+    await expect(
+      managerPage.getByText(
+        `Are you sure you want to remove ${testData.user.displayName}`,
+      ),
+    ).toBeVisible();
+
+    // Click Remove button inside dialog
+    await managerPage
+      .getByRole("dialog")
+      .getByRole("button", { name: "Remove" })
+      .click();
+
+    // Success toast
+    await expect(
+      managerPage.getByText("Action completed successfully."),
+    ).toBeVisible();
+
+    // The removed member should no longer appear
+    await expect(managerPage.getByText(testData.user.displayName)).toBeHidden();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mutation — invitation lifecycle (invite → revoke)
+// ---------------------------------------------------------------------------
+
+test.describe("Members page — invitation lifecycle", () => {
+  test("sends invitation then revokes it", async ({ managerPage }) => {
+    await gotoMembers(managerPage);
+
+    // Send invitation
+    await managerPage.getByRole("button", { name: "Invite Member" }).click();
+    const email = `lifecycle-${Date.now()}@e2e.test`;
+    await managerPage.getByLabel("Email address").fill(email);
+    await managerPage.getByRole("button", { name: "Send Invitation" }).click();
+
+    // Wait for invitation to appear in the pending list (use second table
+    // to avoid matching the success toast which also contains the email)
+    await expect(
+      managerPage.locator("table").nth(1).getByText(email),
+    ).toBeVisible();
+
+    // Revoke the invitation
+    const invRow = managerPage.locator("tr").filter({ hasText: email });
+    await invRow.getByRole("button", { name: "Revoke" }).click();
+
+    // Confirm revoke dialog
+    await expect(
+      managerPage.getByText(
+        `Are you sure you want to revoke the invitation for ${email}?`,
+      ),
+    ).toBeVisible();
+    await managerPage
+      .getByRole("dialog")
+      .getByRole("button", { name: "Revoke" })
+      .click();
+
+    // Success toast
+    await expect(
+      managerPage.getByText(`Invitation for ${email} has been revoked.`),
+    ).toBeVisible();
+
+    // After revocation, the pending invitations table should be gone
+    // (empty state renders a <p> instead of a <table>).
+    await expect(
+      managerPage.getByText("No pending invitations."),
+    ).toBeVisible();
+  });
+
+  test("shows error when inviting an existing member email", async ({
+    managerPage,
+    testData,
+  }) => {
+    await gotoMembers(managerPage);
+
+    await managerPage.getByRole("button", { name: "Invite Member" }).click();
+    // Use the existing User member's email
+    await managerPage.getByLabel("Email address").fill(testData.user.email);
+    await managerPage.getByRole("button", { name: "Send Invitation" }).click();
+
+    // Error toast for already-member
+    await expect(
+      managerPage.getByText(
+        "This email is already a member of the organization.",
+      ),
+    ).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// User role — permission boundary
+// ---------------------------------------------------------------------------
+
+test.describe("Members page — User role", () => {
+  test("User cannot view member list (permission denied)", async ({
+    userPage,
+  }) => {
+    await userPage.goto("/en/settings/members");
+
+    // The page should show an error because /api/members returns 403
+    await expect(
+      userPage.getByText("An error occurred. Please try again."),
+    ).toBeVisible();
+
+    // The member table should NOT be visible
+    await expect(userPage.locator("table")).toBeHidden();
+
+    // The Invite button should NOT be visible
+    await expect(
+      userPage.getByRole("button", { name: "Invite Member" }),
+    ).toBeHidden();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Locale switching
+// ---------------------------------------------------------------------------
+
+test.describe("Members page — locale", () => {
+  test("renders in Korean at default locale path", async ({ managerPage }) => {
+    await gotoMembers(managerPage, "ko");
+
+    await expect(
+      managerPage.getByRole("heading", { name: "멤버", level: 1 }),
+    ).toBeVisible();
+  });
+
+  test("renders in English at /en path", async ({ managerPage }) => {
+    await gotoMembers(managerPage);
+
+    await expect(
+      managerPage.getByRole("heading", { name: "Members", level: 1 }),
+    ).toBeVisible();
+  });
+});

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,5 +1,11 @@
 import { defineConfig, devices } from "@playwright/test";
 
+// CI prerequisites for auth-fixture-based UI tests:
+// - PostgreSQL with migrated auth_db (DATABASE_URL / DATABASE_MIGRATION_URL)
+// - JWT key pair at DATA_DIR/keys/ (ec-private.pem, ec-public.pem)
+// - CSRF_SECRET environment variable
+// These are provided by the docker-compose dev stack; see .env.example.
+
 export default defineConfig({
   testDir: ".",
   fullyParallel: false,


### PR DESCRIPTION
## Summary

- Playwright auth fixture that bypasses Keycloak OIDC via direct JWT cookie injection (supports general/admin contexts and Manager/User roles)
- 23 UI E2E tests for `/settings/members`: rendering, dialog interactions, validation, mutation confirmations (role change, member removal), invitation lifecycle (send → revoke), permission boundary (User role denied), and EN/KO locale switching
- Authenticated smoke tests for members page (API-backed, verifying JWT + session)
- CI provisioned with `CSRF_SECRET` and `DATABASE_MIGRATION_URL` for the E2E job

## Test plan

- [x] `pnpm test:unit` passes (no regressions)
- [x] `pnpm test:e2e` passes with docker-compose stack running
- [x] Verify auth fixture creates valid JWT cookies accepted by the dev server
- [x] Verify test cleanup leaves no orphaned rows in the database

Closes #94