### PR TITLE
Add per-request DB authorization layer

### DIFF
--- a/e2e/authorization-api.spec.ts
+++ b/e2e/authorization-api.spec.ts
@@ -1,0 +1,239 @@
+import { expect, getTestPool, test } from "./fixtures";
+
+// ---------------------------------------------------------------------------
+// E2E authorization tests — verify that the authorization layer enforces
+// role-based access at the API level using real authenticated sessions.
+//
+// Covers verification items:
+//   #4-7  — General flow per role (Manager, User, Admin)
+//   #9    — System Admin has no general permissions
+//   #22   — admin_eligible change → immediate admin rejection
+//   #24   — Membership deletion → immediate general rejection
+//   #25   — Multiple customers with different roles
+// ---------------------------------------------------------------------------
+
+// =========================================================================
+// #4-5: Manager can access members API
+// =========================================================================
+
+test.describe("Authorization — Manager role", () => {
+  test("Manager can list members for their customer", async ({
+    managerPage,
+    testData,
+  }) => {
+    const res = await managerPage.request.get(
+      `/api/members?customer_id=${testData.customer.id}`,
+    );
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(body.members).toBeDefined();
+    expect(body.members.length).toBeGreaterThanOrEqual(2);
+
+    const displayNames = body.members.map(
+      (m: { displayName: string }) => m.displayName,
+    );
+    expect(displayNames).toContain(testData.manager.displayName);
+    expect(displayNames).toContain(testData.user.displayName);
+  });
+
+  test("Manager can access roles API", async ({ managerPage }) => {
+    const res = await managerPage.request.get("/api/roles");
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(body.roles.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// =========================================================================
+// #6-7: User role is denied management APIs
+// =========================================================================
+
+test.describe("Authorization — User role", () => {
+  test("User is denied member list (403)", async ({ userPage, testData }) => {
+    const res = await userPage.request.get(
+      `/api/members?customer_id=${testData.customer.id}`,
+    );
+    expect(res.status()).toBe(403);
+  });
+
+  test("User can access own profile via /api/auth/me", async ({
+    userPage,
+    testData,
+  }) => {
+    const res = await userPage.request.get("/api/auth/me");
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(body.accountId).toBe(testData.user.accountId);
+    expect(body.authContext).toBe("general");
+  });
+});
+
+// =========================================================================
+// #9: Admin session cannot access general-context endpoints
+// =========================================================================
+
+test.describe("Authorization — Admin context boundary", () => {
+  test("Admin session can access /api/admin-auth/me", async ({
+    adminPage,
+    testData,
+  }) => {
+    const res = await adminPage.request.get("/api/admin-auth/me");
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(body.accountId).toBe(testData.admin.accountId);
+    expect(body.authContext).toBe("admin");
+  });
+
+  test("Admin session is rejected by general-context /api/auth/me (401)", async ({
+    adminPage,
+  }) => {
+    // Admin cookie is `at_admin`; the general endpoint expects `at`.
+    // Without a general cookie, the general guard returns 401.
+    const res = await adminPage.request.get("/api/auth/me");
+    expect(res.status()).toBe(401);
+  });
+
+  test("General session is rejected by admin-context /api/admin-auth/me (401)", async ({
+    managerPage,
+  }) => {
+    // General cookie is `at`; the admin endpoint expects `at_admin`.
+    const res = await managerPage.request.get("/api/admin-auth/me");
+    expect(res.status()).toBe(401);
+  });
+});
+
+// =========================================================================
+// #22: admin_eligible change → immediate admin session invalidation
+// =========================================================================
+
+test.describe("Authorization — immediate effect", () => {
+  test("revoking admin_eligible immediately blocks admin API", async ({
+    adminPage,
+    testData,
+  }) => {
+    // Verify admin works first
+    const res1 = await adminPage.request.get("/api/admin-auth/me");
+    expect(res1.status()).toBe(200);
+
+    // Revoke admin_eligible directly in DB
+    const pool = getTestPool();
+    await pool.query(
+      `UPDATE accounts SET admin_eligible = false WHERE id = $1`,
+      [testData.admin.accountId],
+    );
+
+    try {
+      // Next request should fail — the JWT is still valid, but
+      // verifyJwtFull re-checks admin_eligible from DB.
+      const res2 = await adminPage.request.get("/api/admin-auth/me");
+      expect(res2.status()).toBe(401);
+    } finally {
+      // Restore for other tests
+      await pool.query(
+        `UPDATE accounts SET admin_eligible = true WHERE id = $1`,
+        [testData.admin.accountId],
+      );
+    }
+  });
+
+  test("removing membership immediately blocks member list", async ({
+    userPage,
+    testData,
+  }) => {
+    // User can access their own profile (proves session is valid)
+    const res1 = await userPage.request.get("/api/auth/me");
+    expect(res1.status()).toBe(200);
+
+    // Remove User's membership from customer A
+    const pool = getTestPool();
+    await pool.query(
+      `DELETE FROM account_customer_memberships
+       WHERE account_id = $1 AND customer_id = $2`,
+      [testData.user.accountId, testData.customer.id],
+    );
+
+    try {
+      // /api/auth/me still works (session is valid, no customer check)
+      const res2 = await userPage.request.get("/api/auth/me");
+      expect(res2.status()).toBe(200);
+
+      // But memberships array should be empty for this customer
+      const body = await res2.json();
+      const customerIds = body.memberships.map(
+        (m: { customerId: string }) => m.customerId,
+      );
+      expect(customerIds).not.toContain(testData.customer.id);
+    } finally {
+      // Restore membership
+      await pool.query(
+        `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+         VALUES ($1, $2, $3)`,
+        [testData.user.accountId, testData.customer.id, testData.roles.userId],
+      );
+    }
+  });
+});
+
+// =========================================================================
+// #25: Multiple customers with different roles
+// =========================================================================
+
+test.describe("Authorization — multi-role across customers", () => {
+  test("multi-role account sees different memberships per customer", async ({
+    multiRolePage,
+    testData,
+  }) => {
+    const res = await multiRolePage.request.get("/api/auth/me");
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(body.accountId).toBe(testData.multiRole.accountId);
+
+    // Should have memberships in both customers
+    const memberships = body.memberships as Array<{
+      customerId: string;
+      roleName: string;
+    }>;
+    expect(memberships.length).toBe(2);
+
+    // User role in customer A
+    const custA = memberships.find(
+      (m) => m.customerId === testData.customer.id,
+    );
+    expect(custA).toBeDefined();
+    expect(custA?.roleName).toBe("User");
+
+    // Manager role in customer B
+    const custB = memberships.find(
+      (m) => m.customerId === testData.customerB.id,
+    );
+    expect(custB).toBeDefined();
+    expect(custB?.roleName).toBe("Manager");
+  });
+
+  test("multi-role account can list members for customer B (Manager)", async ({
+    multiRolePage,
+    testData,
+  }) => {
+    const res = await multiRolePage.request.get(
+      `/api/members?customer_id=${testData.customerB.id}`,
+    );
+    // Manager in customer B → can list members
+    expect(res.status()).toBe(200);
+  });
+
+  test("multi-role account is denied member list for customer A (User)", async ({
+    multiRolePage,
+    testData,
+  }) => {
+    const res = await multiRolePage.request.get(
+      `/api/members?customer_id=${testData.customer.id}`,
+    );
+    // User in customer A → cannot list members
+    expect(res.status()).toBe(403);
+  });
+});

--- a/e2e/fixtures/db.ts
+++ b/e2e/fixtures/db.ts
@@ -14,8 +14,12 @@ export interface TestAccount {
 
 export interface TestData {
   customer: { id: string; name: string; externalKey: string };
+  customerB: { id: string; name: string; externalKey: string };
   manager: TestAccount;
   user: TestAccount;
+  analyst: TestAccount;
+  admin: TestAccount;
+  multiRole: TestAccount;
   roles: { managerId: number; userId: number };
 }
 
@@ -105,6 +109,77 @@ export async function seedTestData(): Promise<TestData> {
     [mgrAccountId, customerId, managerRoleId, usrAccountId, userRoleId],
   );
 
+  // Customer B (for multi-role testing)
+  const customerBId = randomUUID();
+  const customerBName = `E2E Customer B ${suffix}`;
+  const customerBKey = `e2e-b-${suffix}`;
+  await p.query(
+    `INSERT INTO customers (id, external_key, name, status, database_status)
+     VALUES ($1, $2, $3, 'active', 'active')`,
+    [customerBId, customerBKey, customerBName],
+  );
+
+  // Analyst account (analyst_eligible=true, assigned to customer A)
+  const analystAccountId = randomUUID();
+  const analystDisplayName = `E2E Analyst ${suffix}`;
+  const analystEmail = `analyst-${suffix}@e2e.test`;
+  await p.query(
+    `INSERT INTO accounts
+       (id, oidc_issuer, oidc_subject, username, display_name, email, status, analyst_eligible)
+     VALUES ($1, 'e2e-issuer', $2, $3, $4, $5, 'active', true)`,
+    [
+      analystAccountId,
+      `analyst-${suffix}`,
+      `analyst-${suffix}`,
+      analystDisplayName,
+      analystEmail,
+    ],
+  );
+  await p.query(
+    `INSERT INTO analyst_customer_assignments (account_id, customer_id, assigned_by)
+     VALUES ($1, $2, $3)`,
+    [analystAccountId, customerId, mgrAccountId],
+  );
+
+  // Admin account (admin_eligible=true)
+  const adminAccountId = randomUUID();
+  const adminDisplayName = `E2E Admin ${suffix}`;
+  const adminEmail = `admin-${suffix}@e2e.test`;
+  await p.query(
+    `INSERT INTO accounts
+       (id, oidc_issuer, oidc_subject, username, display_name, email, status, admin_eligible)
+     VALUES ($1, 'e2e-issuer', $2, $3, $4, $5, 'active', true)`,
+    [
+      adminAccountId,
+      `admin-${suffix}`,
+      `admin-${suffix}`,
+      adminDisplayName,
+      adminEmail,
+    ],
+  );
+
+  // Multi-role account: User in customer A, Manager in customer B
+  const multiAccountId = randomUUID();
+  const multiDisplayName = `E2E Multi ${suffix}`;
+  const multiEmail = `multi-${suffix}@e2e.test`;
+  await p.query(
+    `INSERT INTO accounts
+       (id, oidc_issuer, oidc_subject, username, display_name, email, status)
+     VALUES ($1, 'e2e-issuer', $2, $3, $4, $5, 'active')`,
+    [
+      multiAccountId,
+      `multi-${suffix}`,
+      `multi-${suffix}`,
+      multiDisplayName,
+      multiEmail,
+    ],
+  );
+  await p.query(
+    `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+     VALUES ($1, $2, $3), ($1, $4, $5)`,
+    [multiAccountId, customerId, userRoleId, customerBId, managerRoleId],
+  );
+
   // Sessions
   const mgrSession = await p.query<{ sid: string }>(
     `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent)
@@ -118,9 +193,32 @@ export async function seedTestData(): Promise<TestData> {
      RETURNING sid`,
     [usrAccountId],
   );
+  const analystSession = await p.query<{ sid: string }>(
+    `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent)
+     VALUES ($1, 'general', '127.0.0.1', 'Playwright E2E')
+     RETURNING sid`,
+    [analystAccountId],
+  );
+  const adminSession = await p.query<{ sid: string }>(
+    `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent)
+     VALUES ($1, 'admin', '127.0.0.1', 'Playwright E2E')
+     RETURNING sid`,
+    [adminAccountId],
+  );
+  const multiSession = await p.query<{ sid: string }>(
+    `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent)
+     VALUES ($1, 'general', '127.0.0.1', 'Playwright E2E')
+     RETURNING sid`,
+    [multiAccountId],
+  );
 
   return {
     customer: { id: customerId, name: customerName, externalKey },
+    customerB: {
+      id: customerBId,
+      name: customerBName,
+      externalKey: customerBKey,
+    },
     manager: {
       accountId: mgrAccountId,
       sessionId: mgrSession.rows[0].sid,
@@ -133,26 +231,62 @@ export async function seedTestData(): Promise<TestData> {
       displayName: usrDisplayName,
       email: usrEmail,
     },
+    analyst: {
+      accountId: analystAccountId,
+      sessionId: analystSession.rows[0].sid,
+      displayName: analystDisplayName,
+      email: analystEmail,
+    },
+    admin: {
+      accountId: adminAccountId,
+      sessionId: adminSession.rows[0].sid,
+      displayName: adminDisplayName,
+      email: adminEmail,
+    },
+    multiRole: {
+      accountId: multiAccountId,
+      sessionId: multiSession.rows[0].sid,
+      displayName: multiDisplayName,
+      email: multiEmail,
+    },
     roles: { managerId: managerRoleId, userId: userRoleId },
   };
 }
 
 export async function cleanupTestData(data: TestData): Promise<void> {
   const p = getPool();
-  const accountIds = [data.manager.accountId, data.user.accountId];
+  const accountIds = [
+    data.manager.accountId,
+    data.user.accountId,
+    data.analyst.accountId,
+    data.admin.accountId,
+    data.multiRole.accountId,
+  ];
+  const customerIds = [data.customer.id, data.customerB.id];
 
   // Delete in reverse dependency order.
-  // Invitations may have been created during tests (e.g. invite dialog test).
-  await p.query(`DELETE FROM invitations WHERE customer_id = $1`, [
-    data.customer.id,
+  await p.query(`DELETE FROM invitations WHERE customer_id = ANY($1)`, [
+    customerIds,
   ]);
+  await p.query(
+    `DELETE FROM analyst_customer_assignments WHERE account_id = ANY($1)`,
+    [accountIds],
+  );
   await p.query(`DELETE FROM sessions WHERE account_id = ANY($1)`, [
     accountIds,
   ]);
   await p.query(
-    `DELETE FROM account_customer_memberships WHERE customer_id = $1`,
-    [data.customer.id],
+    `DELETE FROM account_customer_memberships WHERE customer_id = ANY($1)`,
+    [customerIds],
   );
   await p.query(`DELETE FROM accounts WHERE id = ANY($1)`, [accountIds]);
-  await p.query(`DELETE FROM customers WHERE id = $1`, [data.customer.id]);
+  await p.query(`DELETE FROM customers WHERE id = ANY($1)`, [customerIds]);
+}
+
+/**
+ * Get a fresh DB pool for direct queries in E2E tests (e.g., updating
+ * admin_eligible mid-test). Uses the same pool as seedTestData.
+ */
+export function getTestPool(): Pool {
+  return getPool();
 }

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -8,6 +8,7 @@ loadEnv();
 
 export { expect } from "@playwright/test";
 export type { TestAccount, TestData } from "./db";
+export { getTestPool } from "./db";
 
 // ---------------------------------------------------------------------------
 // Extended test with auth fixtures
@@ -20,6 +21,10 @@ export const test = base.extend<{
   managerPage: Page;
   /** Browser page authenticated as a User. */
   userPage: Page;
+  /** Browser page authenticated as an Admin (admin context). */
+  adminPage: Page;
+  /** Browser page authenticated as a multi-role User. */
+  multiRolePage: Page;
 }>({
   // biome-ignore lint/correctness/noEmptyPattern: Playwright fixture API requires destructuring
   testData: async ({}, use) => {
@@ -39,6 +44,22 @@ export const test = base.extend<{
   userPage: async ({ browser, baseURL, testData }, use) => {
     const context = await browser.newContext({ baseURL: baseURL ?? undefined });
     await injectAuthCookies(context, testData.user, "general");
+    const page = await context.newPage();
+    await use(page);
+    await context.close();
+  },
+
+  adminPage: async ({ browser, baseURL, testData }, use) => {
+    const context = await browser.newContext({ baseURL: baseURL ?? undefined });
+    await injectAuthCookies(context, testData.admin, "admin");
+    const page = await context.newPage();
+    await use(page);
+    await context.close();
+  },
+
+  multiRolePage: async ({ browser, baseURL, testData }, use) => {
+    const context = await browser.newContext({ baseURL: baseURL ?? undefined });
+    await injectAuthCookies(context, testData.multiRole, "general");
     const page = await context.newPage();
     await use(page);
     await context.close();

--- a/src/lib/auth/__tests__/authorization.db.test.ts
+++ b/src/lib/auth/__tests__/authorization.db.test.ts
@@ -988,7 +988,7 @@ describe.skipIf(!hasPostgres)("authorize() (DB integration)", () => {
   describe("listAccessibleEnvironments", () => {
     it("returns active environments linked to customer", async () => {
       const envs = await withClient((c) =>
-        listAccessibleEnvironments(c, activeCustomerId),
+        listAccessibleEnvironments(c, managerAccountId, activeCustomerId),
       );
       const ids = envs.map((e) => e.aiceId);
       expect(ids).toContain(activeAiceId);
@@ -1004,7 +1004,7 @@ describe.skipIf(!hasPostgres)("authorize() (DB integration)", () => {
       );
 
       const envs = await withClient((c) =>
-        listAccessibleEnvironments(c, activeCustomerId),
+        listAccessibleEnvironments(c, managerAccountId, activeCustomerId),
       );
       const ids = envs.map((e) => e.aiceId);
       expect(ids).not.toContain(suspendedAiceId);
@@ -1032,7 +1032,12 @@ describe.skipIf(!hasPostgres)("authorize() (DB integration)", () => {
         customerIds: [activeCustomerId],
       };
       const envs = await withClient((c) =>
-        listAccessibleEnvironments(c, activeCustomerId, bridgeScope),
+        listAccessibleEnvironments(
+          c,
+          managerAccountId,
+          activeCustomerId,
+          bridgeScope,
+        ),
       );
       expect(envs).toHaveLength(1);
       expect(envs[0].aiceId).toBe(activeAiceId);
@@ -1043,6 +1048,29 @@ describe.skipIf(!hasPostgres)("authorize() (DB integration)", () => {
       await pool.query(
         `DELETE FROM aice_environments WHERE aice_id = 'other-active.example.com'`,
       );
+    });
+
+    it("returns empty for account without access to customer", async () => {
+      const envs = await withClient((c) =>
+        listAccessibleEnvironments(c, noAccessAccountId, activeCustomerId),
+      );
+      expect(envs).toHaveLength(0);
+    });
+
+    it("returns empty when customerId is outside bridge scope", async () => {
+      const bridgeScope = {
+        aiceId: activeAiceId,
+        customerIds: [suspendedCustomerId], // activeCustomerId not in scope
+      };
+      const envs = await withClient((c) =>
+        listAccessibleEnvironments(
+          c,
+          managerAccountId,
+          activeCustomerId,
+          bridgeScope,
+        ),
+      );
+      expect(envs).toHaveLength(0);
     });
   });
 });

--- a/src/lib/auth/__tests__/authorization.db.test.ts
+++ b/src/lib/auth/__tests__/authorization.db.test.ts
@@ -1,0 +1,1048 @@
+import { join } from "node:path";
+import type { Pool, PoolClient } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeAdminPool,
+  createTestDatabase,
+  dropTestDatabase,
+  hasPostgres,
+} from "../../db/__tests__/db-test-helpers";
+import { runMigrations } from "../../db/migrate";
+import {
+  assertAuthorized,
+  authorize,
+  listAccessibleCustomers,
+  listAccessibleEnvironments,
+} from "../authorization";
+import { HttpError } from "../errors";
+
+const MIGRATIONS_DIR = join(process.cwd(), "migrations", "auth");
+const LOCK_ID = 1029;
+
+describe.skipIf(!hasPostgres)("authorize() (DB integration)", () => {
+  let pool: Pool;
+  let dbName: string;
+
+  // Role IDs
+  let userRoleId: number;
+  let managerRoleId: number;
+  let sysAdminRoleId: number;
+
+  // Accounts
+  let userAccountId: string;
+  let managerAccountId: string;
+  let analystAccountId: string;
+  let adminAccountId: string;
+  let multiRoleAccountId: string;
+  let noAccessAccountId: string;
+
+  // Customers
+  let activeCustomerId: string;
+  let suspendedCustomerId: string;
+  let customerBId: string;
+  let customerCId: string;
+
+  // AICE environments
+  const activeAiceId = "aice-active.example.com";
+  const suspendedAiceId = "aice-suspended.example.com";
+
+  async function withClient<T>(
+    fn: (client: PoolClient) => Promise<T>,
+  ): Promise<T> {
+    const client = await pool.connect();
+    try {
+      return await fn(client);
+    } finally {
+      client.release();
+    }
+  }
+
+  beforeAll(async () => {
+    const result = await createTestDatabase("authz", "auth");
+    pool = result.pool;
+    dbName = result.dbName;
+
+    await pool.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'aimer_auth') THEN
+          CREATE ROLE aimer_auth LOGIN PASSWORD 'changeme';
+        END IF;
+      END $$
+    `);
+
+    await runMigrations(pool, MIGRATIONS_DIR, LOCK_ID);
+
+    // Lookup built-in roles
+    const roles = await pool.query<{ id: number; name: string }>(
+      `SELECT id, name FROM roles WHERE name IN ('User', 'Manager', 'Analyst', 'System Administrator')`,
+    );
+    for (const r of roles.rows) {
+      if (r.name === "User") userRoleId = r.id;
+      if (r.name === "Manager") managerRoleId = r.id;
+      if (r.name === "System Administrator") sysAdminRoleId = r.id;
+    }
+
+    // Create customers
+    const c1 = await pool.query<{ id: string }>(
+      `INSERT INTO customers (external_key, name, status) VALUES ('cust-active', 'Active Customer', 'active') RETURNING id`,
+    );
+    activeCustomerId = c1.rows[0].id;
+
+    const c2 = await pool.query<{ id: string }>(
+      `INSERT INTO customers (external_key, name, status) VALUES ('cust-suspended', 'Suspended Customer', 'suspended') RETURNING id`,
+    );
+    suspendedCustomerId = c2.rows[0].id;
+
+    const c3 = await pool.query<{ id: string }>(
+      `INSERT INTO customers (external_key, name, status) VALUES ('cust-b', 'Customer B', 'active') RETURNING id`,
+    );
+    customerBId = c3.rows[0].id;
+
+    const c4 = await pool.query<{ id: string }>(
+      `INSERT INTO customers (external_key, name, status) VALUES ('cust-c', 'Customer C', 'active') RETURNING id`,
+    );
+    customerCId = c4.rows[0].id;
+
+    // Create AICE environments
+    await pool.query(
+      `INSERT INTO aice_environments (aice_id, name, status) VALUES ($1, 'Active Env', 'active')`,
+      [activeAiceId],
+    );
+    await pool.query(
+      `INSERT INTO aice_environments (aice_id, name, status) VALUES ($1, 'Suspended Env', 'suspended')`,
+      [suspendedAiceId],
+    );
+
+    // Link active environment to active customer
+    await pool.query(
+      `INSERT INTO aice_environment_customers (aice_id, customer_id) VALUES ($1, $2)`,
+      [activeAiceId, activeCustomerId],
+    );
+
+    // Create accounts
+    const mkAccount = async (
+      sub: string,
+      name: string,
+      opts: { analyst_eligible?: boolean; admin_eligible?: boolean } = {},
+    ) => {
+      const row = await pool.query<{ id: string }>(
+        `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, analyst_eligible, admin_eligible)
+         VALUES ('test-issuer', $1, $2, $3, $4, $5) RETURNING id`,
+        [
+          sub,
+          name,
+          name,
+          opts.analyst_eligible ?? false,
+          opts.admin_eligible ?? false,
+        ],
+      );
+      return row.rows[0].id;
+    };
+
+    userAccountId = await mkAccount("user-001", "user1");
+    managerAccountId = await mkAccount("mgr-001", "manager1");
+    analystAccountId = await mkAccount("analyst-001", "analyst1", {
+      analyst_eligible: true,
+    });
+    adminAccountId = await mkAccount("admin-001", "admin1", {
+      admin_eligible: true,
+    });
+    multiRoleAccountId = await mkAccount("multi-001", "multi1", {
+      analyst_eligible: true,
+    });
+    noAccessAccountId = await mkAccount("noaccess-001", "noaccess1");
+
+    // Memberships
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id) VALUES ($1, $2, $3)`,
+      [userAccountId, activeCustomerId, userRoleId],
+    );
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id) VALUES ($1, $2, $3)`,
+      [managerAccountId, activeCustomerId, managerRoleId],
+    );
+
+    // Multi-role: User in customer A, Manager in customer B, Analyst in customer C
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id) VALUES ($1, $2, $3)`,
+      [multiRoleAccountId, activeCustomerId, userRoleId],
+    );
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id) VALUES ($1, $2, $3)`,
+      [multiRoleAccountId, customerBId, managerRoleId],
+    );
+
+    // Analyst assignments
+    await pool.query(
+      `INSERT INTO analyst_customer_assignments (account_id, customer_id, assigned_by) VALUES ($1, $2, $3)`,
+      [analystAccountId, activeCustomerId, adminAccountId],
+    );
+    await pool.query(
+      `INSERT INTO analyst_customer_assignments (account_id, customer_id, assigned_by) VALUES ($1, $2, $3)`,
+      [multiRoleAccountId, customerCId, adminAccountId],
+    );
+  });
+
+  afterAll(async () => {
+    await dropTestDatabase(dbName, pool, "auth");
+    await closeAdminPool();
+  });
+
+  // -------------------------------------------------------------------------
+  // General flow per role (#4-7)
+  // -------------------------------------------------------------------------
+
+  describe("general flow per role", () => {
+    it("User has basic permissions (workspace:read)", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", userAccountId, "workspace:read", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+    });
+
+    it("User lacks Manager permissions (customer-members:write)", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", userAccountId, "customer-members:write", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+    });
+
+    it("Manager has customer-members:write", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", managerAccountId, "customer-members:write", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+    });
+
+    it("Manager also has basic permissions (workspace:read)", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", managerAccountId, "workspace:read", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+    });
+
+    it("Analyst has analyst-specific permissions (analyses:configure)", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", analystAccountId, "analyses:configure", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+    });
+
+    it("Analyst also has basic permissions (workspace:read)", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", analystAccountId, "workspace:read", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Analyst blocked without eligibility (#6-1)
+  // -------------------------------------------------------------------------
+
+  describe("analyst blocked without eligibility", () => {
+    it("rejects analyst permissions when analyst_eligible=false", async () => {
+      // noAccessAccountId has analyst_eligible=false, even if we add an assignment
+      await pool.query(
+        `INSERT INTO analyst_customer_assignments (account_id, customer_id, assigned_by)
+         VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`,
+        [noAccessAccountId, activeCustomerId, adminAccountId],
+      );
+      // Also need a membership or assignment for any access
+      const result = await withClient((c) =>
+        authorize(c, "general", noAccessAccountId, "analyses:configure", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+
+      // Cleanup
+      await pool.query(
+        `DELETE FROM analyst_customer_assignments WHERE account_id = $1 AND customer_id = $2`,
+        [noAccessAccountId, activeCustomerId],
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Analyst blocked for unassigned customer (#6-2)
+  // -------------------------------------------------------------------------
+
+  describe("analyst blocked for unassigned customer", () => {
+    it("rejects analyst permissions for customer without assignment", async () => {
+      // analystAccountId is analyst-eligible but only assigned to activeCustomerId, not customerBId
+      const result = await withClient((c) =>
+        authorize(c, "general", analystAccountId, "analyses:configure", {
+          customerId: customerBId,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // System Admin has no general permissions (#9)
+  // -------------------------------------------------------------------------
+
+  describe("System Admin has no general permissions", () => {
+    it("rejects general-context permissions for admin", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "admin", adminAccountId, "customer-settings:write", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+    });
+
+    it("grants admin-context permissions", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "admin", adminAccountId, "accounts:read"),
+      );
+      expect(result.authorized).toBe(true);
+    });
+
+    it("rejects admin-context when admin_eligible=false", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "admin", userAccountId, "accounts:read"),
+      );
+      expect(result.authorized).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Immediate effect: analyst_eligible change (#22-1)
+  // -------------------------------------------------------------------------
+
+  describe("analyst_eligible change immediate blocking", () => {
+    it("blocks analyst features immediately after revoking eligibility", async () => {
+      // Verify analyst works before
+      let result = await withClient((c) =>
+        authorize(c, "general", analystAccountId, "analyses:configure", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+
+      // Revoke eligibility
+      await pool.query(
+        `UPDATE accounts SET analyst_eligible = false WHERE id = $1`,
+        [analystAccountId],
+      );
+
+      result = await withClient((c) =>
+        authorize(c, "general", analystAccountId, "analyses:configure", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+
+      // Restore
+      await pool.query(
+        `UPDATE accounts SET analyst_eligible = true WHERE id = $1`,
+        [analystAccountId],
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Immediate effect: analyst_customer_assignments deletion (#22-2)
+  // -------------------------------------------------------------------------
+
+  describe("analyst_customer_assignments deletion immediate blocking", () => {
+    it("blocks access immediately after assignment removal", async () => {
+      let result = await withClient((c) =>
+        authorize(c, "general", analystAccountId, "analyses:configure", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+
+      // Remove assignment
+      await pool.query(
+        `DELETE FROM analyst_customer_assignments WHERE account_id = $1 AND customer_id = $2`,
+        [analystAccountId, activeCustomerId],
+      );
+
+      result = await withClient((c) =>
+        authorize(c, "general", analystAccountId, "analyses:configure", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+
+      // Restore
+      await pool.query(
+        `INSERT INTO analyst_customer_assignments (account_id, customer_id, assigned_by) VALUES ($1, $2, $3)`,
+        [analystAccountId, activeCustomerId, adminAccountId],
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Immediate effect: membership role change (#23)
+  // -------------------------------------------------------------------------
+
+  describe("membership role change immediate effect", () => {
+    it("applies new permissions immediately after role change", async () => {
+      // User initially lacks customer-members:write
+      let result = await withClient((c) =>
+        authorize(c, "general", userAccountId, "customer-members:write", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+
+      // Promote to Manager
+      await pool.query(
+        `UPDATE account_customer_memberships SET role_id = $1 WHERE account_id = $2 AND customer_id = $3`,
+        [managerRoleId, userAccountId, activeCustomerId],
+      );
+
+      result = await withClient((c) =>
+        authorize(c, "general", userAccountId, "customer-members:write", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+
+      // Restore to User
+      await pool.query(
+        `UPDATE account_customer_memberships SET role_id = $1 WHERE account_id = $2 AND customer_id = $3`,
+        [userRoleId, userAccountId, activeCustomerId],
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Immediate effect: membership deletion (#24)
+  // -------------------------------------------------------------------------
+
+  describe("membership deletion immediate blocking", () => {
+    it("blocks access immediately after membership removal", async () => {
+      let result = await withClient((c) =>
+        authorize(c, "general", userAccountId, "workspace:read", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+
+      await pool.query(
+        `DELETE FROM account_customer_memberships WHERE account_id = $1 AND customer_id = $2`,
+        [userAccountId, activeCustomerId],
+      );
+
+      result = await withClient((c) =>
+        authorize(c, "general", userAccountId, "workspace:read", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+
+      // Restore
+      await pool.query(
+        `INSERT INTO account_customer_memberships (account_id, customer_id, role_id) VALUES ($1, $2, $3)`,
+        [userAccountId, activeCustomerId, userRoleId],
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Multiple customers different roles (#25)
+  // -------------------------------------------------------------------------
+
+  describe("multiple customers different roles", () => {
+    it("returns different permissions per customer", async () => {
+      // multiRoleAccountId: User in activeCustomerId, Manager in customerBId, Analyst in customerCId
+      const resultA = await withClient((c) =>
+        authorize(c, "general", multiRoleAccountId, "customer-members:write", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(resultA.authorized).toBe(false); // User role
+
+      const resultB = await withClient((c) =>
+        authorize(c, "general", multiRoleAccountId, "customer-members:write", {
+          customerId: customerBId,
+        }),
+      );
+      expect(resultB.authorized).toBe(true); // Manager role
+
+      const resultC = await withClient((c) =>
+        authorize(c, "general", multiRoleAccountId, "analyses:configure", {
+          customerId: customerCId,
+        }),
+      );
+      expect(resultC.authorized).toBe(true); // Analyst role
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Inactive customer rejection (#32-1)
+  // -------------------------------------------------------------------------
+
+  describe("inactive customer rejection", () => {
+    it("rejects authorization for suspended customer", async () => {
+      // Add membership to suspended customer
+      await pool.query(
+        `INSERT INTO account_customer_memberships (account_id, customer_id, role_id) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`,
+        [userAccountId, suspendedCustomerId, userRoleId],
+      );
+
+      const result = await withClient((c) =>
+        authorize(c, "general", userAccountId, "workspace:read", {
+          customerId: suspendedCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+
+      await pool.query(
+        `DELETE FROM account_customer_memberships WHERE account_id = $1 AND customer_id = $2`,
+        [userAccountId, suspendedCustomerId],
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Inactive environment rejection (#32-2)
+  // -------------------------------------------------------------------------
+
+  describe("inactive environment rejection", () => {
+    it("rejects authorization for suspended environment", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", userAccountId, "workspace:read", {
+          customerId: activeCustomerId,
+          aiceId: suspendedAiceId,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+    });
+
+    it("rejects when environment is not linked to customer", async () => {
+      // activeAiceId is linked to activeCustomerId but not customerBId
+      await pool.query(
+        `INSERT INTO account_customer_memberships (account_id, customer_id, role_id) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`,
+        [managerAccountId, customerBId, managerRoleId],
+      );
+
+      const result = await withClient((c) =>
+        authorize(c, "general", managerAccountId, "workspace:read", {
+          customerId: customerBId,
+          aiceId: activeAiceId,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+
+      await pool.query(
+        `DELETE FROM account_customer_memberships WHERE account_id = $1 AND customer_id = $2`,
+        [managerAccountId, customerBId],
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // requiresAiceId enforcement (#32-3, #32-4)
+  // -------------------------------------------------------------------------
+
+  describe("requiresAiceId enforcement", () => {
+    it("rejects when requiresAiceId=true and aiceId is missing", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", userAccountId, "workspace:read", {
+          customerId: activeCustomerId,
+          requiresAiceId: true,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+    });
+
+    it("allows when requiresAiceId=true and aiceId is provided", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", userAccountId, "workspace:read", {
+          customerId: activeCustomerId,
+          aiceId: activeAiceId,
+          requiresAiceId: true,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+    });
+
+    it("allows Manager access without aiceId when requiresAiceId is not set", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", managerAccountId, "customer-members:write", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // operationKind enforcement (#34, #34-1, #34-1a, #34-1b, #34-2)
+  // -------------------------------------------------------------------------
+
+  describe("operationKind enforcement", () => {
+    const bridgeScope = {
+      aiceId: activeAiceId,
+      customerIds: [activeCustomerId],
+    };
+
+    it("rejects write in bridge session", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", userAccountId, "workspace:read", {
+          customerId: activeCustomerId,
+          operationKind: "write",
+          bridgeScope,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+    });
+
+    it("allows read in bridge session", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", userAccountId, "workspace:read", {
+          customerId: activeCustomerId,
+          operationKind: "read",
+          bridgeScope,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+    });
+
+    it("allows ingest in bridge session", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", userAccountId, "workspace:read", {
+          customerId: activeCustomerId,
+          operationKind: "ingest",
+          bridgeScope,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+    });
+
+    it("allows process in bridge session", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", userAccountId, "workspace:read", {
+          customerId: activeCustomerId,
+          operationKind: "process",
+          bridgeScope,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+    });
+
+    it("allows write in direct access session (no bridge)", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", managerAccountId, "customer-members:write", {
+          customerId: activeCustomerId,
+          operationKind: "write",
+        }),
+      );
+      expect(result.authorized).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // allowInBridge enforcement (#34-3, #34-4, #34-5)
+  // -------------------------------------------------------------------------
+
+  describe("allowInBridge enforcement", () => {
+    const bridgeScope = {
+      aiceId: activeAiceId,
+      customerIds: [activeCustomerId],
+    };
+
+    it("rejects bridge session when allowInBridge=false", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", managerAccountId, "customer-members:read", {
+          customerId: activeCustomerId,
+          allowInBridge: false,
+          bridgeScope,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+    });
+
+    it("allows direct session when allowInBridge=false", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", managerAccountId, "customer-members:read", {
+          customerId: activeCustomerId,
+          allowInBridge: false,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+    });
+
+    it("allowInBridge=false evaluated before operationKind in bridge", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", userAccountId, "workspace:read", {
+          customerId: activeCustomerId,
+          operationKind: "read",
+          allowInBridge: false,
+          bridgeScope,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Bridge scope — customer/aice out of scope
+  // -------------------------------------------------------------------------
+
+  describe("bridge scope restriction", () => {
+    const bridgeScope = {
+      aiceId: activeAiceId,
+      customerIds: [activeCustomerId],
+    };
+
+    it("rejects when customerId is not in bridge scope", async () => {
+      await pool.query(
+        `INSERT INTO account_customer_memberships (account_id, customer_id, role_id) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`,
+        [userAccountId, customerBId, userRoleId],
+      );
+
+      const result = await withClient((c) =>
+        authorize(c, "general", userAccountId, "workspace:read", {
+          customerId: customerBId,
+          bridgeScope,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+
+      await pool.query(
+        `DELETE FROM account_customer_memberships WHERE account_id = $1 AND customer_id = $2`,
+        [userAccountId, customerBId],
+      );
+    });
+
+    it("rejects when aiceId does not match bridge scope", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", userAccountId, "workspace:read", {
+          customerId: activeCustomerId,
+          aiceId: "other-aice.example.com",
+          bridgeScope,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // role_permissions change immediate effect (#35-5)
+  // -------------------------------------------------------------------------
+
+  describe("role_permissions change immediate effect", () => {
+    it("reflects permission removal immediately", async () => {
+      // Manager has customer-members:write
+      let result = await withClient((c) =>
+        authorize(c, "general", managerAccountId, "customer-members:write", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+
+      // Remove permission from Manager role
+      await pool.query(
+        `DELETE FROM role_permissions WHERE role_id = $1 AND permission = 'customer-members:write'`,
+        [managerRoleId],
+      );
+
+      result = await withClient((c) =>
+        authorize(c, "general", managerAccountId, "customer-members:write", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+
+      // Restore
+      await pool.query(
+        `INSERT INTO role_permissions (role_id, permission) VALUES ($1, 'customer-members:write')`,
+        [managerRoleId],
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // DB trigger rejection for admin role in membership (#38)
+  // -------------------------------------------------------------------------
+
+  describe("DB trigger rejection for admin role in membership", () => {
+    it("rejects inserting System Administrator role into memberships", async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO account_customer_memberships (account_id, customer_id, role_id) VALUES ($1, $2, $3)`,
+          [noAccessAccountId, activeCustomerId, sysAdminRoleId],
+        ),
+      ).rejects.toThrow(/auth_context=general/);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // assertAuthorized wrapper
+  // -------------------------------------------------------------------------
+
+  describe("assertAuthorized", () => {
+    it("throws HttpError 403 when not authorized", async () => {
+      await expect(
+        withClient((c) =>
+          assertAuthorized(c, "general", noAccessAccountId, "workspace:read", {
+            customerId: activeCustomerId,
+          }),
+        ),
+      ).rejects.toThrow(HttpError);
+
+      try {
+        await withClient((c) =>
+          assertAuthorized(c, "general", noAccessAccountId, "workspace:read", {
+            customerId: activeCustomerId,
+          }),
+        );
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpError);
+        expect((err as HttpError).statusCode).toBe(403);
+      }
+    });
+
+    it("returns permissions set when authorized", async () => {
+      const permissions = await withClient((c) =>
+        assertAuthorized(c, "general", userAccountId, "workspace:read", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(permissions).toBeInstanceOf(Set);
+      expect(permissions.has("workspace:read")).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // No membership and no analyst assignment
+  // -------------------------------------------------------------------------
+
+  describe("no access", () => {
+    it("rejects when account has no membership or analyst assignment", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", noAccessAccountId, "workspace:read", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(false);
+    });
+
+    it("rejects general context without customerId", async () => {
+      const result = await withClient((c) =>
+        authorize(c, "general", userAccountId, "workspace:read"),
+      );
+      expect(result.authorized).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Permission union — membership + analyst (#33)
+  // -------------------------------------------------------------------------
+
+  describe("permission union", () => {
+    it("analyst-only account gets analyst permissions for assigned customer", async () => {
+      // analystAccountId has no membership, only analyst assignment
+      const result = await withClient((c) =>
+        authorize(c, "general", analystAccountId, "analyses:configure", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+      expect(result.permissions?.has("dashboard:customize")).toBe(true);
+    });
+
+    it("union of membership + analyst when both exist", async () => {
+      // multiRoleAccountId: User in activeCustomerId + assign analyst to activeCustomerId
+      await pool.query(
+        `INSERT INTO analyst_customer_assignments (account_id, customer_id, assigned_by) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`,
+        [multiRoleAccountId, activeCustomerId, adminAccountId],
+      );
+
+      const result = await withClient((c) =>
+        authorize(c, "general", multiRoleAccountId, "analyses:configure", {
+          customerId: activeCustomerId,
+        }),
+      );
+      expect(result.authorized).toBe(true);
+      // Also has User permissions from membership
+      expect(result.permissions?.has("workspace:read")).toBe(true);
+      // And Analyst permissions
+      expect(result.permissions?.has("dashboard:customize")).toBe(true);
+
+      await pool.query(
+        `DELETE FROM analyst_customer_assignments WHERE account_id = $1 AND customer_id = $2`,
+        [multiRoleAccountId, activeCustomerId],
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Sessions DB invariant — admin + bridge CHECK violation (#35-6)
+  // -------------------------------------------------------------------------
+
+  describe("sessions DB invariant", () => {
+    it("rejects admin session with bridge context", async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent, bridge_aice_id, bridge_customer_ids)
+           VALUES ($1, 'admin', '127.0.0.1', 'test', 'some-aice.example.com', $2)`,
+          [adminAccountId, [activeCustomerId]],
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("rejects bridge_aice_id without bridge_customer_ids", async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent, bridge_aice_id)
+           VALUES ($1, 'general', '127.0.0.1', 'test', 'some-aice.example.com')`,
+          [userAccountId],
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("rejects bridge_customer_ids without bridge_aice_id", async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent, bridge_customer_ids)
+           VALUES ($1, 'general', '127.0.0.1', 'test', $2)`,
+          [userAccountId, [activeCustomerId]],
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // listAccessibleCustomers (#33, #33-1)
+  // -------------------------------------------------------------------------
+
+  describe("listAccessibleCustomers", () => {
+    it("returns union of membership + analyst customers", async () => {
+      // multiRoleAccountId: User in activeCustomerId, Manager in customerBId, Analyst in customerCId
+      const customers = await withClient((c) =>
+        listAccessibleCustomers(c, multiRoleAccountId),
+      );
+      const ids = customers.map((c) => c.id);
+      expect(ids).toContain(activeCustomerId);
+      expect(ids).toContain(customerBId);
+      expect(ids).toContain(customerCId);
+    });
+
+    it("excludes suspended customers", async () => {
+      await pool.query(
+        `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+         VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`,
+        [userAccountId, suspendedCustomerId, userRoleId],
+      );
+
+      const customers = await withClient((c) =>
+        listAccessibleCustomers(c, userAccountId),
+      );
+      const ids = customers.map((c) => c.id);
+      expect(ids).not.toContain(suspendedCustomerId);
+
+      await pool.query(
+        `DELETE FROM account_customer_memberships WHERE account_id = $1 AND customer_id = $2`,
+        [userAccountId, suspendedCustomerId],
+      );
+    });
+
+    it("restricts to bridge scope when provided", async () => {
+      const bridgeScope = {
+        aiceId: activeAiceId,
+        customerIds: [activeCustomerId],
+      };
+      const customers = await withClient((c) =>
+        listAccessibleCustomers(c, multiRoleAccountId, bridgeScope),
+      );
+      const ids = customers.map((c) => c.id);
+      expect(ids).toContain(activeCustomerId);
+      expect(ids).not.toContain(customerBId);
+      expect(ids).not.toContain(customerCId);
+    });
+
+    it("returns empty for account with no access", async () => {
+      const customers = await withClient((c) =>
+        listAccessibleCustomers(c, noAccessAccountId),
+      );
+      expect(customers).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // listAccessibleEnvironments (#33-2, #33-3)
+  // -------------------------------------------------------------------------
+
+  describe("listAccessibleEnvironments", () => {
+    it("returns active environments linked to customer", async () => {
+      const envs = await withClient((c) =>
+        listAccessibleEnvironments(c, activeCustomerId),
+      );
+      const ids = envs.map((e) => e.aiceId);
+      expect(ids).toContain(activeAiceId);
+      // suspendedAiceId is not linked to activeCustomerId, so not present
+    });
+
+    it("excludes suspended environments", async () => {
+      // Link suspended env to active customer
+      await pool.query(
+        `INSERT INTO aice_environment_customers (aice_id, customer_id)
+         VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+        [suspendedAiceId, activeCustomerId],
+      );
+
+      const envs = await withClient((c) =>
+        listAccessibleEnvironments(c, activeCustomerId),
+      );
+      const ids = envs.map((e) => e.aiceId);
+      expect(ids).not.toContain(suspendedAiceId);
+
+      await pool.query(
+        `DELETE FROM aice_environment_customers WHERE aice_id = $1 AND customer_id = $2`,
+        [suspendedAiceId, activeCustomerId],
+      );
+    });
+
+    it("restricts to bridge scope aiceId when provided", async () => {
+      // Add another active env linked to activeCustomerId
+      await pool.query(
+        `INSERT INTO aice_environments (aice_id, name, status)
+         VALUES ('other-active.example.com', 'Other Env', 'active') ON CONFLICT DO NOTHING`,
+      );
+      await pool.query(
+        `INSERT INTO aice_environment_customers (aice_id, customer_id)
+         VALUES ('other-active.example.com', $1) ON CONFLICT DO NOTHING`,
+        [activeCustomerId],
+      );
+
+      const bridgeScope = {
+        aiceId: activeAiceId,
+        customerIds: [activeCustomerId],
+      };
+      const envs = await withClient((c) =>
+        listAccessibleEnvironments(c, activeCustomerId, bridgeScope),
+      );
+      expect(envs).toHaveLength(1);
+      expect(envs[0].aiceId).toBe(activeAiceId);
+
+      await pool.query(
+        `DELETE FROM aice_environment_customers WHERE aice_id = 'other-active.example.com'`,
+      );
+      await pool.query(
+        `DELETE FROM aice_environments WHERE aice_id = 'other-active.example.com'`,
+      );
+    });
+  });
+});

--- a/src/lib/auth/__tests__/authorization.db.test.ts
+++ b/src/lib/auth/__tests__/authorization.db.test.ts
@@ -592,17 +592,18 @@ describe.skipIf(!hasPostgres)("authorize() (DB integration)", () => {
   // -------------------------------------------------------------------------
 
   describe("operationKind enforcement", () => {
-    const bridgeScope = {
+    // bridgeScope must be built lazily — describe runs before beforeAll.
+    const mkBridgeScope = () => ({
       aiceId: activeAiceId,
       customerIds: [activeCustomerId],
-    };
+    });
 
     it("rejects write in bridge session", async () => {
       const result = await withClient((c) =>
         authorize(c, "general", userAccountId, "workspace:read", {
           customerId: activeCustomerId,
           operationKind: "write",
-          bridgeScope,
+          bridgeScope: mkBridgeScope(),
         }),
       );
       expect(result.authorized).toBe(false);
@@ -613,7 +614,7 @@ describe.skipIf(!hasPostgres)("authorize() (DB integration)", () => {
         authorize(c, "general", userAccountId, "workspace:read", {
           customerId: activeCustomerId,
           operationKind: "read",
-          bridgeScope,
+          bridgeScope: mkBridgeScope(),
         }),
       );
       expect(result.authorized).toBe(true);
@@ -624,7 +625,7 @@ describe.skipIf(!hasPostgres)("authorize() (DB integration)", () => {
         authorize(c, "general", userAccountId, "workspace:read", {
           customerId: activeCustomerId,
           operationKind: "ingest",
-          bridgeScope,
+          bridgeScope: mkBridgeScope(),
         }),
       );
       expect(result.authorized).toBe(true);
@@ -635,7 +636,7 @@ describe.skipIf(!hasPostgres)("authorize() (DB integration)", () => {
         authorize(c, "general", userAccountId, "workspace:read", {
           customerId: activeCustomerId,
           operationKind: "process",
-          bridgeScope,
+          bridgeScope: mkBridgeScope(),
         }),
       );
       expect(result.authorized).toBe(true);
@@ -657,17 +658,17 @@ describe.skipIf(!hasPostgres)("authorize() (DB integration)", () => {
   // -------------------------------------------------------------------------
 
   describe("allowInBridge enforcement", () => {
-    const bridgeScope = {
+    const mkBridgeScope = () => ({
       aiceId: activeAiceId,
       customerIds: [activeCustomerId],
-    };
+    });
 
     it("rejects bridge session when allowInBridge=false", async () => {
       const result = await withClient((c) =>
         authorize(c, "general", managerAccountId, "customer-members:read", {
           customerId: activeCustomerId,
           allowInBridge: false,
-          bridgeScope,
+          bridgeScope: mkBridgeScope(),
         }),
       );
       expect(result.authorized).toBe(false);
@@ -689,7 +690,7 @@ describe.skipIf(!hasPostgres)("authorize() (DB integration)", () => {
           customerId: activeCustomerId,
           operationKind: "read",
           allowInBridge: false,
-          bridgeScope,
+          bridgeScope: mkBridgeScope(),
         }),
       );
       expect(result.authorized).toBe(false);
@@ -701,10 +702,10 @@ describe.skipIf(!hasPostgres)("authorize() (DB integration)", () => {
   // -------------------------------------------------------------------------
 
   describe("bridge scope restriction", () => {
-    const bridgeScope = {
+    const mkBridgeScope = () => ({
       aiceId: activeAiceId,
       customerIds: [activeCustomerId],
-    };
+    });
 
     it("rejects when customerId is not in bridge scope", async () => {
       await pool.query(
@@ -715,7 +716,7 @@ describe.skipIf(!hasPostgres)("authorize() (DB integration)", () => {
       const result = await withClient((c) =>
         authorize(c, "general", userAccountId, "workspace:read", {
           customerId: customerBId,
-          bridgeScope,
+          bridgeScope: mkBridgeScope(),
         }),
       );
       expect(result.authorized).toBe(false);
@@ -731,7 +732,7 @@ describe.skipIf(!hasPostgres)("authorize() (DB integration)", () => {
         authorize(c, "general", userAccountId, "workspace:read", {
           customerId: activeCustomerId,
           aiceId: "other-aice.example.com",
-          bridgeScope,
+          bridgeScope: mkBridgeScope(),
         }),
       );
       expect(result.authorized).toBe(false);

--- a/src/lib/auth/__tests__/session-validator.db.test.ts
+++ b/src/lib/auth/__tests__/session-validator.db.test.ts
@@ -1,0 +1,175 @@
+import { join } from "node:path";
+import type { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeAdminPool,
+  createTestDatabase,
+  dropTestDatabase,
+  hasPostgres,
+} from "../../db/__tests__/db-test-helpers";
+import { runMigrations } from "../../db/migrate";
+import {
+  SessionExpiredError,
+  SessionRevokedError,
+  validateSession,
+} from "../session-validator";
+
+const MIGRATIONS_DIR = join(process.cwd(), "migrations", "auth");
+const LOCK_ID = 1030;
+
+describe.skipIf(!hasPostgres)("validateSession (DB integration)", () => {
+  let pool: Pool;
+  let dbName: string;
+  let accountId: string;
+
+  const defaultPolicy = {
+    idle_timeout_minutes: 30,
+    absolute_timeout_minutes: 480,
+  };
+
+  beforeAll(async () => {
+    const result = await createTestDatabase("sessval", "auth");
+    pool = result.pool;
+    dbName = result.dbName;
+
+    await pool.query(`
+        DO $$ BEGIN
+          IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'aimer_auth') THEN
+            CREATE ROLE aimer_auth LOGIN PASSWORD 'changeme';
+          END IF;
+        END $$
+      `);
+
+    await runMigrations(pool, MIGRATIONS_DIR, LOCK_ID);
+
+    const acct = await pool.query<{ id: string }>(
+      `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name)
+         VALUES ('test-issuer', 'sv-001', 'svuser', 'Session Validator User')
+         RETURNING id`,
+    );
+    accountId = acct.rows[0].id;
+  });
+
+  afterAll(async () => {
+    await dropTestDatabase(dbName, pool, "auth");
+    await closeAdminPool();
+  });
+
+  it("returns session data for a valid session", async () => {
+    const sess = await pool.query<{ sid: string }>(
+      `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent)
+         VALUES ($1, 'general', '127.0.0.1', 'test') RETURNING sid`,
+      [accountId],
+    );
+
+    const result = await validateSession(pool, sess.rows[0].sid, defaultPolicy);
+    expect(result.bridgeAiceId).toBeNull();
+    expect(result.bridgeCustomerIds).toBeNull();
+    expect(result.createdAt).toBeGreaterThan(0);
+  });
+
+  it("returns bridge fields when present", async () => {
+    const custId = (
+      await pool.query<{ id: string }>(
+        `INSERT INTO customers (external_key, name) VALUES ('sv-cust', 'SV Customer') RETURNING id`,
+      )
+    ).rows[0].id;
+
+    await pool.query(
+      `INSERT INTO aice_environments (aice_id, name) VALUES ('sv-aice.example.com', 'SV Env') ON CONFLICT DO NOTHING`,
+    );
+
+    const sess = await pool.query<{ sid: string }>(
+      `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent, bridge_aice_id, bridge_customer_ids)
+         VALUES ($1, 'general', '127.0.0.1', 'test', 'sv-aice.example.com', $2) RETURNING sid`,
+      [accountId, [custId]],
+    );
+
+    const result = await validateSession(pool, sess.rows[0].sid, defaultPolicy);
+    expect(result.bridgeAiceId).toBe("sv-aice.example.com");
+    expect(result.bridgeCustomerIds).toContain(custId);
+  });
+
+  it("throws SessionRevokedError for revoked session", async () => {
+    const sess = await pool.query<{ sid: string }>(
+      `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent, revoked)
+         VALUES ($1, 'general', '127.0.0.1', 'test', true) RETURNING sid`,
+      [accountId],
+    );
+
+    await expect(
+      validateSession(pool, sess.rows[0].sid, defaultPolicy),
+    ).rejects.toThrow(SessionRevokedError);
+  });
+
+  it("throws SessionExpiredError(idle) for idle session", async () => {
+    const sess = await pool.query<{ sid: string }>(
+      `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent, last_active_at)
+         VALUES ($1, 'general', '127.0.0.1', 'test', NOW() - INTERVAL '31 minutes') RETURNING sid`,
+      [accountId],
+    );
+
+    await expect(
+      validateSession(pool, sess.rows[0].sid, defaultPolicy),
+    ).rejects.toThrow(SessionExpiredError);
+
+    try {
+      await validateSession(pool, sess.rows[0].sid, defaultPolicy);
+    } catch (err) {
+      expect((err as SessionExpiredError).reason).toBe("idle");
+    }
+  });
+
+  it("throws SessionExpiredError(absolute) for session past absolute timeout", async () => {
+    const sess = await pool.query<{ sid: string }>(
+      `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent, created_at, last_active_at)
+         VALUES ($1, 'general', '127.0.0.1', 'test', NOW() - INTERVAL '9 hours', NOW()) RETURNING sid`,
+      [accountId],
+    );
+
+    await expect(
+      validateSession(pool, sess.rows[0].sid, defaultPolicy),
+    ).rejects.toThrow(SessionExpiredError);
+
+    try {
+      await validateSession(pool, sess.rows[0].sid, defaultPolicy);
+    } catch (err) {
+      expect((err as SessionExpiredError).reason).toBe("absolute");
+    }
+  });
+
+  it("throws SessionExpiredError for non-existent session", async () => {
+    await expect(
+      validateSession(
+        pool,
+        "00000000-0000-0000-0000-000000000000",
+        defaultPolicy,
+      ),
+    ).rejects.toThrow(SessionExpiredError);
+  });
+
+  it("updates last_active_at on successful validation", async () => {
+    const sess = await pool.query<{ sid: string }>(
+      `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent, last_active_at)
+         VALUES ($1, 'general', '127.0.0.1', 'test', NOW() - INTERVAL '5 minutes') RETURNING sid`,
+      [accountId],
+    );
+    const sid = sess.rows[0].sid;
+
+    const before = await pool.query<{ last_active_at: Date }>(
+      `SELECT last_active_at FROM sessions WHERE sid = $1`,
+      [sid],
+    );
+
+    await validateSession(pool, sid, defaultPolicy);
+
+    const after = await pool.query<{ last_active_at: Date }>(
+      `SELECT last_active_at FROM sessions WHERE sid = $1`,
+      [sid],
+    );
+
+    expect(after.rows[0].last_active_at.getTime()).toBeGreaterThan(
+      before.rows[0].last_active_at.getTime(),
+    );
+  });
+});

--- a/src/lib/auth/authorization.ts
+++ b/src/lib/auth/authorization.ts
@@ -244,9 +244,30 @@ export interface AccessibleEnvironment {
 
 export async function listAccessibleEnvironments(
   client: PoolClient,
+  accountId: string,
   customerId: string,
   bridgeScope?: { aiceId: string; customerIds: string[] } | null,
 ): Promise<AccessibleEnvironment[]> {
+  // Verify the account has access to this customer (membership or analyst)
+  const accessRows = await client.query(
+    `SELECT 1 FROM account_customer_memberships
+     WHERE account_id = $1 AND customer_id = $2
+     UNION ALL
+     SELECT 1 FROM analyst_customer_assignments aca
+     JOIN accounts a ON a.id = aca.account_id AND a.analyst_eligible = true
+     WHERE aca.account_id = $1 AND aca.customer_id = $2
+     LIMIT 1`,
+    [accountId, customerId],
+  );
+  if (accessRows.rows.length === 0) {
+    return [];
+  }
+
+  // Bridge scope: verify customerId is within bridge scope
+  if (bridgeScope && !bridgeScope.customerIds.includes(customerId)) {
+    return [];
+  }
+
   const rows = await client.query<{
     aice_id: string;
     name: string;

--- a/src/lib/auth/authorization.ts
+++ b/src/lib/auth/authorization.ts
@@ -1,0 +1,297 @@
+import type { PoolClient } from "pg";
+import { HttpError } from "./errors";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type OperationKind = "read" | "write" | "ingest" | "process";
+
+export interface AuthorizeOptions {
+  customerId?: string;
+  aiceId?: string;
+  requiresAiceId?: boolean;
+  operationKind?: OperationKind;
+  /** If false, immediately reject in bridge sessions. Default: true. */
+  allowInBridge?: boolean;
+  bridgeScope?: { aiceId: string; customerIds: string[] } | null;
+}
+
+export interface AuthorizeResult {
+  authorized: boolean;
+  permissions?: Set<string>;
+}
+
+// ---------------------------------------------------------------------------
+// authorize — per-request DB authorization
+// ---------------------------------------------------------------------------
+
+export async function authorize(
+  client: PoolClient,
+  authContext: "general" | "admin",
+  accountId: string,
+  requiredPermission: string,
+  options: AuthorizeOptions = {},
+): Promise<AuthorizeResult> {
+  const {
+    customerId,
+    aiceId,
+    requiresAiceId = false,
+    operationKind,
+    allowInBridge = true,
+    bridgeScope = null,
+  } = options;
+
+  // 1. requiresAiceId enforcement
+  if (requiresAiceId && !aiceId) {
+    return { authorized: false };
+  }
+
+  // 2. Bridge scope restriction
+  if (bridgeScope) {
+    if (!allowInBridge) {
+      return { authorized: false };
+    }
+    if (operationKind === "write") {
+      return { authorized: false };
+    }
+    if (customerId && !bridgeScope.customerIds.includes(customerId)) {
+      return { authorized: false };
+    }
+    if (aiceId && aiceId !== bridgeScope.aiceId) {
+      return { authorized: false };
+    }
+  }
+
+  // 3. Admin context
+  if (authContext === "admin") {
+    return authorizeAdmin(client, accountId, requiredPermission);
+  }
+
+  // 4. General context — customerId required
+  if (!customerId) {
+    return { authorized: false };
+  }
+
+  // Verify customer is active
+  const customerRows = await client.query<{ status: string }>(
+    `SELECT status FROM customers WHERE id = $1`,
+    [customerId],
+  );
+  if (
+    customerRows.rows.length === 0 ||
+    customerRows.rows[0].status !== "active"
+  ) {
+    return { authorized: false };
+  }
+
+  // 5. aiceId validation (if provided)
+  if (aiceId) {
+    const envRows = await client.query<{ status: string }>(
+      `SELECT status FROM aice_environments WHERE aice_id = $1`,
+      [aiceId],
+    );
+    if (envRows.rows.length === 0 || envRows.rows[0].status !== "active") {
+      return { authorized: false };
+    }
+
+    const linkRows = await client.query(
+      `SELECT 1 FROM aice_environment_customers
+       WHERE aice_id = $1 AND customer_id = $2`,
+      [aiceId, customerId],
+    );
+    if (linkRows.rows.length === 0) {
+      return { authorized: false };
+    }
+  }
+
+  // 6. Permission union — membership + analyst
+  return authorizeGeneral(client, accountId, customerId, requiredPermission);
+}
+
+// ---------------------------------------------------------------------------
+// Admin context authorization
+// ---------------------------------------------------------------------------
+
+async function authorizeAdmin(
+  client: PoolClient,
+  accountId: string,
+  requiredPermission: string,
+): Promise<AuthorizeResult> {
+  const accountRows = await client.query<{ admin_eligible: boolean }>(
+    `SELECT admin_eligible FROM accounts WHERE id = $1`,
+    [accountId],
+  );
+  if (accountRows.rows.length === 0 || !accountRows.rows[0].admin_eligible) {
+    return { authorized: false };
+  }
+
+  const permRows = await client.query<{ permission: string }>(
+    `SELECT rp.permission
+     FROM role_permissions rp
+     JOIN roles r ON r.id = rp.role_id
+     WHERE r.name = 'System Administrator' AND r.auth_context = 'admin'`,
+  );
+
+  const permissions = new Set(permRows.rows.map((r) => r.permission));
+  return {
+    authorized: permissions.has(requiredPermission),
+    permissions,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// General context authorization — union of membership + analyst
+// ---------------------------------------------------------------------------
+
+async function authorizeGeneral(
+  client: PoolClient,
+  accountId: string,
+  customerId: string,
+  requiredPermission: string,
+): Promise<AuthorizeResult> {
+  // Single query: union of membership permissions + analyst permissions.
+  // Analyst branch requires analyst_eligible=true AND an active assignment.
+  const rows = await client.query<{ permission: string }>(
+    `SELECT DISTINCT rp.permission
+     FROM account_customer_memberships acm
+     JOIN role_permissions rp ON rp.role_id = acm.role_id
+     WHERE acm.account_id = $1 AND acm.customer_id = $2
+     UNION
+     SELECT DISTINCT rp.permission
+     FROM analyst_customer_assignments aca
+     JOIN accounts a ON a.id = aca.account_id AND a.analyst_eligible = true
+     JOIN roles r ON r.name = 'Analyst' AND r.auth_context = 'general'
+     JOIN role_permissions rp ON rp.role_id = r.id
+     WHERE aca.account_id = $1 AND aca.customer_id = $2`,
+    [accountId, customerId],
+  );
+
+  if (rows.rows.length === 0) {
+    return { authorized: false };
+  }
+
+  const permissions = new Set(rows.rows.map((r) => r.permission));
+  return {
+    authorized: permissions.has(requiredPermission),
+    permissions,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// listAccessibleCustomers — union of membership + analyst, with bridge scope
+// ---------------------------------------------------------------------------
+
+export interface AccessibleCustomer {
+  id: string;
+  name: string;
+  externalKey: string;
+}
+
+export async function listAccessibleCustomers(
+  client: PoolClient,
+  accountId: string,
+  bridgeScope?: { aiceId: string; customerIds: string[] } | null,
+): Promise<AccessibleCustomer[]> {
+  // Union of membership customers and analyst-assigned customers (active only)
+  const rows = await client.query<{
+    id: string;
+    name: string;
+    external_key: string;
+  }>(
+    `SELECT DISTINCT c.id, c.name, c.external_key
+     FROM customers c
+     WHERE c.status = 'active'
+       AND (
+         EXISTS (
+           SELECT 1 FROM account_customer_memberships acm
+           WHERE acm.account_id = $1 AND acm.customer_id = c.id
+         )
+         OR EXISTS (
+           SELECT 1 FROM analyst_customer_assignments aca
+           JOIN accounts a ON a.id = aca.account_id
+           WHERE aca.account_id = $1 AND aca.customer_id = c.id
+             AND a.analyst_eligible = true
+         )
+       )
+     ORDER BY c.name`,
+    [accountId],
+  );
+
+  let customers = rows.rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    externalKey: r.external_key,
+  }));
+
+  // Bridge scope restriction
+  if (bridgeScope) {
+    const scopeSet = new Set(bridgeScope.customerIds);
+    customers = customers.filter((c) => scopeSet.has(c.id));
+  }
+
+  return customers;
+}
+
+// ---------------------------------------------------------------------------
+// listAccessibleEnvironments — environments linked to a customer
+// ---------------------------------------------------------------------------
+
+export interface AccessibleEnvironment {
+  aiceId: string;
+  name: string;
+}
+
+export async function listAccessibleEnvironments(
+  client: PoolClient,
+  customerId: string,
+  bridgeScope?: { aiceId: string; customerIds: string[] } | null,
+): Promise<AccessibleEnvironment[]> {
+  const rows = await client.query<{
+    aice_id: string;
+    name: string;
+  }>(
+    `SELECT ae.aice_id, ae.name
+     FROM aice_environments ae
+     JOIN aice_environment_customers aec ON aec.aice_id = ae.aice_id
+     WHERE aec.customer_id = $1 AND ae.status = 'active'
+     ORDER BY ae.name`,
+    [customerId],
+  );
+
+  let environments = rows.rows.map((r) => ({
+    aiceId: r.aice_id,
+    name: r.name,
+  }));
+
+  // Bridge scope restriction: only the bridge's aice_id
+  if (bridgeScope) {
+    environments = environments.filter((e) => e.aiceId === bridgeScope.aiceId);
+  }
+
+  return environments;
+}
+
+// ---------------------------------------------------------------------------
+// assertAuthorized — throwing wrapper
+// ---------------------------------------------------------------------------
+
+export async function assertAuthorized(
+  client: PoolClient,
+  authContext: "general" | "admin",
+  accountId: string,
+  requiredPermission: string,
+  options: AuthorizeOptions = {},
+): Promise<Set<string>> {
+  const result = await authorize(
+    client,
+    authContext,
+    accountId,
+    requiredPermission,
+    options,
+  );
+  if (!result.authorized) {
+    throw new HttpError("Forbidden", 403);
+  }
+  return result.permissions ?? new Set();
+}

--- a/src/lib/auth/guards.ts
+++ b/src/lib/auth/guards.ts
@@ -1,5 +1,5 @@
 import type { NextRequest } from "next/server";
-import { getAuthPool, query } from "../db/client";
+import { getAuthPool } from "../db/client";
 import type { AuthContext } from "./cookies";
 import { getAuthCookie, setAuthCookies } from "./cookies";
 import { validateCsrf } from "./csrf";
@@ -8,6 +8,11 @@ import type { RequestMeta } from "./request-meta";
 import { extractRequestMeta } from "./request-meta";
 import { maybeRotateSession } from "./rotation";
 import { getSessionPolicy } from "./session-policy";
+import {
+  SessionExpiredError,
+  SessionRevokedError,
+  validateSession,
+} from "./session-validator";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -20,6 +25,8 @@ export interface AuthenticatedRequest {
   tokenVersion: number;
   iat: number;
   meta: RequestMeta;
+  bridgeAiceId: string | null;
+  bridgeCustomerIds: string[] | null;
 }
 
 export interface LogoutAuthRequest {
@@ -55,35 +62,28 @@ export function withAuth(
     // Session policy check
     const policy = await getSessionPolicy();
     const ctxPolicy = policy[ctx];
-    const now = Math.floor(Date.now() / 1000);
 
-    const session = await query<{
-      created_at: Date;
-      last_active_at: Date;
-    }>(
-      getAuthPool(),
-      `SELECT created_at, last_active_at FROM sessions WHERE sid = $1`,
-      [claims.sid],
-    );
-
-    if (session.length > 0) {
-      const createdAt = Math.floor(session[0].created_at.getTime() / 1000);
-      const lastActive = Math.floor(session[0].last_active_at.getTime() / 1000);
-      const idleSeconds = ctxPolicy.idle_timeout_minutes * 60;
-      const absoluteSeconds = ctxPolicy.absolute_timeout_minutes * 60;
-
-      if (now - lastActive > idleSeconds) {
+    let bridgeAiceId: string | null = null;
+    let bridgeCustomerIds: string[] | null = null;
+    try {
+      const session = await validateSession(
+        getAuthPool(),
+        claims.sid,
+        ctxPolicy,
+      );
+      bridgeAiceId = session.bridgeAiceId;
+      bridgeCustomerIds = session.bridgeCustomerIds;
+    } catch (err) {
+      if (err instanceof SessionExpiredError) {
         return Response.json(
-          { error: "Session expired (idle)" },
+          { error: `Session expired (${err.reason})` },
           { status: 401 },
         );
       }
-      if (now - createdAt > absoluteSeconds) {
-        return Response.json(
-          { error: "Session expired (absolute)" },
-          { status: 401 },
-        );
+      if (err instanceof SessionRevokedError) {
+        return Response.json({ error: "Session revoked" }, { status: 401 });
       }
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     // Rotation
@@ -97,13 +97,6 @@ export function withAuth(
       });
     }
 
-    // Update last_active_at
-    await query(
-      getAuthPool(),
-      `UPDATE sessions SET last_active_at = NOW() WHERE sid = $1`,
-      [claims.sid],
-    );
-
     const meta = extractRequestMeta(req);
 
     return handler(req, {
@@ -113,6 +106,8 @@ export function withAuth(
       tokenVersion: claims.tv,
       iat: rotation.rotated && rotation.iat ? rotation.iat : claims.iat,
       meta,
+      bridgeAiceId,
+      bridgeCustomerIds,
     });
   };
 }

--- a/src/lib/auth/jwt.ts
+++ b/src/lib/auth/jwt.ts
@@ -138,11 +138,13 @@ export async function verifyJwtFull(
     needs_reauth: boolean;
     account_status: string;
     account_token_version: number;
+    admin_eligible: boolean;
   }>(
     getAuthPool(),
     `SELECT s.revoked, s.needs_reauth,
             a.status AS account_status,
-            a.token_version AS account_token_version
+            a.token_version AS account_token_version,
+            a.admin_eligible
      FROM sessions s
      JOIN accounts a ON a.id = s.account_id
      WHERE s.sid = $1`,
@@ -165,6 +167,10 @@ export async function verifyJwtFull(
   }
   if (row.account_token_version !== claims.tv) {
     throw new Error("Token version mismatch");
+  }
+  // Fail-closed: admin sessions require admin_eligible flag
+  if (claims.ctx === "admin" && !row.admin_eligible) {
+    throw new Error("Account not admin-eligible");
   }
 
   return claims;

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -4,6 +4,11 @@ import { HttpError } from "./errors";
 /**
  * Assert that the given account has a specific permission for the given
  * customer. Throws 403 if the permission is not found.
+ *
+ * @deprecated Use {@link authorize} or {@link assertAuthorized} from
+ * `authorization.ts` instead — they check both membership and analyst
+ * permissions (union), enforce bridge scope, and validate customer/environment
+ * status.
  */
 export async function assertPermission(
   client: PoolClient,
@@ -27,6 +32,8 @@ export async function assertPermission(
 /**
  * Assert that the given account has Manager-level write permission
  * (`customer-members:write`) for the given customer.
+ *
+ * @deprecated Use {@link assertAuthorized} from `authorization.ts` instead.
  */
 export async function assertManagerPermission(
   client: PoolClient,

--- a/src/lib/auth/session-validator.ts
+++ b/src/lib/auth/session-validator.ts
@@ -1,0 +1,89 @@
+import type { Pool } from "pg";
+import { query } from "../db/client";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ValidatedSession {
+  createdAt: number;
+  lastActiveAt: number;
+  bridgeAiceId: string | null;
+  bridgeCustomerIds: string[] | null;
+}
+
+export class SessionExpiredError extends Error {
+  readonly reason: "idle" | "absolute";
+
+  constructor(reason: "idle" | "absolute") {
+    super(`Session expired (${reason})`);
+    this.reason = reason;
+  }
+}
+
+export class SessionRevokedError extends Error {
+  constructor() {
+    super("Session revoked");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// validateSession — revoked check, timeouts, last_active_at update
+// ---------------------------------------------------------------------------
+
+export async function validateSession(
+  pool: Pool,
+  sid: string,
+  ctxPolicy: { idle_timeout_minutes: number; absolute_timeout_minutes: number },
+): Promise<ValidatedSession> {
+  const rows = await query<{
+    revoked: boolean;
+    created_at: Date;
+    last_active_at: Date;
+    bridge_aice_id: string | null;
+    bridge_customer_ids: string[] | null;
+  }>(
+    pool,
+    `SELECT revoked, created_at, last_active_at, bridge_aice_id, bridge_customer_ids
+     FROM sessions WHERE sid = $1`,
+    [sid],
+  );
+
+  if (rows.length === 0) {
+    throw new SessionExpiredError("absolute");
+  }
+
+  const row = rows[0];
+
+  // Revoked check
+  if (row.revoked) {
+    throw new SessionRevokedError();
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const createdAt = Math.floor(row.created_at.getTime() / 1000);
+  const lastActiveAt = Math.floor(row.last_active_at.getTime() / 1000);
+  const idleSeconds = ctxPolicy.idle_timeout_minutes * 60;
+  const absoluteSeconds = ctxPolicy.absolute_timeout_minutes * 60;
+
+  if (now - lastActiveAt > idleSeconds) {
+    throw new SessionExpiredError("idle");
+  }
+  if (now - createdAt > absoluteSeconds) {
+    throw new SessionExpiredError("absolute");
+  }
+
+  // Update last_active_at
+  await query(
+    pool,
+    `UPDATE sessions SET last_active_at = NOW() WHERE sid = $1`,
+    [sid],
+  );
+
+  return {
+    createdAt,
+    lastActiveAt,
+    bridgeAiceId: row.bridge_aice_id,
+    bridgeCustomerIds: row.bridge_customer_ids,
+  };
+}


### PR DESCRIPTION
## Summary

Implement the `authorize()` function and supporting infrastructure for per-request DB authorization. JWT remains authentication-only; `authorize()` checks permissions via DB lookup on every call, so permission/role/membership changes take effect immediately.

**Note:** This PR adds the authorization primitives and tests. Existing endpoint handlers (`members.ts`, `invitations.ts`, `invitation-management.ts`) still use the old `assertPermission` helpers, which work correctly for the membership-only case. Migration of those callers to `authorize()` is a follow-up.

### What's included

- `authorize()` with permission union (membership + analyst), bridge scope enforcement, `operationKind`/`allowInBridge` blocking, `requiresAiceId`, inactive customer/environment rejection
- `session-validator.ts`: revoked check, idle/absolute timeouts, `last_active_at` update, bridge field retrieval
- `verifyJwtFull` admin_eligible fail-closed defense
- `listAccessibleCustomers`/`listAccessibleEnvironments` with account-level access checks and bridge scope filtering
- `assertAuthorized()` throwing wrapper
- `@deprecated` annotations on old `assertPermission` helpers

## Test plan

- [x] 59 DB integration tests pass (`pnpm vitest run src/lib/auth/__tests__/authorization.db.test.ts src/lib/auth/__tests__/session-validator.db.test.ts`)
- [x] 12 E2E tests pass (`pnpm playwright test e2e/authorization-api.spec.ts`)
- [x] All existing auth tests still pass (`pnpm vitest run src/lib/auth/__tests__/`)
- [x] `pnpm typecheck` passes
- [x] `pnpm biome check` passes

Closes #29