### PR TITLE
Fix test cleanup race in dropTestDatabase

### DIFF
--- a/src/lib/db/__tests__/db-test-helpers.ts
+++ b/src/lib/db/__tests__/db-test-helpers.ts
@@ -67,18 +67,27 @@ export async function dropTestDatabase(
   pool?: Pool,
   scope: "auth" | "audit" = "auth",
 ): Promise<void> {
-  if (pool) {
-    await pool.end();
-  }
   const adminUrl = (
     scope === "audit" ? AUDIT_ADMIN_URL : AUTH_ADMIN_URL
   ) as string;
   const admin = getAdminPool(adminUrl);
+
+  // Suppress error events BEFORE terminating backends — the FATAL
+  // arrives asynchronously and may fire before pool.end() is called.
+  if (pool) {
+    pool.on("error", () => {});
+  }
+
   await admin.query(`
     SELECT pg_terminate_backend(pid)
     FROM pg_stat_activity
     WHERE datname = '${dbName}' AND pid <> pg_backend_pid()
   `);
+
+  if (pool) {
+    await pool.end();
+  }
+
   await admin.query(`DROP DATABASE IF EXISTS ${dbName}`);
 }
 


### PR DESCRIPTION
## Summary

- Reorder `dropTestDatabase()` to call `pg_terminate_backend()` before `pool.end()`, preventing unhandled "connection terminated" error events during test teardown.
- Add a no-op `pool.on("error")` handler to suppress any late-arriving errors from the terminated connections.

Closes #98