### PR TITLE
Add configurable session policy API

### DIFF
--- a/e2e/session-policy-api.spec.ts
+++ b/e2e/session-policy-api.spec.ts
@@ -1,0 +1,286 @@
+import { expect as baseExpect, test as baseTest } from "@playwright/test";
+import { expect, test } from "./fixtures";
+
+// ---------------------------------------------------------------------------
+// E2E session policy tests — verify that the session policy API enforces
+// admin-only access, validates input, and persists/returns policy values.
+//
+// Unauthenticated HTTP layer tests use base Playwright (no fixtures).
+// Authenticated tests use the custom fixtures with admin/general sessions.
+// ---------------------------------------------------------------------------
+
+const ORIGIN = "http://localhost:3000";
+
+// =========================================================================
+// Unauthenticated — auth enforcement and method routing
+// =========================================================================
+
+baseTest.describe("GET /api/admin/session-policy — unauthenticated", () => {
+  baseTest("returns 401 without auth cookie", async ({ request }) => {
+    const res = await request.get("/api/admin/session-policy");
+    baseExpect(res.status()).toBe(401);
+    const body = await res.json();
+    baseExpect(body.error).toBe("Unauthorized");
+  });
+
+  baseTest("returns 401 with invalid auth cookie", async ({ context }) => {
+    await context.addCookies([
+      {
+        name: "at_admin",
+        value: "invalid-jwt-token",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+
+    const res = await context.request.get("/api/admin/session-policy");
+    baseExpect(res.status()).toBe(401);
+  });
+});
+
+baseTest.describe("PUT /api/admin/session-policy — unauthenticated", () => {
+  baseTest("returns 401 without auth cookie", async ({ request }) => {
+    const res = await request.put("/api/admin/session-policy", {
+      headers: { origin: ORIGIN },
+      data: {},
+    });
+    baseExpect(res.status()).toBe(401);
+    const body = await res.json();
+    baseExpect(body.error).toBe("Unauthorized");
+  });
+
+  baseTest("returns 401 with invalid auth cookie", async ({ context }) => {
+    await context.addCookies([
+      {
+        name: "at_admin",
+        value: "invalid-jwt-token",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+
+    const res = await context.request.put("/api/admin/session-policy", {
+      headers: { origin: ORIGIN },
+      data: {},
+    });
+    baseExpect(res.status()).toBe(401);
+  });
+});
+
+baseTest.describe("/api/admin/session-policy — unsupported methods", () => {
+  baseTest("returns 405 for POST", async ({ request }) => {
+    const res = await request.post("/api/admin/session-policy", {
+      headers: { origin: ORIGIN },
+      data: {},
+    });
+    baseExpect(res.status()).toBe(405);
+  });
+
+  baseTest("returns 405 for DELETE", async ({ request }) => {
+    const res = await request.delete("/api/admin/session-policy");
+    baseExpect(res.status()).toBe(405);
+  });
+
+  baseTest("returns 405 for PATCH", async ({ request }) => {
+    const res = await request.patch("/api/admin/session-policy", {
+      headers: { origin: ORIGIN },
+      data: {},
+    });
+    baseExpect(res.status()).toBe(405);
+  });
+});
+
+// =========================================================================
+// Authenticated — admin can read and update policy
+// =========================================================================
+
+test.describe("GET /api/admin/session-policy — authenticated admin", () => {
+  test("admin can read session policy", async ({ adminPage }) => {
+    const res = await adminPage.request.get("/api/admin/session-policy");
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(body.policy).toBeDefined();
+    expect(body.policy.general).toBeDefined();
+    expect(body.policy.admin).toBeDefined();
+    expect(typeof body.policy.general.idle_timeout_minutes).toBe("number");
+    expect(typeof body.policy.general.absolute_timeout_minutes).toBe("number");
+    expect(typeof body.policy.admin.idle_timeout_minutes).toBe("number");
+    expect(typeof body.policy.admin.absolute_timeout_minutes).toBe("number");
+  });
+});
+
+test.describe("PUT /api/admin/session-policy — authenticated admin", () => {
+  test("admin can update session policy", async ({ adminPage }) => {
+    const newPolicy = {
+      general: { idle_timeout_minutes: 45, absolute_timeout_minutes: 600 },
+      admin: { idle_timeout_minutes: 10, absolute_timeout_minutes: 90 },
+    };
+
+    // Read CSRF from cookies
+    const cookies = await adminPage.context().cookies();
+    const csrfValue = cookies.find((c) => c.name === "csrf_admin")?.value;
+    expect(csrfValue).toBeDefined();
+
+    const res = await adminPage.request.put("/api/admin/session-policy", {
+      headers: { origin: ORIGIN, "x-csrf-token-admin": csrfValue as string },
+      data: newPolicy,
+    });
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(body.policy).toEqual(newPolicy);
+
+    // Verify the change persisted by reading it back
+    const getRes = await adminPage.request.get("/api/admin/session-policy");
+    const getBody = await getRes.json();
+    expect(getBody.policy).toEqual(newPolicy);
+
+    // Clean up — restore defaults so other tests are not affected
+    await adminPage.request.put("/api/admin/session-policy", {
+      headers: { origin: ORIGIN, "x-csrf-token-admin": csrfValue as string },
+      data: {
+        general: { idle_timeout_minutes: 30, absolute_timeout_minutes: 480 },
+        admin: { idle_timeout_minutes: 15, absolute_timeout_minutes: 120 },
+      },
+    });
+  });
+
+  test("rejects idle floor violation", async ({ adminPage }) => {
+    const cookies = await adminPage.context().cookies();
+    const csrfValue = cookies.find((c) => c.name === "csrf_admin")?.value;
+
+    const res = await adminPage.request.put("/api/admin/session-policy", {
+      headers: { origin: ORIGIN, "x-csrf-token-admin": csrfValue as string },
+      data: {
+        general: { idle_timeout_minutes: 2, absolute_timeout_minutes: 480 },
+        admin: { idle_timeout_minutes: 15, absolute_timeout_minutes: 120 },
+      },
+    });
+    expect(res.status()).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toContain("idle_timeout_minutes must be at least");
+  });
+
+  test("rejects absolute floor violation", async ({ adminPage }) => {
+    const cookies = await adminPage.context().cookies();
+    const csrfValue = cookies.find((c) => c.name === "csrf_admin")?.value;
+
+    const res = await adminPage.request.put("/api/admin/session-policy", {
+      headers: { origin: ORIGIN, "x-csrf-token-admin": csrfValue as string },
+      data: {
+        general: { idle_timeout_minutes: 30, absolute_timeout_minutes: 480 },
+        admin: { idle_timeout_minutes: 15, absolute_timeout_minutes: 30 },
+      },
+    });
+    expect(res.status()).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toContain("absolute_timeout_minutes must be at least");
+  });
+
+  test("rejects PUT without CSRF token", async ({ adminPage }) => {
+    const res = await adminPage.request.put("/api/admin/session-policy", {
+      headers: { origin: ORIGIN },
+      data: {
+        general: { idle_timeout_minutes: 30, absolute_timeout_minutes: 480 },
+        admin: { idle_timeout_minutes: 15, absolute_timeout_minutes: 120 },
+      },
+    });
+    expect(res.status()).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("CSRF token required");
+  });
+
+  test("rejects PUT with wrong origin", async ({ adminPage }) => {
+    const cookies = await adminPage.context().cookies();
+    const csrfValue = cookies.find((c) => c.name === "csrf_admin")?.value;
+
+    const res = await adminPage.request.put("/api/admin/session-policy", {
+      headers: {
+        origin: "https://evil.example.com",
+        "x-csrf-token-admin": csrfValue as string,
+      },
+      data: {
+        general: { idle_timeout_minutes: 30, absolute_timeout_minutes: 480 },
+        admin: { idle_timeout_minutes: 15, absolute_timeout_minutes: 120 },
+      },
+    });
+    expect(res.status()).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Origin mismatch");
+  });
+
+  test("rejects invalid JSON body structure", async ({ adminPage }) => {
+    const cookies = await adminPage.context().cookies();
+    const csrfValue = cookies.find((c) => c.name === "csrf_admin")?.value;
+
+    const res = await adminPage.request.put("/api/admin/session-policy", {
+      headers: { origin: ORIGIN, "x-csrf-token-admin": csrfValue as string },
+      data: { general: { idle_timeout_minutes: "not-a-number" } },
+    });
+    expect(res.status()).toBe(400);
+  });
+});
+
+// =========================================================================
+// Authenticated — updated policy does not break subsequent auth
+// =========================================================================
+
+test.describe("Session policy — post-update auth smoke test", () => {
+  test("admin request succeeds after policy tightened to minimum", async ({
+    adminPage,
+  }) => {
+    const cookies = await adminPage.context().cookies();
+    const csrfValue = cookies.find((c) => c.name === "csrf_admin")?.value;
+    expect(csrfValue).toBeDefined();
+
+    // Tighten policy to minimum allowed values and verify the subsequent
+    // authenticated GET still succeeds (the session is fresh, so it passes
+    // under any valid policy). This is a smoke test — it confirms that
+    // the full withAuth → getSessionPolicy → validateSession path does not
+    // error after an update, but does not prove cache invalidation on its
+    // own (that would require a session whose age falls between old and
+    // new thresholds, which is impractical in E2E without DB manipulation).
+    const tightPolicy = {
+      general: { idle_timeout_minutes: 5, absolute_timeout_minutes: 60 },
+      admin: { idle_timeout_minutes: 5, absolute_timeout_minutes: 60 },
+    };
+
+    const putRes = await adminPage.request.put("/api/admin/session-policy", {
+      headers: { origin: ORIGIN, "x-csrf-token-admin": csrfValue as string },
+      data: tightPolicy,
+    });
+    expect(putRes.status()).toBe(200);
+
+    const getRes = await adminPage.request.get("/api/admin/session-policy");
+    expect(getRes.status()).toBe(200);
+    const body = await getRes.json();
+    expect(body.policy).toEqual(tightPolicy);
+
+    // Restore defaults
+    await adminPage.request.put("/api/admin/session-policy", {
+      headers: { origin: ORIGIN, "x-csrf-token-admin": csrfValue as string },
+      data: {
+        general: { idle_timeout_minutes: 30, absolute_timeout_minutes: 480 },
+        admin: { idle_timeout_minutes: 15, absolute_timeout_minutes: 120 },
+      },
+    });
+  });
+});
+
+// =========================================================================
+// Authenticated — general-context user cannot access admin endpoint
+// =========================================================================
+
+test.describe("Session policy — general context rejection", () => {
+  test("general-context user gets 401 on admin endpoint", async ({
+    managerPage,
+  }) => {
+    // General-context cookies (at, csrf) are set, but admin endpoint
+    // requires admin-context cookies (at_admin, csrf_admin).
+    const res = await managerPage.request.get("/api/admin/session-policy");
+    expect(res.status()).toBe(401);
+  });
+});

--- a/src/app/api/admin/session-policy/route.ts
+++ b/src/app/api/admin/session-policy/route.ts
@@ -1,0 +1,82 @@
+import type { NextRequest } from "next/server";
+import { auditLog } from "@/lib/auth/audit-stub";
+import { HttpError } from "@/lib/auth/errors";
+import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
+import {
+  clearSessionPolicyCache,
+  readSessionPolicy,
+  updateSessionPolicy,
+} from "@/lib/auth/session-policy";
+import { getAuthPool, withTransaction } from "@/lib/db/client";
+
+export const GET = withAuth(
+  async (_req: NextRequest, auth) => {
+    try {
+      const policy = await withTransaction(getAuthPool(), (client) =>
+        readSessionPolicy(client, auth.accountId),
+      );
+
+      return Response.json({ policy });
+    } catch (err: unknown) {
+      if (err instanceof HttpError) {
+        return Response.json(
+          { error: err.message },
+          { status: err.statusCode },
+        );
+      }
+      throw err;
+    }
+  },
+  { ctx: "admin" },
+);
+
+export const PUT = withAuth(
+  async (req: NextRequest, auth) => {
+    const originErr = verifyOrigin(req);
+    if (originErr) return originErr;
+
+    const csrfErr = verifyCsrf(req, {
+      ctx: "admin",
+      sid: auth.sessionId,
+      iat: auth.iat,
+    });
+    if (csrfErr) return csrfErr;
+
+    let raw: unknown;
+    try {
+      raw = await req.json();
+    } catch {
+      return Response.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    try {
+      const policy = await withTransaction(getAuthPool(), (client) =>
+        updateSessionPolicy(client, auth.accountId, raw),
+      );
+
+      clearSessionPolicyCache();
+
+      await auditLog({
+        actorId: auth.accountId,
+        authContext: "admin",
+        action: "session-policy.update",
+        targetType: "system-settings",
+        targetId: "session_policy",
+        details: { policy },
+        ipAddress: auth.meta.ipAddress,
+        sid: auth.sessionId,
+      });
+
+      return Response.json({ policy });
+    } catch (err: unknown) {
+      if (err instanceof HttpError) {
+        return Response.json(
+          { error: err.message },
+          { status: err.statusCode },
+        );
+      }
+      throw err;
+    }
+  },
+  { ctx: "admin" },
+);

--- a/src/lib/auth/__tests__/session-policy.db.test.ts
+++ b/src/lib/auth/__tests__/session-policy.db.test.ts
@@ -1,0 +1,371 @@
+import { join } from "node:path";
+import type { Pool, PoolClient } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeAdminPool,
+  createTestDatabase,
+  dropTestDatabase,
+  hasPostgres,
+} from "../../db/__tests__/db-test-helpers";
+import { runMigrations } from "../../db/migrate";
+import { HttpError } from "../errors";
+import {
+  clearSessionPolicyCache,
+  DEFAULT_POLICY,
+  MIN_ABSOLUTE_MINUTES,
+  MIN_IDLE_MINUTES,
+  readSessionPolicy,
+  updateSessionPolicy,
+} from "../session-policy";
+
+const MIGRATIONS_DIR = join(process.cwd(), "migrations", "auth");
+const LOCK_ID = 1031;
+
+describe.skipIf(!hasPostgres)(
+  "readSessionPolicy / updateSessionPolicy (DB integration)",
+  () => {
+    let pool: Pool;
+    let dbName: string;
+
+    let adminAccountId: string;
+    let nonAdminAccountId: string;
+
+    async function withClient<T>(
+      fn: (client: PoolClient) => Promise<T>,
+    ): Promise<T> {
+      const client = await pool.connect();
+      try {
+        return await fn(client);
+      } finally {
+        client.release();
+      }
+    }
+
+    beforeAll(async () => {
+      const result = await createTestDatabase("sesspol", "auth");
+      pool = result.pool;
+      dbName = result.dbName;
+
+      await pool.query(`
+        DO $$ BEGIN
+          IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'aimer_auth') THEN
+            CREATE ROLE aimer_auth LOGIN PASSWORD 'changeme';
+          END IF;
+        END $$
+      `);
+
+      await runMigrations(pool, MIGRATIONS_DIR, LOCK_ID);
+
+      // Create admin-eligible account
+      const admin = await pool.query<{ id: string }>(
+        `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, admin_eligible)
+         VALUES ('test-issuer', 'sp-admin-001', 'spadmin', 'SP Admin', true)
+         RETURNING id`,
+      );
+      adminAccountId = admin.rows[0].id;
+
+      // Create non-admin account
+      const user = await pool.query<{ id: string }>(
+        `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, admin_eligible)
+         VALUES ('test-issuer', 'sp-user-001', 'spuser', 'SP User', false)
+         RETURNING id`,
+      );
+      nonAdminAccountId = user.rows[0].id;
+    });
+
+    afterAll(async () => {
+      clearSessionPolicyCache();
+      await dropTestDatabase(dbName, pool, "auth");
+      await closeAdminPool();
+    });
+
+    // ----- readSessionPolicy -----
+
+    it("returns default policy when no row exists", async () => {
+      const policy = await withClient((client) =>
+        readSessionPolicy(client, adminAccountId),
+      );
+      expect(policy).toEqual(DEFAULT_POLICY);
+    });
+
+    it("rejects non-admin accounts", async () => {
+      await expect(
+        withClient((client) => readSessionPolicy(client, nonAdminAccountId)),
+      ).rejects.toThrow(HttpError);
+    });
+
+    // ----- updateSessionPolicy -----
+
+    it("persists and returns the new policy", async () => {
+      const input = {
+        general: { idle_timeout_minutes: 60, absolute_timeout_minutes: 960 },
+        admin: { idle_timeout_minutes: 10, absolute_timeout_minutes: 120 },
+      };
+
+      const result = await withClient((client) =>
+        updateSessionPolicy(client, adminAccountId, input),
+      );
+
+      expect(result).toEqual(input);
+
+      // Verify persisted
+      const persisted = await withClient((client) =>
+        readSessionPolicy(client, adminAccountId),
+      );
+      expect(persisted).toEqual(input);
+    });
+
+    it("rejects idle_timeout_minutes below floor", async () => {
+      const input = {
+        general: {
+          idle_timeout_minutes: MIN_IDLE_MINUTES - 1,
+          absolute_timeout_minutes: 480,
+        },
+        admin: { idle_timeout_minutes: 15, absolute_timeout_minutes: 120 },
+      };
+
+      await expect(
+        withClient((client) =>
+          updateSessionPolicy(client, adminAccountId, input),
+        ),
+      ).rejects.toThrow(
+        `general.idle_timeout_minutes must be at least ${MIN_IDLE_MINUTES}`,
+      );
+    });
+
+    it("rejects absolute_timeout_minutes below floor", async () => {
+      const input = {
+        general: { idle_timeout_minutes: 30, absolute_timeout_minutes: 480 },
+        admin: {
+          idle_timeout_minutes: 15,
+          absolute_timeout_minutes: MIN_ABSOLUTE_MINUTES - 1,
+        },
+      };
+
+      await expect(
+        withClient((client) =>
+          updateSessionPolicy(client, adminAccountId, input),
+        ),
+      ).rejects.toThrow(
+        `admin.absolute_timeout_minutes must be at least ${MIN_ABSOLUTE_MINUTES}`,
+      );
+    });
+
+    it("rejects non-integer timeout values", async () => {
+      const input = {
+        general: {
+          idle_timeout_minutes: 30.5,
+          absolute_timeout_minutes: 480,
+        },
+        admin: { idle_timeout_minutes: 15, absolute_timeout_minutes: 120 },
+      };
+
+      await expect(
+        withClient((client) =>
+          updateSessionPolicy(client, adminAccountId, input),
+        ),
+      ).rejects.toThrow("general.idle_timeout_minutes must be an integer");
+    });
+
+    it("rejects missing general or admin context", async () => {
+      await expect(
+        withClient((client) =>
+          updateSessionPolicy(client, adminAccountId, {
+            general: {
+              idle_timeout_minutes: 30,
+              absolute_timeout_minutes: 480,
+            },
+          }),
+        ),
+      ).rejects.toThrow("Both general and admin policy contexts are required");
+    });
+
+    it("rejects non-admin accounts for update", async () => {
+      const input = {
+        general: { idle_timeout_minutes: 30, absolute_timeout_minutes: 480 },
+        admin: { idle_timeout_minutes: 15, absolute_timeout_minutes: 120 },
+      };
+
+      await expect(
+        withClient((client) =>
+          updateSessionPolicy(client, nonAdminAccountId, input),
+        ),
+      ).rejects.toThrow(HttpError);
+    });
+
+    it("accepts values exactly at the floor", async () => {
+      const input = {
+        general: {
+          idle_timeout_minutes: MIN_IDLE_MINUTES,
+          absolute_timeout_minutes: MIN_ABSOLUTE_MINUTES,
+        },
+        admin: {
+          idle_timeout_minutes: MIN_IDLE_MINUTES,
+          absolute_timeout_minutes: MIN_ABSOLUTE_MINUTES,
+        },
+      };
+
+      const result = await withClient((client) =>
+        updateSessionPolicy(client, adminAccountId, input),
+      );
+      expect(result).toEqual(input);
+    });
+
+    // ----- input shape validation -----
+
+    it("rejects null input", async () => {
+      await expect(
+        withClient((client) =>
+          updateSessionPolicy(client, adminAccountId, null),
+        ),
+      ).rejects.toThrow("Request body must be a JSON object");
+    });
+
+    it("rejects array input", async () => {
+      await expect(
+        withClient((client) =>
+          updateSessionPolicy(client, adminAccountId, [1, 2]),
+        ),
+      ).rejects.toThrow("Request body must be a JSON object");
+    });
+
+    it("rejects non-object context value", async () => {
+      await expect(
+        withClient((client) =>
+          updateSessionPolicy(client, adminAccountId, {
+            general: "not-an-object",
+            admin: { idle_timeout_minutes: 15, absolute_timeout_minutes: 120 },
+          }),
+        ),
+      ).rejects.toThrow("general must be an object");
+    });
+
+    it("rejects NaN timeout value", async () => {
+      await expect(
+        withClient((client) =>
+          updateSessionPolicy(client, adminAccountId, {
+            general: {
+              idle_timeout_minutes: Number.NaN,
+              absolute_timeout_minutes: 480,
+            },
+            admin: { idle_timeout_minutes: 15, absolute_timeout_minutes: 120 },
+          }),
+        ),
+      ).rejects.toThrow("general.idle_timeout_minutes must be an integer");
+    });
+
+    it("rejects Infinity timeout value", async () => {
+      await expect(
+        withClient((client) =>
+          updateSessionPolicy(client, adminAccountId, {
+            general: {
+              idle_timeout_minutes: Number.POSITIVE_INFINITY,
+              absolute_timeout_minutes: 480,
+            },
+            admin: { idle_timeout_minutes: 15, absolute_timeout_minutes: 120 },
+          }),
+        ),
+      ).rejects.toThrow("general.idle_timeout_minutes must be an integer");
+    });
+
+    it("rejects missing field within context", async () => {
+      await expect(
+        withClient((client) =>
+          updateSessionPolicy(client, adminAccountId, {
+            general: { idle_timeout_minutes: 30 },
+            admin: { idle_timeout_minutes: 15, absolute_timeout_minutes: 120 },
+          }),
+        ),
+      ).rejects.toThrow("general.absolute_timeout_minutes must be an integer");
+    });
+
+    it("rejects string timeout value", async () => {
+      await expect(
+        withClient((client) =>
+          updateSessionPolicy(client, adminAccountId, {
+            general: {
+              idle_timeout_minutes: "30",
+              absolute_timeout_minutes: 480,
+            },
+            admin: { idle_timeout_minutes: 15, absolute_timeout_minutes: 120 },
+          }),
+        ),
+      ).rejects.toThrow("general.idle_timeout_minutes must be an integer");
+    });
+
+    // ----- upsert behavior -----
+
+    it("overwrites existing policy on second update", async () => {
+      const first = {
+        general: { idle_timeout_minutes: 20, absolute_timeout_minutes: 240 },
+        admin: { idle_timeout_minutes: 10, absolute_timeout_minutes: 120 },
+      };
+      await withClient((client) =>
+        updateSessionPolicy(client, adminAccountId, first),
+      );
+
+      const second = {
+        general: { idle_timeout_minutes: 45, absolute_timeout_minutes: 720 },
+        admin: { idle_timeout_minutes: 8, absolute_timeout_minutes: 90 },
+      };
+      await withClient((client) =>
+        updateSessionPolicy(client, adminAccountId, second),
+      );
+
+      const persisted = await withClient((client) =>
+        readSessionPolicy(client, adminAccountId),
+      );
+      expect(persisted).toEqual(second);
+    });
+
+    // ----- error status codes -----
+
+    it("returns 403 for non-admin read", async () => {
+      try {
+        await withClient((client) =>
+          readSessionPolicy(client, nonAdminAccountId),
+        );
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpError);
+        expect((err as HttpError).statusCode).toBe(403);
+      }
+    });
+
+    it("returns 403 for non-admin update", async () => {
+      try {
+        await withClient((client) =>
+          updateSessionPolicy(client, nonAdminAccountId, {
+            general: {
+              idle_timeout_minutes: 30,
+              absolute_timeout_minutes: 480,
+            },
+            admin: { idle_timeout_minutes: 15, absolute_timeout_minutes: 120 },
+          }),
+        );
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpError);
+        expect((err as HttpError).statusCode).toBe(403);
+      }
+    });
+
+    it("returns 400 for floor violations", async () => {
+      try {
+        await withClient((client) =>
+          updateSessionPolicy(client, adminAccountId, {
+            general: {
+              idle_timeout_minutes: 1,
+              absolute_timeout_minutes: 480,
+            },
+            admin: { idle_timeout_minutes: 15, absolute_timeout_minutes: 120 },
+          }),
+        );
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpError);
+        expect((err as HttpError).statusCode).toBe(400);
+      }
+    });
+  },
+);

--- a/src/lib/auth/session-policy.ts
+++ b/src/lib/auth/session-policy.ts
@@ -1,23 +1,28 @@
+import type { PoolClient } from "pg";
 import { getAuthPool, query } from "../db/client";
+import { assertAuthorized } from "./authorization";
+import { HttpError } from "./errors";
 
-export interface SessionPolicy {
-  general: { idle_timeout_minutes: number; absolute_timeout_minutes: number };
-  admin: { idle_timeout_minutes: number; absolute_timeout_minutes: number };
+export interface SessionPolicyContext {
+  idle_timeout_minutes: number;
+  absolute_timeout_minutes: number;
 }
 
-const DEFAULT_POLICY: SessionPolicy = {
+export interface SessionPolicy {
+  general: SessionPolicyContext;
+  admin: SessionPolicyContext;
+}
+
+export const DEFAULT_POLICY: SessionPolicy = {
   general: { idle_timeout_minutes: 30, absolute_timeout_minutes: 480 },
   admin: { idle_timeout_minutes: 15, absolute_timeout_minutes: 120 },
 };
 
 // Minimum floor enforcement — prevents dangerously short timeouts
-const MIN_IDLE_MINUTES = 5;
-const MIN_ABSOLUTE_MINUTES = 60;
+export const MIN_IDLE_MINUTES = 5;
+export const MIN_ABSOLUTE_MINUTES = 60;
 
-function enforceFloor(ctx: {
-  idle_timeout_minutes: number;
-  absolute_timeout_minutes: number;
-}) {
+function enforceFloor(ctx: SessionPolicyContext): SessionPolicyContext {
   return {
     idle_timeout_minutes: Math.max(ctx.idle_timeout_minutes, MIN_IDLE_MINUTES),
     absolute_timeout_minutes: Math.max(
@@ -60,4 +65,108 @@ export async function getSessionPolicy(): Promise<SessionPolicy> {
 /** Clear the cached session policy (useful for tests). */
 export function clearSessionPolicyCache(): void {
   cached = null;
+}
+
+// ---------------------------------------------------------------------------
+// readSessionPolicy — returns current policy from DB (or defaults)
+// ---------------------------------------------------------------------------
+
+export async function readSessionPolicy(
+  client: PoolClient,
+  accountId: string,
+): Promise<SessionPolicy> {
+  await assertAuthorized(client, "admin", accountId, "system-settings:read");
+
+  const rows = await client.query<{ value: SessionPolicy }>(
+    `SELECT value FROM system_settings WHERE key = 'session_policy'`,
+  );
+  return rows.rows.length > 0 ? rows.rows[0].value : DEFAULT_POLICY;
+}
+
+// ---------------------------------------------------------------------------
+// updateSessionPolicy — validates floors and persists to DB
+// ---------------------------------------------------------------------------
+
+function validateContext(label: string, ctx: unknown): SessionPolicyContext {
+  if (typeof ctx !== "object" || ctx === null || Array.isArray(ctx)) {
+    throw new HttpError(`${label} must be an object`, 400);
+  }
+
+  const { idle_timeout_minutes, absolute_timeout_minutes } = ctx as Record<
+    string,
+    unknown
+  >;
+
+  if (
+    typeof idle_timeout_minutes !== "number" ||
+    !Number.isFinite(idle_timeout_minutes) ||
+    idle_timeout_minutes !== Math.floor(idle_timeout_minutes)
+  ) {
+    throw new HttpError(
+      `${label}.idle_timeout_minutes must be an integer`,
+      400,
+    );
+  }
+
+  if (
+    typeof absolute_timeout_minutes !== "number" ||
+    !Number.isFinite(absolute_timeout_minutes) ||
+    absolute_timeout_minutes !== Math.floor(absolute_timeout_minutes)
+  ) {
+    throw new HttpError(
+      `${label}.absolute_timeout_minutes must be an integer`,
+      400,
+    );
+  }
+
+  if (idle_timeout_minutes < MIN_IDLE_MINUTES) {
+    throw new HttpError(
+      `${label}.idle_timeout_minutes must be at least ${MIN_IDLE_MINUTES}`,
+      400,
+    );
+  }
+
+  if (absolute_timeout_minutes < MIN_ABSOLUTE_MINUTES) {
+    throw new HttpError(
+      `${label}.absolute_timeout_minutes must be at least ${MIN_ABSOLUTE_MINUTES}`,
+      400,
+    );
+  }
+
+  return { idle_timeout_minutes, absolute_timeout_minutes };
+}
+
+export async function updateSessionPolicy(
+  client: PoolClient,
+  accountId: string,
+  input: unknown,
+): Promise<SessionPolicy> {
+  await assertAuthorized(client, "admin", accountId, "system-settings:write");
+
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    throw new HttpError("Request body must be a JSON object", 400);
+  }
+
+  const { general, admin } = input as Record<string, unknown>;
+  if (general === undefined || admin === undefined) {
+    throw new HttpError(
+      "Both general and admin policy contexts are required",
+      400,
+    );
+  }
+
+  const policy: SessionPolicy = {
+    general: validateContext("general", general),
+    admin: validateContext("admin", admin),
+  };
+
+  await client.query(
+    `INSERT INTO system_settings (key, value, updated_at)
+     VALUES ('session_policy', $1::jsonb, NOW())
+     ON CONFLICT (key)
+     DO UPDATE SET value = $1::jsonb, updated_at = NOW()`,
+    [JSON.stringify(policy)],
+  );
+
+  return policy;
 }


### PR DESCRIPTION
## Summary

- Add `readSessionPolicy` and `updateSessionPolicy` business logic to `session-policy.ts` with input validation (integer check, minimum floor enforcement: idle ≥ 5 min, absolute ≥ 60 min)
- Add `GET/PUT /api/admin/session-policy` admin-only API endpoint with Origin and CSRF verification
- Cache invalidated after transaction commit so policy changes take effect on next request without restart
- Successful updates recorded via `auditLog()`

## Test plan

- [x] DB integration tests (20 cases): default read, auth rejection, persist/read-back, floor violations (idle, absolute), type validation (float, NaN, Infinity, string), shape validation (null, array, non-object context, missing fields), upsert overwrite, status code verification (403/400)
- [x] E2E tests (16 cases): unauthenticated 401 (GET/PUT × 2), unsupported methods 405 (POST/DELETE/PATCH), admin read 200, admin update with persistence, idle floor rejection 400, absolute floor rejection 400, CSRF missing 403 (with specific error assertion), origin mismatch 403, invalid body 400, post-update auth smoke test, general-context user rejection 401

Closes #30