### PR TITLE
Add context token verification & pending connections

### DIFF
--- a/e2e/bridge-api.spec.ts
+++ b/e2e/bridge-api.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("bridge API endpoint", () => {
+  const BASE_URL = "http://localhost:3000";
+
+  test("POST /api/auth/bridge returns 400 without context_token", async ({
+    request,
+  }) => {
+    const res = await request.post(`${BASE_URL}/api/auth/bridge`, {
+      multipart: {},
+    });
+    // Missing context_token → 400
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("context_token");
+  });
+
+  test("POST /api/auth/bridge returns 403 for invalid context token", async ({
+    request,
+  }) => {
+    const res = await request.post(`${BASE_URL}/api/auth/bridge`, {
+      multipart: {
+        context_token: "invalid.jwt.token",
+      },
+    });
+    expect(res.status()).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid context token");
+  });
+
+  test("GET /api/auth/bridge returns 405", async ({ request }) => {
+    const res = await request.get(`${BASE_URL}/api/auth/bridge`);
+    expect(res.status()).toBe(405);
+  });
+});

--- a/e2e/bridge-deny-page.spec.ts
+++ b/e2e/bridge-deny-page.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("bridge deny page reasons", () => {
+  test("renders bridge_expired reason", async ({ page }) => {
+    await page.goto("/deny?reason=bridge_expired");
+    await expect(page.locator("h1")).toContainText("Access Denied");
+    await expect(
+      page.locator("text=bridge connection has expired"),
+    ).toBeVisible();
+  });
+
+  test("renders bridge_customer_mismatch reason", async ({ page }) => {
+    await page.goto("/deny?reason=bridge_customer_mismatch");
+    await expect(page.locator("h1")).toContainText("Access Denied");
+    await expect(page.locator("text=could not be matched")).toBeVisible();
+  });
+
+  test("renders bridge_customer_inactive reason", async ({ page }) => {
+    await page.goto("/deny?reason=bridge_customer_inactive");
+    await expect(page.locator("h1")).toContainText("Access Denied");
+    await expect(page.locator("text=customers are inactive")).toBeVisible();
+  });
+
+  test("renders bridge_environment_inactive reason", async ({ page }) => {
+    await page.goto("/deny?reason=bridge_environment_inactive");
+    await expect(page.locator("h1")).toContainText("Access Denied");
+    await expect(page.locator("text=environment is inactive")).toBeVisible();
+  });
+
+  test("renders bridge_no_access reason", async ({ page }) => {
+    await page.goto("/deny?reason=bridge_no_access");
+    await expect(page.locator("h1")).toContainText("Access Denied");
+    await expect(
+      page.locator("text=do not have access to the requested"),
+    ).toBeVisible();
+  });
+
+  test("back to sign in link is visible on bridge deny", async ({ page }) => {
+    await page.goto("/deny?reason=bridge_expired");
+    const link = page.locator('a[href="/api/auth/sign-in"]');
+    await expect(link).toBeVisible();
+  });
+});

--- a/src/app/[locale]/(auth)/deny/page.tsx
+++ b/src/app/[locale]/(auth)/deny/page.tsx
@@ -10,6 +10,11 @@ type DenyMessageKey =
   | "invitationExpired"
   | "invitationEmailMismatch"
   | "invitationEmailNotVerified"
+  | "bridgeExpired"
+  | "bridgeCustomerMismatch"
+  | "bridgeCustomerInactive"
+  | "bridgeEnvironmentInactive"
+  | "bridgeNoAccess"
   | "genericError";
 
 const REASON_KEYS: Record<string, DenyMessageKey> = {
@@ -22,6 +27,11 @@ const REASON_KEYS: Record<string, DenyMessageKey> = {
   invitation_expired: "invitationExpired",
   invitation_email_mismatch: "invitationEmailMismatch",
   invitation_email_not_verified: "invitationEmailNotVerified",
+  bridge_expired: "bridgeExpired",
+  bridge_customer_mismatch: "bridgeCustomerMismatch",
+  bridge_customer_inactive: "bridgeCustomerInactive",
+  bridge_environment_inactive: "bridgeEnvironmentInactive",
+  bridge_no_access: "bridgeNoAccess",
 };
 
 export default async function DenyPage({

--- a/src/app/api/admin-auth/sign-in/route.ts
+++ b/src/app/api/admin-auth/sign-in/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server";
 import {
-  clearFlowCookies,
+  clearConnectionIdCookie,
+  clearInvitationTokenCookie,
   clearOidcTempCookies,
   setOidcTempCookies,
 } from "@/lib/auth/cookies";
@@ -24,7 +25,8 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const codeChallenge = generateCodeChallenge(codeVerifier);
 
   await clearOidcTempCookies("admin");
-  await clearFlowCookies();
+  await clearConnectionIdCookie();
+  await clearInvitationTokenCookie();
 
   await setOidcTempCookies("admin", { state, nonce, codeVerifier });
 

--- a/src/app/api/auth/__tests__/bridge-entry.unit.test.ts
+++ b/src/app/api/auth/__tests__/bridge-entry.unit.test.ts
@@ -1,0 +1,225 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockVerifyContextToken = vi.fn();
+const mockVerifyEventsEnvelope = vi.fn();
+const mockCreatePendingConnection = vi.fn();
+const mockStageEventsPayload = vi.fn();
+const setConnectionIdCookie = vi.fn();
+const clearInvitationTokenCookie = vi.fn();
+
+vi.mock("@/lib/auth/context-token", () => ({
+  verifyContextToken: (...args: unknown[]) => mockVerifyContextToken(...args),
+}));
+
+vi.mock("@/lib/auth/events-envelope", () => ({
+  verifyEventsEnvelope: (...args: unknown[]) =>
+    mockVerifyEventsEnvelope(...args),
+}));
+
+vi.mock("@/lib/auth/bridge", () => ({
+  createPendingConnection: (...args: unknown[]) =>
+    mockCreatePendingConnection(...args),
+  stageEventsPayload: (...args: unknown[]) => mockStageEventsPayload(...args),
+}));
+
+vi.mock("@/lib/auth/cookies", () => ({
+  setConnectionIdCookie,
+  clearInvitationTokenCookie,
+}));
+
+vi.mock("@/lib/auth/audit-stub", () => ({
+  auditLog: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  getAuthPool: vi.fn(() => ({})),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeFormData(fields: Record<string, string | Blob>): FormData {
+  const form = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    form.append(key, value);
+  }
+  return form;
+}
+
+function makeBridgeRequest(body: FormData): NextRequest {
+  return new NextRequest("http://localhost:3000/api/auth/bridge", {
+    method: "POST",
+    body,
+  });
+}
+
+const validContextClaims = {
+  iss: "https://aice.test",
+  aud: "aimer-web",
+  sub: "user-001",
+  aiceId: "aice-1",
+  customerIds: ["cust-ext-1"],
+  iat: 1000,
+  exp: 2000,
+  jti: "unique-jti",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/auth/bridge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVerifyContextToken.mockResolvedValue(validContextClaims);
+    mockCreatePendingConnection.mockResolvedValue("conn-id-1");
+  });
+
+  async function callPOST(req: NextRequest) {
+    const { POST } = await import("../bridge/route");
+    return POST(req);
+  }
+
+  it("accepts valid context token and redirects to sign-in", async () => {
+    const form = makeFormData({ context_token: "valid-jwt" });
+    const res = await callPOST(makeBridgeRequest(form));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain(
+      "/api/auth/sign-in?flow=bridge",
+    );
+    expect(setConnectionIdCookie).toHaveBeenCalledWith("conn-id-1");
+    expect(clearInvitationTokenCookie).toHaveBeenCalled();
+    expect(mockCreatePendingConnection).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        jti: "unique-jti",
+        aiceId: "aice-1",
+        customerIds: ["cust-ext-1"],
+      }),
+    );
+  });
+
+  it("returns 400 for missing context_token", async () => {
+    const form = makeFormData({});
+    const res = await callPOST(makeBridgeRequest(form));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("context_token");
+  });
+
+  it("returns 403 for invalid context token", async () => {
+    mockVerifyContextToken.mockRejectedValue(new Error("bad signature"));
+    const form = makeFormData({ context_token: "invalid-jwt" });
+    const res = await callPOST(makeBridgeRequest(form));
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid context token");
+  });
+
+  it("returns 409 for jti replay (duplicate)", async () => {
+    const jtiError = new Error(
+      'duplicate key value violates unique constraint "pending_connections_jti_key"',
+    );
+    mockCreatePendingConnection.mockRejectedValue(jtiError);
+
+    const form = makeFormData({ context_token: "valid-jwt" });
+    const res = await callPOST(makeBridgeRequest(form));
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toContain("already used");
+  });
+
+  it("accepts context token with events envelope", async () => {
+    mockVerifyEventsEnvelope.mockResolvedValue({
+      iss: "https://aice.test",
+      aiceId: "aice-1",
+      customerIds: ["cust-ext-1"],
+      contextJti: "unique-jti",
+      payloadHash: "abc123",
+      eventCount: 10,
+      schemaVersion: "1.0",
+    });
+    mockStageEventsPayload.mockResolvedValue("staged-id-1");
+
+    const eventsBlob = new File([new Uint8Array([1, 2, 3])], "events.bin");
+    const form = makeFormData({
+      context_token: "valid-jwt",
+      events_envelope: "valid-jws",
+      events_data: eventsBlob,
+    });
+    const res = await callPOST(makeBridgeRequest(form));
+
+    expect(res.status).toBe(307);
+    expect(mockStageEventsPayload).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        connectionId: "conn-id-1",
+        aiceId: "aice-1",
+        payloadHash: "abc123",
+      }),
+    );
+  });
+
+  it("returns 403 for invalid events envelope", async () => {
+    mockVerifyEventsEnvelope.mockRejectedValue(
+      new Error("payload_hash mismatch"),
+    );
+
+    const eventsBlob = new File([new Uint8Array([1, 2, 3])], "events.bin");
+    const form = makeFormData({
+      context_token: "valid-jwt",
+      events_envelope: "invalid-jws",
+      events_data: eventsBlob,
+    });
+    const res = await callPOST(makeBridgeRequest(form));
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid events envelope");
+  });
+
+  it("returns 400 for envelope without events_data", async () => {
+    const form = makeFormData({
+      context_token: "valid-jwt",
+      events_envelope: "some-jws",
+    });
+    const res = await callPOST(makeBridgeRequest(form));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("events_data");
+  });
+
+  it("returns 400 for events_data without envelope", async () => {
+    const eventsBlob = new File([new Uint8Array([1, 2, 3])], "events.bin");
+    const form = new FormData();
+    form.append("context_token", "valid-jwt");
+    form.append("events_data", eventsBlob);
+    const res = await callPOST(makeBridgeRequest(form));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("events_envelope");
+  });
+
+  it("propagates non-jti database errors as 500", async () => {
+    mockCreatePendingConnection.mockRejectedValue(
+      new Error("connection refused"),
+    );
+
+    const form = makeFormData({ context_token: "valid-jwt" });
+    await expect(callPOST(makeBridgeRequest(form))).rejects.toThrow(
+      "connection refused",
+    );
+  });
+});

--- a/src/app/api/auth/__tests__/callback-bridge.unit.test.ts
+++ b/src/app/api/auth/__tests__/callback-bridge.unit.test.ts
@@ -1,0 +1,262 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const clearConnectionIdCookie = vi.fn();
+const clearAuthCookies = vi.fn();
+const clearInvitationTokenCookie = vi.fn();
+const clearOidcTempCookies = vi.fn();
+const setAuthCookies = vi.fn();
+
+vi.mock("@/lib/auth/cookies", () => ({
+  getOidcTempCookies: vi.fn(async () => ({
+    state: "test-state",
+    nonce: "test-nonce",
+    codeVerifier: "test-verifier",
+  })),
+  clearOidcTempCookies,
+  clearInvitationTokenCookie,
+  clearConnectionIdCookie,
+  clearAuthCookies,
+  setAuthCookies,
+}));
+
+vi.mock("@/lib/auth/oidc-discovery", () => ({
+  getOidcDiscovery: vi.fn(async () => ({
+    token_endpoint: "https://idp.test/token",
+    jwks_uri: "https://idp.test/jwks",
+    issuer: "https://idp.test",
+  })),
+}));
+
+vi.mock("@/lib/auth/oidc", () => ({
+  getIssuerUrl: vi.fn(() => "https://idp.test"),
+  exchangeCodeForTokens: vi.fn(async () => ({
+    id_token: "fake-id-token",
+    access_token: "fake-access-token",
+  })),
+}));
+
+vi.mock("@/lib/auth/oidc-validate", () => ({
+  validateIdToken: vi.fn(async () => ({
+    sub: "user-sub-001",
+    preferred_username: "testuser",
+    name: "Test User",
+    email: "test@example.com",
+    email_verified: true,
+  })),
+}));
+
+vi.mock("@/lib/auth/account", () => ({
+  upsertAccount: vi.fn(async () => ({
+    id: "account-001",
+    status: "active",
+    token_version: 1,
+    admin_eligible: false,
+    locale: null,
+  })),
+  countAccessibleCustomers: vi.fn(async () => 1),
+}));
+
+vi.mock("@/lib/auth/invitations", () => ({
+  acceptInvitation: vi.fn(async () => ({ deny: null })),
+}));
+
+vi.mock("@/lib/auth/audit-stub", () => ({
+  auditLog: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/auth/jwt", () => ({
+  signJwt: vi.fn(async () => ({
+    token: "jwt-token",
+    iat: 1000,
+    exp: 2000,
+  })),
+}));
+
+vi.mock("@/lib/auth/csrf", () => ({
+  generateCsrf: vi.fn(() => "csrf-token"),
+}));
+
+vi.mock("@/lib/auth/same-account", () => ({
+  enforceSameAccount: vi.fn(async () => {}),
+}));
+
+const mockProcessBridgeCallback = vi.fn();
+
+vi.mock("@/lib/auth/bridge", () => ({
+  processBridgeCallback: (...args: unknown[]) =>
+    mockProcessBridgeCallback(...args),
+}));
+
+const mockQuery = vi.fn(async () => [{ sid: "session-001" }]);
+
+vi.mock("@/lib/db/client", () => ({
+  getAuthPool: vi.fn(() => ({})),
+  query: (...args: Parameters<typeof mockQuery>) => mockQuery(...args),
+  // biome-ignore lint/complexity/noBannedTypes: test mock needs generic callable
+  withTransaction: vi.fn(async (_pool: unknown, fn: Function) => fn({})),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCallbackRequest(withConnectionId = true): NextRequest {
+  const url =
+    "http://localhost:3000/api/auth/callback?code=abc&state=test-state";
+  const req = new NextRequest(url);
+  if (withConnectionId) {
+    req.cookies.set("connection_id", "conn-id-1");
+  }
+  return req;
+}
+
+async function callGET(req: NextRequest) {
+  const { GET } = await import("../callback/route");
+  return GET(req);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("callback route — bridge flow (#33)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.OIDC_GENERAL_CLIENT_SECRET = "test-secret";
+    mockProcessBridgeCallback.mockResolvedValue({
+      sessionId: "bridge-session-001",
+      bridgeAiceId: "aice-1",
+      bridgeCustomerIds: ["cust-uuid-1", "cust-uuid-2"],
+    });
+  });
+
+  it("creates bridge session when connection_id cookie is present", async () => {
+    const res = await callGET(makeCallbackRequest());
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("localhost:3000");
+    expect(mockProcessBridgeCallback).toHaveBeenCalledWith(
+      expect.anything(),
+      "conn-id-1",
+      "account-001",
+      expect.objectContaining({ ipAddress: expect.any(String) }),
+    );
+    expect(clearConnectionIdCookie).toHaveBeenCalled();
+    expect(setAuthCookies).toHaveBeenCalled();
+  });
+
+  it("passes session params to processBridgeCallback", async () => {
+    await callGET(makeCallbackRequest());
+
+    // Session creation now happens inside processBridgeCallback's transaction
+    expect(mockProcessBridgeCallback).toHaveBeenCalledWith(
+      expect.anything(),
+      "conn-id-1",
+      "account-001",
+      expect.objectContaining({
+        ipAddress: expect.any(String),
+        userAgent: expect.any(String),
+      }),
+    );
+  });
+
+  it("uses sessionId from processBridgeCallback for JWT", async () => {
+    const res = await callGET(makeCallbackRequest());
+
+    // Session + event linking happen inside processBridgeCallback's transaction.
+    // Callback only signs JWT with the returned sessionId.
+    expect(res.status).toBe(307);
+    expect(setAuthCookies).toHaveBeenCalled();
+  });
+
+  it("redirects to deny page on bridge_expired", async () => {
+    mockProcessBridgeCallback.mockResolvedValue({
+      deny: "bridge_expired",
+    });
+
+    const res = await callGET(makeCallbackRequest());
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("bridge_expired");
+    expect(clearAuthCookies).toHaveBeenCalledWith("general");
+  });
+
+  it("redirects to deny page on bridge_customer_mismatch", async () => {
+    mockProcessBridgeCallback.mockResolvedValue({
+      deny: "bridge_customer_mismatch",
+    });
+
+    const res = await callGET(makeCallbackRequest());
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("bridge_customer_mismatch");
+    expect(clearAuthCookies).toHaveBeenCalledWith("general");
+  });
+
+  it("redirects to deny page on bridge_no_access", async () => {
+    mockProcessBridgeCallback.mockResolvedValue({
+      deny: "bridge_no_access",
+    });
+
+    const res = await callGET(makeCallbackRequest());
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("bridge_no_access");
+  });
+
+  it("redirects to deny page on bridge_customer_inactive", async () => {
+    mockProcessBridgeCallback.mockResolvedValue({
+      deny: "bridge_customer_inactive",
+    });
+
+    const res = await callGET(makeCallbackRequest());
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("bridge_customer_inactive");
+  });
+
+  it("redirects to deny page on bridge_environment_inactive", async () => {
+    mockProcessBridgeCallback.mockResolvedValue({
+      deny: "bridge_environment_inactive",
+    });
+
+    const res = await callGET(makeCallbackRequest());
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain(
+      "bridge_environment_inactive",
+    );
+  });
+
+  it("clears connection_id cookie even on deny", async () => {
+    mockProcessBridgeCallback.mockResolvedValue({
+      deny: "bridge_expired",
+    });
+
+    await callGET(makeCallbackRequest());
+    expect(clearConnectionIdCookie).toHaveBeenCalled();
+  });
+
+  it("does not set auth cookies on deny", async () => {
+    mockProcessBridgeCallback.mockResolvedValue({
+      deny: "bridge_expired",
+    });
+
+    await callGET(makeCallbackRequest());
+    expect(setAuthCookies).not.toHaveBeenCalled();
+  });
+
+  it("proceeds with standard flow when no connection_id cookie", async () => {
+    const res = await callGET(makeCallbackRequest(false));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("localhost:3000");
+    expect(mockProcessBridgeCallback).not.toHaveBeenCalled();
+    // Standard session created (no bridge fields)
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.not.stringContaining("bridge_aice_id"),
+      expect.any(Array),
+    );
+  });
+});

--- a/src/app/api/auth/__tests__/callback-invitation.unit.test.ts
+++ b/src/app/api/auth/__tests__/callback-invitation.unit.test.ts
@@ -18,6 +18,8 @@ vi.mock("@/lib/auth/cookies", () => ({
   })),
   clearOidcTempCookies,
   clearInvitationTokenCookie,
+  clearConnectionIdCookie: vi.fn(),
+  clearAuthCookies: vi.fn(),
   setAuthCookies,
 }));
 
@@ -82,6 +84,11 @@ vi.mock("@/lib/auth/csrf", () => ({
 
 vi.mock("@/lib/auth/same-account", () => ({
   enforceSameAccount: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/auth/bridge", () => ({
+  processBridgeCallback: vi.fn(async () => ({ deny: null })),
+  denyConnection: vi.fn(async () => {}),
 }));
 
 vi.mock("@/lib/db/client", () => ({

--- a/src/app/api/auth/bridge/route.ts
+++ b/src/app/api/auth/bridge/route.ts
@@ -1,0 +1,170 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { auditLog } from "@/lib/auth/audit-stub";
+import { createPendingConnection, stageEventsPayload } from "@/lib/auth/bridge";
+import { verifyContextToken } from "@/lib/auth/context-token";
+import {
+  clearInvitationTokenCookie,
+  setConnectionIdCookie,
+} from "@/lib/auth/cookies";
+import { verifyEventsEnvelope } from "@/lib/auth/events-envelope";
+import { extractRequestMeta } from "@/lib/auth/request-meta";
+import { getAuthPool } from "@/lib/db/client";
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const pool = getAuthPool();
+  const meta = extractRequestMeta(request);
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid multipart form data" },
+      { status: 400 },
+    );
+  }
+
+  // Extract fields
+  const contextTokenField = formData.get("context_token");
+  if (typeof contextTokenField !== "string" || !contextTokenField) {
+    return NextResponse.json(
+      { error: "Missing context_token" },
+      { status: 400 },
+    );
+  }
+
+  // Verify context token (cryptographic properties only)
+  let contextClaims: Awaited<ReturnType<typeof verifyContextToken>>;
+  try {
+    contextClaims = await verifyContextToken(pool, contextTokenField);
+  } catch (err) {
+    await auditLog({
+      actorId: "unknown",
+      action: "bridge.context_token_rejected",
+      targetType: "bridge",
+      details: { reason: String(err) },
+      ipAddress: meta.ipAddress,
+    });
+    return NextResponse.json(
+      { error: "Invalid context token" },
+      { status: 403 },
+    );
+  }
+
+  // Verify events envelope if present
+  const envelopeField = formData.get("events_envelope");
+  const eventsDataField = formData.get("events_data");
+
+  let envelopeClaims:
+    | Awaited<ReturnType<typeof verifyEventsEnvelope>>
+    | undefined;
+  let eventsDataBuffer: Buffer | undefined;
+
+  if (envelopeField || eventsDataField) {
+    if (typeof envelopeField !== "string" || !envelopeField) {
+      return NextResponse.json(
+        { error: "Missing events_envelope" },
+        { status: 400 },
+      );
+    }
+    if (!(eventsDataField instanceof File)) {
+      return NextResponse.json(
+        { error: "Missing events_data" },
+        { status: 400 },
+      );
+    }
+
+    const eventsDataBytes = new Uint8Array(await eventsDataField.arrayBuffer());
+
+    try {
+      envelopeClaims = await verifyEventsEnvelope(
+        pool,
+        envelopeField,
+        eventsDataBytes,
+        contextClaims,
+      );
+    } catch (err) {
+      await auditLog({
+        actorId: "unknown",
+        action: "bridge.envelope_rejected",
+        targetType: "bridge",
+        details: { reason: String(err), jti: contextClaims.jti },
+        ipAddress: meta.ipAddress,
+      });
+      return NextResponse.json(
+        { error: "Invalid events envelope" },
+        { status: 403 },
+      );
+    }
+
+    eventsDataBuffer = Buffer.from(eventsDataBytes);
+  }
+
+  // Create pending connection (jti uniqueness enforced by DB constraint)
+  let connectionId: string;
+  try {
+    connectionId = await createPendingConnection(pool, {
+      jti: contextClaims.jti,
+      issuer: contextClaims.iss,
+      aiceId: contextClaims.aiceId,
+      customerIds: contextClaims.customerIds,
+      sub: contextClaims.sub,
+    });
+  } catch (err) {
+    // jti uniqueness violation → replay attempt
+    if (
+      err instanceof Error &&
+      err.message.includes("pending_connections_jti_key")
+    ) {
+      await auditLog({
+        actorId: "unknown",
+        action: "bridge.jti_replay",
+        targetType: "bridge",
+        details: { jti: contextClaims.jti },
+        ipAddress: meta.ipAddress,
+      });
+      return NextResponse.json(
+        { error: "Context token already used" },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }
+
+  // Stage events data if present
+  if (envelopeClaims && eventsDataBuffer) {
+    await stageEventsPayload(pool, {
+      connectionId,
+      aiceId: envelopeClaims.aiceId,
+      payloadHash: envelopeClaims.payloadHash,
+      payload: eventsDataBuffer,
+      eventCount: envelopeClaims.eventCount,
+      schemaVersion: envelopeClaims.schemaVersion,
+    });
+  }
+
+  // Set connection_id cookie
+  await setConnectionIdCookie(connectionId);
+
+  // Bridge entry deletes invitation_token (prevent stale cookie)
+  await clearInvitationTokenCookie();
+
+  await auditLog({
+    actorId: "unknown",
+    action: "bridge.entry",
+    targetType: "bridge",
+    details: {
+      connectionId,
+      aiceId: contextClaims.aiceId,
+      jti: contextClaims.jti,
+      hasEvents: !!envelopeClaims,
+    },
+    ipAddress: meta.ipAddress,
+  });
+
+  // Redirect to general OIDC sign-in (flow=bridge preserves connection_id cookie)
+  const origin = request.nextUrl.origin;
+  return NextResponse.redirect(
+    new URL("/api/auth/sign-in?flow=bridge", origin),
+  );
+}

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,7 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { countAccessibleCustomers, upsertAccount } from "@/lib/auth/account";
 import { auditLog } from "@/lib/auth/audit-stub";
+import { processBridgeCallback } from "@/lib/auth/bridge";
 import {
+  clearAuthCookies,
+  clearConnectionIdCookie,
   clearInvitationTokenCookie,
   clearOidcTempCookies,
   getOidcTempCookies,
@@ -154,10 +157,68 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     });
   }
 
-  // Bridge stub (#33): check for connection_id cookie
+  // Bridge flow (#33): check for connection_id cookie
   const connectionId = request.cookies.get("connection_id")?.value;
   if (connectionId) {
-    // TODO(#33): Process bridge flow
+    // Same-account enforcement before consuming the connection so that
+    // a DB failure here does not leave the connection permanently consumed.
+    await enforceSameAccount(request, account.id, "general", meta);
+
+    const bridgeResult = await processBridgeCallback(
+      pool,
+      connectionId,
+      account.id,
+      { ipAddress: meta.ipAddress, userAgent: meta.userAgent },
+    );
+
+    if (bridgeResult.deny) {
+      // Intentional denial — safe to clear cookie now
+      await clearConnectionIdCookie();
+      await clearAuthCookies("general");
+      await auditLog({
+        actorId: account.id,
+        authContext: "general",
+        action: "auth.bridge_denied",
+        targetType: "bridge",
+        details: { reason: bridgeResult.deny, connectionId },
+        ipAddress: meta.ipAddress,
+      });
+      return denyRedirect(request, bridgeResult.deny);
+    }
+
+    // Session + staged events already created inside the transaction.
+    // Only JWT signing + cookies remain (idempotent, safe outside tx).
+    const bridgeSid = bridgeResult.sessionId as string;
+
+    // Sign JWT + CSRF + cookies
+    const { token, iat, exp } = await signJwt({
+      sub: account.id,
+      sid: bridgeSid,
+      ctx: "general",
+      tv: account.token_version,
+    });
+    const csrfToken = generateCsrf({ ctx: "general", sid: bridgeSid, iat });
+    await setAuthCookies("general", { jwt: token, csrfToken, expiresAt: exp });
+
+    // Bridge flow fully succeeded — safe to clear the one-time cookie
+    await clearConnectionIdCookie();
+
+    await auditLog({
+      actorId: account.id,
+      authContext: "general",
+      action: "auth.bridge_sign_in",
+      targetType: "session",
+      targetId: bridgeSid,
+      details: {
+        connectionId,
+        aiceId: bridgeResult.bridgeAiceId,
+        customerIds: bridgeResult.bridgeCustomerIds,
+      },
+      ipAddress: meta.ipAddress,
+      sid: bridgeSid,
+    });
+
+    return NextResponse.redirect(new URL("/", request.url));
   }
 
   // Standard check: count accessible customers

--- a/src/app/api/auth/invite/[token]/route.ts
+++ b/src/app/api/auth/invite/[token]/route.ts
@@ -1,5 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { clearFlowCookies, setInvitationTokenCookie } from "@/lib/auth/cookies";
+import {
+  clearConnectionIdCookie,
+  setInvitationTokenCookie,
+} from "@/lib/auth/cookies";
 import { hashToken } from "@/lib/auth/invitations";
 import { getAuthPool, query } from "@/lib/db/client";
 
@@ -25,12 +28,12 @@ export async function GET(
     );
   }
 
-  // Clear stale flow cookies before setting new ones (conflict prevention)
-  await clearFlowCookies();
+  // Clear stale bridge cookie (conflict prevention), then set invite token
+  await clearConnectionIdCookie();
   await setInvitationTokenCookie(token);
 
   const response = NextResponse.redirect(
-    new URL("/api/auth/sign-in", request.url),
+    new URL("/api/auth/sign-in?flow=invite", request.url),
   );
   response.headers.set("Referrer-Policy", "no-referrer");
   return response;

--- a/src/app/api/auth/sign-in/route.ts
+++ b/src/app/api/auth/sign-in/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server";
 import {
-  clearFlowCookies,
+  clearConnectionIdCookie,
+  clearInvitationTokenCookie,
   clearOidcTempCookies,
   setOidcTempCookies,
 } from "@/lib/auth/cookies";
@@ -23,9 +24,12 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = generateCodeChallenge(codeVerifier);
 
-  // Clean up stale temporary cookies from previous incomplete flows
+  // Clean up stale temporary cookies from previous incomplete flows.
+  // Preserve the active flow's cookie — only clear the OTHER flow's cookie.
   await clearOidcTempCookies("general");
-  await clearFlowCookies();
+  const flow = request.nextUrl.searchParams.get("flow");
+  if (flow !== "bridge") await clearConnectionIdCookie();
+  if (flow !== "invite") await clearInvitationTokenCookie();
 
   // Store OIDC parameters in cookies for callback verification
   await setOidcTempCookies("general", { state, nonce, codeVerifier });

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -29,6 +29,11 @@
       "invitationExpired": "This invitation has expired or is no longer valid. Please request a new invitation.",
       "invitationEmailMismatch": "The email address you signed in with does not match the invited email. Please sign in with the correct account.",
       "invitationEmailNotVerified": "Your email address has not been verified. Please verify your email before accepting the invitation.",
+      "bridgeExpired": "The bridge connection has expired or was already used. Please initiate a new connection from AICE.",
+      "bridgeCustomerMismatch": "The requested customers could not be matched. Please verify the customer configuration in AICE.",
+      "bridgeCustomerInactive": "One or more requested customers are inactive. Please contact an administrator.",
+      "bridgeEnvironmentInactive": "The AICE environment is inactive. Please contact an administrator.",
+      "bridgeNoAccess": "You do not have access to the requested customers. Please request access from a manager.",
       "backToSignIn": "Back to Sign In",
       "contactAdmin": "If you believe this is an error, please contact your system administrator."
     }

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -29,6 +29,11 @@
       "invitationExpired": "초대가 만료되었거나 더 이상 유효하지 않습니다. 새로운 초대를 요청해 주세요.",
       "invitationEmailMismatch": "로그인한 이메일 주소가 초대된 이메일과 일치하지 않습니다. 올바른 계정으로 로그인해 주세요.",
       "invitationEmailNotVerified": "이메일 주소가 인증되지 않았습니다. 초대를 수락하기 전에 이메일을 인증해 주세요.",
+      "bridgeExpired": "브릿지 연결이 만료되었거나 이미 사용되었습니다. AICE에서 새로운 연결을 시작해 주세요.",
+      "bridgeCustomerMismatch": "요청된 고객을 매칭할 수 없습니다. AICE의 고객 구성을 확인해 주세요.",
+      "bridgeCustomerInactive": "요청된 고객 중 하나 이상이 비활성 상태입니다. 관리자에게 문의해 주세요.",
+      "bridgeEnvironmentInactive": "AICE 환경이 비활성 상태입니다. 관리자에게 문의해 주세요.",
+      "bridgeNoAccess": "요청된 고객에 대한 접근 권한이 없습니다. 매니저에게 접근 권한을 요청해 주세요.",
       "backToSignIn": "로그인으로 돌아가기",
       "contactAdmin": "오류라고 생각되시면 시스템 관리자에게 문의해 주세요."
     }

--- a/src/lib/auth/__tests__/bridge.db.test.ts
+++ b/src/lib/auth/__tests__/bridge.db.test.ts
@@ -1,0 +1,383 @@
+import type { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeAdminPool,
+  createTestDatabase,
+  dropTestDatabase,
+} from "../../db/__tests__/db-test-helpers";
+
+const hasPostgres = !!process.env.DATABASE_ADMIN_URL;
+
+describe.skipIf(!hasPostgres)("bridge DB integration", () => {
+  let pool: Pool;
+  let dbName: string;
+  let accountId: string;
+  let customerId: string;
+  let customerIdB: string;
+
+  beforeAll(async () => {
+    const result = await createTestDatabase("bridge", "auth");
+    pool = result.pool;
+    dbName = result.dbName;
+
+    // Seed: account, customers, environment, trust registry, memberships
+    const acct = await pool.query<{ id: string }>(
+      `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+       VALUES ('test-issuer', 'bridge-user', 'bridgeuser', 'Bridge User', 'bridge@test.com')
+       RETURNING id`,
+    );
+    accountId = acct.rows[0].id;
+
+    const custA = await pool.query<{ id: string }>(
+      `INSERT INTO customers (external_key, name, status, database_status)
+       VALUES ('ext-cust-a', 'Customer A', 'active', 'active')
+       RETURNING id`,
+    );
+    customerId = custA.rows[0].id;
+
+    const custB = await pool.query<{ id: string }>(
+      `INSERT INTO customers (external_key, name, status, database_status)
+       VALUES ('ext-cust-b', 'Customer B', 'active', 'active')
+       RETURNING id`,
+    );
+    customerIdB = custB.rows[0].id;
+
+    // Environment
+    await pool.query(
+      `INSERT INTO aice_environments (aice_id, name, status)
+       VALUES ('aice-test-1', 'Test AICE', 'active')`,
+    );
+
+    // Link customers to environment
+    await pool.query(
+      `INSERT INTO aice_environment_customers (aice_id, customer_id)
+       VALUES ('aice-test-1', $1), ('aice-test-1', $2)`,
+      [customerId, customerIdB],
+    );
+
+    // Trust registry
+    await pool.query(
+      `INSERT INTO trust_registry (aice_id, issuer, kid, public_key)
+       VALUES ('aice-test-1', 'https://aice.test', 'key-1', $1)`,
+      [JSON.stringify({ kty: "EC", crv: "P-256" })],
+    );
+
+    // Membership for account → customer A
+    const userRole = await pool.query<{ id: number }>(
+      `SELECT id FROM roles WHERE name = 'User' AND auth_context = 'general'`,
+    );
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+       VALUES ($1, $2, $3)`,
+      [accountId, customerId, userRole.rows[0].id],
+    );
+    // Membership for account → customer B
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+       VALUES ($1, $2, $3)`,
+      [accountId, customerIdB, userRole.rows[0].id],
+    );
+  });
+
+  afterAll(async () => {
+    await dropTestDatabase(dbName, pool, "auth");
+    await closeAdminPool();
+  });
+
+  // -- Pending connections --
+
+  describe("pending connections", () => {
+    it("creates a pending connection with jti", async () => {
+      const result = await pool.query<{
+        connection_id: string;
+        status: string;
+      }>(
+        `INSERT INTO pending_connections (jti, issuer, aice_id, customer_ids, sub, expires_at)
+         VALUES ('jti-db-1', 'https://aice.test', 'aice-test-1', $1, 'user-1', NOW() + INTERVAL '5 minutes')
+         RETURNING connection_id, status`,
+        [["ext-cust-a"]],
+      );
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].status).toBe("pending");
+    });
+
+    it("rejects duplicate jti (replay prevention)", async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO pending_connections (jti, issuer, aice_id, customer_ids, sub, expires_at)
+           VALUES ('jti-db-1', 'https://aice.test', 'aice-test-1', $1, 'user-2', NOW() + INTERVAL '5 minutes')`,
+          [["ext-cust-a"]],
+        ),
+      ).rejects.toThrow(/pending_connections_jti_key/);
+    });
+
+    it("atomically consumes a pending connection", async () => {
+      // Insert
+      const ins = await pool.query<{ connection_id: string }>(
+        `INSERT INTO pending_connections (jti, issuer, aice_id, customer_ids, sub, expires_at)
+         VALUES ('jti-consume-1', 'https://aice.test', 'aice-test-1', $1, 'user-1', NOW() + INTERVAL '5 minutes')
+         RETURNING connection_id`,
+        [["ext-cust-a"]],
+      );
+      const connId = ins.rows[0].connection_id;
+
+      // Consume
+      const consumed = await pool.query<{ status: string }>(
+        `UPDATE pending_connections SET status = 'consumed'
+         WHERE connection_id = $1 AND status = 'pending' AND expires_at > NOW()
+         RETURNING status`,
+        [connId],
+      );
+      expect(consumed.rows).toHaveLength(1);
+      expect(consumed.rows[0].status).toBe("consumed");
+
+      // Second consume attempt returns nothing
+      const second = await pool.query(
+        `UPDATE pending_connections SET status = 'consumed'
+         WHERE connection_id = $1 AND status = 'pending' AND expires_at > NOW()
+         RETURNING status`,
+        [connId],
+      );
+      expect(second.rows).toHaveLength(0);
+    });
+
+    it("does not consume expired connections", async () => {
+      const ins = await pool.query<{ connection_id: string }>(
+        `INSERT INTO pending_connections (jti, issuer, aice_id, customer_ids, sub, expires_at)
+         VALUES ('jti-expired-1', 'https://aice.test', 'aice-test-1', $1, 'user-1', NOW() - INTERVAL '1 second')
+         RETURNING connection_id`,
+        [["ext-cust-a"]],
+      );
+      const connId = ins.rows[0].connection_id;
+
+      const consumed = await pool.query(
+        `UPDATE pending_connections SET status = 'consumed'
+         WHERE connection_id = $1 AND status = 'pending' AND expires_at > NOW()
+         RETURNING status`,
+        [connId],
+      );
+      expect(consumed.rows).toHaveLength(0);
+    });
+  });
+
+  // -- Bridge session creation --
+
+  describe("bridge session", () => {
+    it("creates session with bridge_aice_id and bridge_customer_ids", async () => {
+      const session = await pool.query<{
+        sid: string;
+        bridge_aice_id: string;
+        bridge_customer_ids: string[];
+      }>(
+        `INSERT INTO sessions (account_id, auth_context, bridge_aice_id, bridge_customer_ids, ip_address, user_agent)
+         VALUES ($1, 'general', 'aice-test-1', $2, '127.0.0.1', 'test')
+         RETURNING sid, bridge_aice_id, bridge_customer_ids`,
+        [accountId, [customerId, customerIdB]],
+      );
+      expect(session.rows).toHaveLength(1);
+      expect(session.rows[0].bridge_aice_id).toBe("aice-test-1");
+      expect(session.rows[0].bridge_customer_ids).toEqual([
+        customerId,
+        customerIdB,
+      ]);
+    });
+
+    it("rejects admin session with bridge context", async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO sessions (account_id, auth_context, bridge_aice_id, bridge_customer_ids, ip_address, user_agent)
+           VALUES ($1, 'admin', 'aice-test-1', $2, '127.0.0.1', 'test')`,
+          [accountId, [customerId]],
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("rejects bridge_aice_id without bridge_customer_ids", async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO sessions (account_id, auth_context, bridge_aice_id, ip_address, user_agent)
+           VALUES ($1, 'general', 'aice-test-1', '127.0.0.1', 'test')`,
+          [accountId],
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  // -- Customer mapping --
+
+  describe("customer mapping via aice_environment_customers", () => {
+    it("maps external_key to internal customer_id", async () => {
+      const result = await pool.query<{
+        customer_id: string;
+        external_key: string;
+        customer_status: string;
+        env_status: string;
+      }>(
+        `SELECT DISTINCT c.id AS customer_id,
+                c.external_key,
+                c.status AS customer_status,
+                ae.status AS env_status
+         FROM aice_environment_customers aec
+         JOIN customers c ON c.id = aec.customer_id
+         JOIN aice_environments ae ON ae.aice_id = aec.aice_id
+         WHERE aec.aice_id = 'aice-test-1'
+           AND c.external_key = ANY($1::text[])`,
+        [["ext-cust-a", "ext-cust-b"]],
+      );
+      expect(result.rows).toHaveLength(2);
+      const keys = result.rows.map((r) => r.external_key).sort();
+      expect(keys).toEqual(["ext-cust-a", "ext-cust-b"]);
+      for (const row of result.rows) {
+        expect(row.customer_status).toBe("active");
+        expect(row.env_status).toBe("active");
+      }
+    });
+
+    it("returns nothing for unknown external_key", async () => {
+      const result = await pool.query(
+        `SELECT c.id FROM aice_environment_customers aec
+         JOIN customers c ON c.id = aec.customer_id
+         WHERE aec.aice_id = 'aice-test-1'
+           AND c.external_key = ANY($1::text[])`,
+        [["nonexistent-key"]],
+      );
+      expect(result.rows).toHaveLength(0);
+    });
+  });
+
+  // -- Staged events --
+
+  describe("staged event payloads", () => {
+    it("stores and links staged events to session", async () => {
+      // Create connection
+      const conn = await pool.query<{ connection_id: string }>(
+        `INSERT INTO pending_connections (jti, issuer, aice_id, customer_ids, sub, expires_at)
+         VALUES ('jti-staged-1', 'https://aice.test', 'aice-test-1', $1, 'user-1', NOW() + INTERVAL '5 minutes')
+         RETURNING connection_id`,
+        [["ext-cust-a"]],
+      );
+      const connId = conn.rows[0].connection_id;
+
+      // Stage payload
+      const staged = await pool.query<{ id: string }>(
+        `INSERT INTO staged_event_payloads (connection_id, aice_id, payload_hash, payload, event_count, schema_version, expires_at)
+         VALUES ($1, 'aice-test-1', 'hash123', $2, 5, '1.0', NOW() + INTERVAL '5 minutes')
+         RETURNING id`,
+        [connId, Buffer.from("test payload")],
+      );
+      expect(staged.rows).toHaveLength(1);
+
+      // Create session
+      const session = await pool.query<{ sid: string }>(
+        `INSERT INTO sessions (account_id, auth_context, bridge_aice_id, bridge_customer_ids, ip_address, user_agent)
+         VALUES ($1, 'general', 'aice-test-1', $2, '127.0.0.1', 'test')
+         RETURNING sid`,
+        [accountId, [customerId]],
+      );
+      const sid = session.rows[0].sid;
+
+      // Link
+      await pool.query(
+        `UPDATE staged_event_payloads SET session_id = $1 WHERE connection_id = $2`,
+        [sid, connId],
+      );
+
+      // Verify link
+      const linked = await pool.query<{ session_id: string }>(
+        `SELECT session_id FROM staged_event_payloads WHERE id = $1`,
+        [staged.rows[0].id],
+      );
+      expect(linked.rows[0].session_id).toBe(sid);
+    });
+  });
+
+  // -- Cleanup --
+
+  describe("expired connection cleanup", () => {
+    it("deletes connections past the 24-hour grace period", async () => {
+      // Insert an old expired connection
+      await pool.query(
+        `INSERT INTO pending_connections (jti, issuer, aice_id, customer_ids, sub, expires_at)
+         VALUES ('jti-old-1', 'https://aice.test', 'aice-test-1', $1, 'user-1', NOW() - INTERVAL '25 hours')`,
+        [["ext-cust-a"]],
+      );
+
+      const result = await pool.query(
+        `DELETE FROM pending_connections
+         WHERE expires_at < NOW() - INTERVAL '24 hours'
+         RETURNING connection_id`,
+      );
+      expect(result.rowCount).toBeGreaterThanOrEqual(1);
+    });
+
+    it("preserves connections within the 24-hour grace period", async () => {
+      // Insert a recently expired connection (within grace period)
+      await pool.query(
+        `INSERT INTO pending_connections (jti, issuer, aice_id, customer_ids, sub, expires_at)
+         VALUES ('jti-recent-1', 'https://aice.test', 'aice-test-1', $1, 'user-1', NOW() - INTERVAL '1 hour')`,
+        [["ext-cust-a"]],
+      );
+
+      const result = await pool.query(
+        `DELETE FROM pending_connections
+         WHERE jti = 'jti-recent-1' AND expires_at < NOW() - INTERVAL '24 hours'
+         RETURNING connection_id`,
+      );
+      expect(result.rowCount).toBe(0);
+
+      // Verify it still exists (jti still blocks replay)
+      const exists = await pool.query(
+        `SELECT 1 FROM pending_connections WHERE jti = 'jti-recent-1'`,
+      );
+      expect(exists.rows).toHaveLength(1);
+    });
+  });
+
+  // -- Trust registry --
+
+  describe("trust registry", () => {
+    it("stores and retrieves keys", async () => {
+      const result = await pool.query<{
+        aice_id: string;
+        kid: string;
+        enabled: boolean;
+      }>(
+        `SELECT aice_id, kid, enabled FROM trust_registry
+         WHERE aice_id = 'aice-test-1' AND issuer = 'https://aice.test'`,
+      );
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].kid).toBe("key-1");
+      expect(result.rows[0].enabled).toBe(true);
+    });
+
+    it("supports multiple kids per issuer (key rotation)", async () => {
+      await pool.query(
+        `INSERT INTO trust_registry (aice_id, issuer, kid, public_key)
+         VALUES ('aice-test-1', 'https://aice.test', 'key-2', $1)`,
+        [JSON.stringify({ kty: "EC", crv: "P-256", x: "rotated" })],
+      );
+
+      const result = await pool.query(
+        `SELECT kid FROM trust_registry
+         WHERE aice_id = 'aice-test-1' AND issuer = 'https://aice.test' AND enabled = true
+         ORDER BY kid`,
+      );
+      expect(result.rows).toHaveLength(2);
+    });
+
+    it("disabled key not returned when filtering by enabled", async () => {
+      await pool.query(
+        `INSERT INTO trust_registry (aice_id, issuer, kid, public_key, enabled)
+         VALUES ('aice-test-1', 'https://aice.test', 'key-disabled', $1, false)`,
+        [JSON.stringify({ kty: "EC", crv: "P-256" })],
+      );
+
+      const result = await pool.query(
+        `SELECT kid FROM trust_registry
+         WHERE aice_id = 'aice-test-1' AND issuer = 'https://aice.test' AND enabled = true`,
+      );
+      const kids = result.rows.map((r: { kid: string }) => r.kid);
+      expect(kids).not.toContain("key-disabled");
+    });
+  });
+});

--- a/src/lib/auth/__tests__/context-token.unit.test.ts
+++ b/src/lib/auth/__tests__/context-token.unit.test.ts
@@ -1,0 +1,236 @@
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+// Mock server-only
+vi.mock("server-only", () => ({}));
+
+// Mock trust registry
+const mockLookup = vi.fn();
+vi.mock("../trust-registry", () => ({
+  lookupTrustRegistryKey: (...args: unknown[]) => mockLookup(...args),
+}));
+
+import { verifyContextToken } from "../context-token";
+
+const fakePool = {} as Parameters<typeof verifyContextToken>[0];
+
+let privateKey: CryptoKey;
+let publicJwk: JsonWebKey;
+
+beforeAll(async () => {
+  const kp = await generateKeyPair("ES256");
+  privateKey = kp.privateKey;
+  publicJwk = await exportJWK(kp.publicKey);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+async function signContextToken(
+  overrides: Record<string, unknown> = {},
+  headerOverrides: Record<string, unknown> = {},
+): Promise<string> {
+  const claims = {
+    aice_id: "aice-1",
+    customer_ids: ["cust-ext-1", "cust-ext-2"],
+    ...overrides,
+  };
+
+  const builder = new SignJWT(claims)
+    .setProtectedHeader({
+      alg: "ES256",
+      kid: "key-1",
+      ...headerOverrides,
+    })
+    .setIssuer("https://aice.test")
+    .setAudience("aimer-web")
+    .setSubject("user-001")
+    .setJti("unique-jti-1")
+    .setIssuedAt()
+    .setExpirationTime("2m");
+
+  // Allow overriding issuer/audience/subject/jti
+  if ("iss" in overrides) {
+    // Re-set issuer from override
+  }
+
+  return builder.sign(privateKey);
+}
+
+function setupTrustRegistry(): void {
+  mockLookup.mockResolvedValue({
+    aiceId: "aice-1",
+    issuer: "https://aice.test",
+    kid: "key-1",
+    publicKey: publicJwk,
+  });
+}
+
+describe("context token verification", () => {
+  it("verifies a valid context token", async () => {
+    setupTrustRegistry();
+    const token = await signContextToken();
+    const claims = await verifyContextToken(fakePool, token);
+
+    expect(claims.iss).toBe("https://aice.test");
+    expect(claims.aud).toBe("aimer-web");
+    expect(claims.sub).toBe("user-001");
+    expect(claims.aiceId).toBe("aice-1");
+    expect(claims.customerIds).toEqual(["cust-ext-1", "cust-ext-2"]);
+    expect(claims.jti).toBe("unique-jti-1");
+    expect(typeof claims.iat).toBe("number");
+    expect(typeof claims.exp).toBe("number");
+  });
+
+  it("rejects token with unknown issuer/kid", async () => {
+    mockLookup.mockResolvedValue(null);
+    const token = await signContextToken();
+
+    await expect(verifyContextToken(fakePool, token)).rejects.toThrow(
+      "Trust registry: unknown key",
+    );
+  });
+
+  it("rejects tampered token", async () => {
+    setupTrustRegistry();
+    const token = await signContextToken();
+    const parts = token.split(".");
+    parts[1] = `${parts[1]}tampered`;
+    const tampered = parts.join(".");
+
+    await expect(verifyContextToken(fakePool, tampered)).rejects.toThrow();
+  });
+
+  it("rejects token with wrong audience", async () => {
+    mockLookup.mockResolvedValue({
+      aiceId: "aice-1",
+      issuer: "https://aice.test",
+      kid: "key-1",
+      publicKey: publicJwk,
+    });
+
+    const token = await new SignJWT({
+      aice_id: "aice-1",
+      customer_ids: ["c1"],
+    })
+      .setProtectedHeader({ alg: "ES256", kid: "key-1" })
+      .setIssuer("https://aice.test")
+      .setAudience("wrong-audience")
+      .setSubject("user-001")
+      .setJti("jti-2")
+      .setIssuedAt()
+      .setExpirationTime("2m")
+      .sign(privateKey);
+
+    await expect(verifyContextToken(fakePool, token)).rejects.toThrow();
+  });
+
+  it("rejects expired token", async () => {
+    setupTrustRegistry();
+
+    const token = await new SignJWT({
+      aice_id: "aice-1",
+      customer_ids: ["c1"],
+    })
+      .setProtectedHeader({ alg: "ES256", kid: "key-1" })
+      .setIssuer("https://aice.test")
+      .setAudience("aimer-web")
+      .setSubject("user-001")
+      .setJti("jti-3")
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 600)
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 300)
+      .sign(privateKey);
+
+    await expect(verifyContextToken(fakePool, token)).rejects.toThrow();
+  });
+
+  it("rejects customer_ids exceeding 20", async () => {
+    setupTrustRegistry();
+    const tooMany = Array.from({ length: 21 }, (_, i) => `cust-${i}`);
+    const token = await signContextToken({ customer_ids: tooMany });
+
+    await expect(verifyContextToken(fakePool, token)).rejects.toThrow(
+      "exceeds maximum",
+    );
+  });
+
+  it("accepts exactly 20 customer_ids", async () => {
+    setupTrustRegistry();
+    const exact20 = Array.from({ length: 20 }, (_, i) => `cust-${i}`);
+    const token = await signContextToken({ customer_ids: exact20 });
+
+    const claims = await verifyContextToken(fakePool, token);
+    expect(claims.customerIds).toHaveLength(20);
+  });
+
+  it("rejects token missing aice_id", async () => {
+    setupTrustRegistry();
+    // Build manually without aice_id in payload
+    const token = await new SignJWT({ customer_ids: ["c1"] })
+      .setProtectedHeader({ alg: "ES256", kid: "key-1" })
+      .setIssuer("https://aice.test")
+      .setAudience("aimer-web")
+      .setSubject("user-001")
+      .setJti("jti-4")
+      .setIssuedAt()
+      .setExpirationTime("2m")
+      .sign(privateKey);
+
+    // Trust registry lookup will fail because unverified payload has no aice_id
+    await expect(verifyContextToken(fakePool, token)).rejects.toThrow(
+      "missing aice_id",
+    );
+  });
+
+  it("rejects token missing jti", async () => {
+    setupTrustRegistry();
+    const token = await new SignJWT({
+      aice_id: "aice-1",
+      customer_ids: ["c1"],
+    })
+      .setProtectedHeader({ alg: "ES256", kid: "key-1" })
+      .setIssuer("https://aice.test")
+      .setAudience("aimer-web")
+      .setSubject("user-001")
+      .setIssuedAt()
+      .setExpirationTime("2m")
+      .sign(privateKey);
+
+    await expect(verifyContextToken(fakePool, token)).rejects.toThrow(
+      "missing jti",
+    );
+  });
+
+  it("rejects token with non-string customer_ids", async () => {
+    setupTrustRegistry();
+    const token = await signContextToken({ customer_ids: [1, 2, 3] });
+
+    await expect(verifyContextToken(fakePool, token)).rejects.toThrow(
+      "must be strings",
+    );
+  });
+
+  it("rejects invalid token format", async () => {
+    await expect(verifyContextToken(fakePool, "not.a.valid")).rejects.toThrow();
+  });
+
+  it("rejects token with missing kid in header", async () => {
+    const token = await new SignJWT({
+      aice_id: "aice-1",
+      customer_ids: ["c1"],
+    })
+      .setProtectedHeader({ alg: "ES256" })
+      .setIssuer("https://aice.test")
+      .setAudience("aimer-web")
+      .setSubject("user-001")
+      .setJti("jti-5")
+      .setIssuedAt()
+      .setExpirationTime("2m")
+      .sign(privateKey);
+
+    await expect(verifyContextToken(fakePool, token)).rejects.toThrow(
+      "missing kid",
+    );
+  });
+});

--- a/src/lib/auth/__tests__/events-envelope.unit.test.ts
+++ b/src/lib/auth/__tests__/events-envelope.unit.test.ts
@@ -1,0 +1,218 @@
+import { createHash } from "node:crypto";
+import { CompactSign, exportJWK, generateKeyPair } from "jose";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { ContextTokenClaims } from "../context-token";
+
+// Mock server-only
+vi.mock("server-only", () => ({}));
+
+// Mock trust registry
+const mockLookup = vi.fn();
+vi.mock("../trust-registry", () => ({
+  lookupTrustRegistryKey: (...args: unknown[]) => mockLookup(...args),
+}));
+
+import { verifyEventsEnvelope } from "../events-envelope";
+
+const fakePool = {} as Parameters<typeof verifyEventsEnvelope>[0];
+
+let privateKey: CryptoKey;
+let publicJwk: JsonWebKey;
+
+beforeAll(async () => {
+  const kp = await generateKeyPair("ES256");
+  privateKey = kp.privateKey;
+  publicJwk = await exportJWK(kp.publicKey);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+const samplePayload = Buffer.from("detection events binary data");
+const sampleHash = createHash("sha256").update(samplePayload).digest("hex");
+
+const baseClaims: ContextTokenClaims = {
+  iss: "https://aice.test",
+  aud: "aimer-web",
+  sub: "user-001",
+  aiceId: "aice-1",
+  customerIds: ["cust-ext-1"],
+  iat: Math.floor(Date.now() / 1000),
+  exp: Math.floor(Date.now() / 1000) + 120,
+  jti: "context-jti-1",
+};
+
+function setupTrustRegistry(): void {
+  mockLookup.mockResolvedValue({
+    aiceId: "aice-1",
+    issuer: "https://aice.test",
+    kid: "key-1",
+    publicKey: publicJwk,
+  });
+}
+
+async function signEnvelope(
+  claimsOverrides: Record<string, unknown> = {},
+): Promise<string> {
+  const envelopeClaims = {
+    iss: "https://aice.test",
+    aice_id: "aice-1",
+    customer_ids: ["cust-ext-1"],
+    context_jti: "context-jti-1",
+    payload_hash: sampleHash,
+    event_count: 42,
+    schema_version: "1.0",
+    ...claimsOverrides,
+  };
+
+  const payload = new TextEncoder().encode(JSON.stringify(envelopeClaims));
+  return new CompactSign(payload)
+    .setProtectedHeader({ alg: "ES256", kid: "key-1" })
+    .sign(privateKey);
+}
+
+describe("events envelope verification", () => {
+  it("verifies a valid envelope", async () => {
+    setupTrustRegistry();
+    const envelope = await signEnvelope();
+    const result = await verifyEventsEnvelope(
+      fakePool,
+      envelope,
+      samplePayload,
+      baseClaims,
+    );
+
+    expect(result.iss).toBe("https://aice.test");
+    expect(result.aiceId).toBe("aice-1");
+    expect(result.customerIds).toEqual(["cust-ext-1"]);
+    expect(result.contextJti).toBe("context-jti-1");
+    expect(result.payloadHash).toBe(sampleHash);
+    expect(result.eventCount).toBe(42);
+    expect(result.schemaVersion).toBe("1.0");
+  });
+
+  it("rejects payload exceeding size cap", async () => {
+    setupTrustRegistry();
+    vi.stubEnv("BRIDGE_MAX_PAYLOAD_BYTES", "10");
+    const envelope = await signEnvelope();
+    const largePayload = new Uint8Array(11);
+
+    await expect(
+      verifyEventsEnvelope(fakePool, envelope, largePayload, baseClaims),
+    ).rejects.toThrow("exceeds size cap");
+
+    vi.unstubAllEnvs();
+  });
+
+  it("rejects payload hash mismatch", async () => {
+    setupTrustRegistry();
+    const envelope = await signEnvelope();
+    const wrongPayload = Buffer.from("different data");
+
+    await expect(
+      verifyEventsEnvelope(fakePool, envelope, wrongPayload, baseClaims),
+    ).rejects.toThrow("payload_hash mismatch");
+  });
+
+  it("rejects context_jti mismatch", async () => {
+    setupTrustRegistry();
+    const envelope = await signEnvelope({ context_jti: "wrong-jti" });
+
+    await expect(
+      verifyEventsEnvelope(fakePool, envelope, samplePayload, baseClaims),
+    ).rejects.toThrow("context_jti does not match");
+  });
+
+  it("rejects iss mismatch", async () => {
+    setupTrustRegistry();
+    const envelope = await signEnvelope({ iss: "https://other.test" });
+
+    await expect(
+      verifyEventsEnvelope(fakePool, envelope, samplePayload, baseClaims),
+    ).rejects.toThrow("iss does not match");
+  });
+
+  it("rejects aice_id mismatch", async () => {
+    setupTrustRegistry();
+    const envelope = await signEnvelope({ aice_id: "aice-wrong" });
+
+    await expect(
+      verifyEventsEnvelope(fakePool, envelope, samplePayload, baseClaims),
+    ).rejects.toThrow("aice_id does not match");
+  });
+
+  it("rejects customer_ids mismatch", async () => {
+    setupTrustRegistry();
+    const envelope = await signEnvelope({ customer_ids: ["different-cust"] });
+
+    await expect(
+      verifyEventsEnvelope(fakePool, envelope, samplePayload, baseClaims),
+    ).rejects.toThrow("customer_ids does not match");
+  });
+
+  it("rejects tampered envelope signature", async () => {
+    setupTrustRegistry();
+    const envelope = await signEnvelope();
+    const parts = envelope.split(".");
+    parts[2] = `${parts[2]}tampered`;
+    const tampered = parts.join(".");
+
+    await expect(
+      verifyEventsEnvelope(fakePool, tampered, samplePayload, baseClaims),
+    ).rejects.toThrow();
+  });
+
+  it("rejects unknown key in trust registry", async () => {
+    mockLookup.mockResolvedValue(null);
+    const envelope = await signEnvelope();
+
+    await expect(
+      verifyEventsEnvelope(fakePool, envelope, samplePayload, baseClaims),
+    ).rejects.toThrow("unknown key");
+  });
+
+  it("rejects invalid envelope format", async () => {
+    setupTrustRegistry();
+
+    await expect(
+      verifyEventsEnvelope(fakePool, "not-valid", samplePayload, baseClaims),
+    ).rejects.toThrow();
+  });
+
+  it("rejects envelope missing required claims", async () => {
+    setupTrustRegistry();
+    // Missing event_count
+    const partial = {
+      iss: "https://aice.test",
+      aice_id: "aice-1",
+      customer_ids: ["cust-ext-1"],
+      context_jti: "context-jti-1",
+      payload_hash: sampleHash,
+      schema_version: "1.0",
+    };
+    const payload = new TextEncoder().encode(JSON.stringify(partial));
+    const envelope = await new CompactSign(payload)
+      .setProtectedHeader({ alg: "ES256", kid: "key-1" })
+      .sign(privateKey);
+
+    await expect(
+      verifyEventsEnvelope(fakePool, envelope, samplePayload, baseClaims),
+    ).rejects.toThrow("missing event_count");
+  });
+
+  it("checks size cap before crypto (performance guard)", async () => {
+    // Even without trust registry setup (no key), size cap should fail first
+    vi.stubEnv("BRIDGE_MAX_PAYLOAD_BYTES", "5");
+    const envelope = await signEnvelope();
+    const largePayload = new Uint8Array(10);
+
+    await expect(
+      verifyEventsEnvelope(fakePool, envelope, largePayload, baseClaims),
+    ).rejects.toThrow("exceeds size cap");
+
+    // Trust registry was never called
+    expect(mockLookup).not.toHaveBeenCalled();
+    vi.unstubAllEnvs();
+  });
+});

--- a/src/lib/auth/__tests__/trust-registry.unit.test.ts
+++ b/src/lib/auth/__tests__/trust-registry.unit.test.ts
@@ -1,0 +1,218 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+// Mock server-only before importing the module
+vi.mock("server-only", () => ({}));
+
+// Mock the DB client
+const mockQuery = vi.fn();
+vi.mock("../../db/client", () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+import {
+  invalidateTrustRegistryCache,
+  lookupTrustRegistryKey,
+} from "../trust-registry";
+
+const fakePool = {} as Parameters<typeof lookupTrustRegistryKey>[0];
+
+const sampleKey: JsonWebKey = {
+  kty: "EC",
+  crv: "P-256",
+  x: "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+  y: "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+};
+
+beforeAll(() => {
+  vi.useFakeTimers();
+});
+
+afterAll(() => {
+  vi.useRealTimers();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  invalidateTrustRegistryCache();
+});
+
+describe("trust registry", () => {
+  it("returns entry for a matching key", async () => {
+    mockQuery.mockResolvedValueOnce([
+      {
+        aice_id: "aice-1",
+        issuer: "https://aice.test",
+        kid: "key-1",
+        public_key: sampleKey,
+      },
+    ]);
+
+    const entry = await lookupTrustRegistryKey(
+      fakePool,
+      "aice-1",
+      "https://aice.test",
+      "key-1",
+    );
+    expect(entry).not.toBeNull();
+    expect(entry?.aiceId).toBe("aice-1");
+    expect(entry?.issuer).toBe("https://aice.test");
+    expect(entry?.kid).toBe("key-1");
+    expect(entry?.publicKey).toEqual(sampleKey);
+  });
+
+  it("returns null for unknown key", async () => {
+    mockQuery.mockResolvedValueOnce([
+      {
+        aice_id: "aice-1",
+        issuer: "https://aice.test",
+        kid: "key-1",
+        public_key: sampleKey,
+      },
+    ]);
+
+    const entry = await lookupTrustRegistryKey(
+      fakePool,
+      "aice-1",
+      "https://aice.test",
+      "unknown-kid",
+    );
+    expect(entry).toBeNull();
+  });
+
+  it("supports multiple keys per issuer (key rotation)", async () => {
+    const key2: JsonWebKey = { ...sampleKey, x: "different" };
+    mockQuery.mockResolvedValueOnce([
+      {
+        aice_id: "aice-1",
+        issuer: "https://aice.test",
+        kid: "key-1",
+        public_key: sampleKey,
+      },
+      {
+        aice_id: "aice-1",
+        issuer: "https://aice.test",
+        kid: "key-2",
+        public_key: key2,
+      },
+    ]);
+
+    const entry1 = await lookupTrustRegistryKey(
+      fakePool,
+      "aice-1",
+      "https://aice.test",
+      "key-1",
+    );
+    const entry2 = await lookupTrustRegistryKey(
+      fakePool,
+      "aice-1",
+      "https://aice.test",
+      "key-2",
+    );
+    expect(entry1?.publicKey).toEqual(sampleKey);
+    expect(entry2?.publicKey).toEqual(key2);
+    // Only one DB call (cache hit for second lookup)
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches results for 60 seconds", async () => {
+    mockQuery.mockResolvedValue([
+      {
+        aice_id: "aice-1",
+        issuer: "https://aice.test",
+        kid: "key-1",
+        public_key: sampleKey,
+      },
+    ]);
+
+    await lookupTrustRegistryKey(
+      fakePool,
+      "aice-1",
+      "https://aice.test",
+      "key-1",
+    );
+    await lookupTrustRegistryKey(
+      fakePool,
+      "aice-1",
+      "https://aice.test",
+      "key-1",
+    );
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+
+    // Advance past TTL
+    vi.advanceTimersByTime(61_000);
+    await lookupTrustRegistryKey(
+      fakePool,
+      "aice-1",
+      "https://aice.test",
+      "key-1",
+    );
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidateCache forces a fresh load", async () => {
+    mockQuery.mockResolvedValue([
+      {
+        aice_id: "aice-1",
+        issuer: "https://aice.test",
+        kid: "key-1",
+        public_key: sampleKey,
+      },
+    ]);
+
+    await lookupTrustRegistryKey(
+      fakePool,
+      "aice-1",
+      "https://aice.test",
+      "key-1",
+    );
+    invalidateTrustRegistryCache();
+    await lookupTrustRegistryKey(
+      fakePool,
+      "aice-1",
+      "https://aice.test",
+      "key-1",
+    );
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("distinguishes keys across different aice_ids", async () => {
+    mockQuery.mockResolvedValueOnce([
+      {
+        aice_id: "aice-1",
+        issuer: "https://aice.test",
+        kid: "key-1",
+        public_key: sampleKey,
+      },
+      {
+        aice_id: "aice-2",
+        issuer: "https://aice.test",
+        kid: "key-1",
+        public_key: { ...sampleKey, x: "other" },
+      },
+    ]);
+
+    const e1 = await lookupTrustRegistryKey(
+      fakePool,
+      "aice-1",
+      "https://aice.test",
+      "key-1",
+    );
+    const e2 = await lookupTrustRegistryKey(
+      fakePool,
+      "aice-2",
+      "https://aice.test",
+      "key-1",
+    );
+    expect(e1?.aiceId).toBe("aice-1");
+    expect(e2?.aiceId).toBe("aice-2");
+    expect(e1?.publicKey).not.toEqual(e2?.publicKey);
+  });
+});

--- a/src/lib/auth/bridge.ts
+++ b/src/lib/auth/bridge.ts
@@ -1,0 +1,302 @@
+import "server-only";
+
+import type { Pool, PoolClient } from "pg";
+import { query, withTransaction } from "../db/client";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PendingConnection {
+  connectionId: string;
+  jti: string;
+  issuer: string;
+  aiceId: string;
+  customerIds: string[];
+  sub: string | null;
+  status: string;
+  expiresAt: Date;
+}
+
+export interface BridgeCallbackResult {
+  deny?: string;
+  sessionId?: string;
+  bridgeAiceId?: string;
+  bridgeCustomerIds?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CONNECTION_TTL_SECONDS = 300; // 5 minutes
+const JTI_GRACE_PERIOD_HOURS = 24;
+
+// ---------------------------------------------------------------------------
+// Create pending connection
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert a new pending_connections row. The jti unique constraint
+ * provides replay prevention.
+ */
+export async function createPendingConnection(
+  pool: Pool,
+  params: {
+    jti: string;
+    issuer: string;
+    aiceId: string;
+    customerIds: string[];
+    sub: string;
+  },
+): Promise<string> {
+  const rows = await query<{ connection_id: string }>(
+    pool,
+    `INSERT INTO pending_connections (jti, issuer, aice_id, customer_ids, sub, expires_at)
+     VALUES ($1, $2, $3, $4, $5, NOW() + INTERVAL '${CONNECTION_TTL_SECONDS} seconds')
+     RETURNING connection_id`,
+    [params.jti, params.issuer, params.aiceId, params.customerIds, params.sub],
+  );
+  return rows[0].connection_id;
+}
+
+// ---------------------------------------------------------------------------
+// Stage events payload
+// ---------------------------------------------------------------------------
+
+/**
+ * Store staged event payload linked to a pending connection.
+ */
+export async function stageEventsPayload(
+  pool: Pool,
+  params: {
+    connectionId: string;
+    aiceId: string;
+    payloadHash: string;
+    payload: Buffer;
+    eventCount: number;
+    schemaVersion: string;
+  },
+): Promise<string> {
+  const rows = await query<{ id: string }>(
+    pool,
+    `INSERT INTO staged_event_payloads
+       (connection_id, aice_id, payload_hash, payload, event_count, schema_version, expires_at)
+     VALUES ($1, $2, $3, $4, $5, $6, NOW() + INTERVAL '${CONNECTION_TTL_SECONDS} seconds')
+     RETURNING id`,
+    [
+      params.connectionId,
+      params.aiceId,
+      params.payloadHash,
+      params.payload,
+      params.eventCount,
+      params.schemaVersion,
+    ],
+  );
+  return rows[0].id;
+}
+
+// ---------------------------------------------------------------------------
+// Consume pending connection (atomic, in callback)
+// ---------------------------------------------------------------------------
+
+/**
+ * Atomically consume a pending connection. Only the first caller
+ * succeeds — concurrent attempts get zero rows from the RETURNING
+ * clause.
+ */
+async function atomicConsume(
+  client: PoolClient,
+  connectionId: string,
+): Promise<PendingConnection | null> {
+  const result = await client.query<{
+    connection_id: string;
+    jti: string;
+    issuer: string;
+    aice_id: string;
+    customer_ids: string[];
+    sub: string | null;
+    status: string;
+    expires_at: Date;
+  }>(
+    `UPDATE pending_connections
+     SET status = 'consumed'
+     WHERE connection_id = $1
+       AND status = 'pending'
+       AND expires_at > NOW()
+     RETURNING connection_id, jti, issuer, aice_id, customer_ids, sub, status, expires_at`,
+    [connectionId],
+  );
+
+  if (result.rows.length === 0) return null;
+
+  const row = result.rows[0];
+  return {
+    connectionId: row.connection_id,
+    jti: row.jti,
+    issuer: row.issuer,
+    aiceId: row.aice_id,
+    customerIds: row.customer_ids,
+    sub: row.sub,
+    expiresAt: row.expires_at,
+    status: row.status,
+  };
+}
+
+async function denyConsumed(
+  client: PoolClient,
+  connectionId: string,
+  reason: string,
+): Promise<BridgeCallbackResult> {
+  await client.query(
+    `UPDATE pending_connections SET status = 'denied' WHERE connection_id = $1`,
+    [connectionId],
+  );
+  return { deny: reason };
+}
+
+/**
+ * Process bridge callback: atomically consume the pending connection,
+ * verify customer mappings, create session, and link staged events —
+ * all within a single transaction so that a downstream failure rolls
+ * back the consume rather than leaving the connection unrecoverable.
+ */
+export async function processBridgeCallback(
+  pool: Pool,
+  connectionId: string,
+  accountId: string,
+  sessionParams: { ipAddress: string; userAgent: string },
+): Promise<BridgeCallbackResult> {
+  return withTransaction(pool, async (client) => {
+    // 1. Atomic consume
+    const conn = await atomicConsume(client, connectionId);
+    if (!conn) {
+      return { deny: "bridge_expired" };
+    }
+
+    // 2. Map external customer_ids to internal UUIDs via aice_environment_customers
+    //    customer_ids in pending_connections are external_key values.
+    //    Single query returns both internal ID and external_key with status info.
+    const mappingResult = await client.query<{
+      customer_id: string;
+      external_key: string;
+      customer_status: string;
+      env_status: string;
+    }>(
+      `SELECT DISTINCT c.id AS customer_id,
+              c.external_key,
+              c.status AS customer_status,
+              ae.status AS env_status
+       FROM aice_environment_customers aec
+       JOIN customers c ON c.id = aec.customer_id
+       JOIN aice_environments ae ON ae.aice_id = aec.aice_id
+       WHERE aec.aice_id = $1
+         AND c.external_key = ANY($2::text[])`,
+      [conn.aiceId, conn.customerIds],
+    );
+
+    // 3. Exact match verification
+    const mappedExternalKeys = new Set<string>();
+    const mappedCustomerIds: string[] = [];
+    for (const row of mappingResult.rows) {
+      if (row.customer_status !== "active") {
+        return denyConsumed(client, connectionId, "bridge_customer_inactive");
+      }
+      if (row.env_status !== "active") {
+        return denyConsumed(
+          client,
+          connectionId,
+          "bridge_environment_inactive",
+        );
+      }
+      mappedExternalKeys.add(row.external_key);
+      mappedCustomerIds.push(row.customer_id);
+    }
+
+    if (mappedExternalKeys.size !== conn.customerIds.length) {
+      return denyConsumed(client, connectionId, "bridge_customer_mismatch");
+    }
+
+    // 4. Verify account has access to ALL mapped customers
+    //    (membership or analyst assignment — single query for all)
+    const accessResult = await client.query<{ customer_id: string }>(
+      `SELECT customer_id FROM (
+         SELECT customer_id FROM account_customer_memberships
+         WHERE account_id = $1 AND customer_id = ANY($2::uuid[])
+         UNION
+         SELECT aca.customer_id FROM analyst_customer_assignments aca
+         JOIN accounts a ON a.id = aca.account_id AND a.analyst_eligible = true
+         WHERE aca.account_id = $1 AND aca.customer_id = ANY($2::uuid[])
+       ) sub`,
+      [accountId, mappedCustomerIds],
+    );
+
+    const accessibleIds = new Set(accessResult.rows.map((r) => r.customer_id));
+    for (const custId of mappedCustomerIds) {
+      if (!accessibleIds.has(custId)) {
+        return denyConsumed(client, connectionId, "bridge_no_access");
+      }
+    }
+
+    // 5. Create bridge session (inside transaction so consume rolls back on failure)
+    const sessionResult = await client.query<{ sid: string }>(
+      `INSERT INTO sessions
+         (account_id, auth_context, bridge_aice_id, bridge_customer_ids, ip_address, user_agent)
+       VALUES ($1, 'general', $2, $3, $4, $5)
+       RETURNING sid`,
+      [
+        accountId,
+        conn.aiceId,
+        mappedCustomerIds,
+        sessionParams.ipAddress,
+        sessionParams.userAgent,
+      ],
+    );
+    const sessionId = sessionResult.rows[0].sid;
+
+    // 6. Link staged events to the new session
+    await client.query(
+      `UPDATE staged_event_payloads SET session_id = $1 WHERE connection_id = $2`,
+      [sessionId, connectionId],
+    );
+
+    return {
+      sessionId,
+      bridgeAiceId: conn.aiceId,
+      bridgeCustomerIds: mappedCustomerIds,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Deny connection (set status back to denied)
+// ---------------------------------------------------------------------------
+
+export async function denyConnection(
+  pool: Pool,
+  connectionId: string,
+): Promise<void> {
+  await query(
+    pool,
+    `UPDATE pending_connections SET status = 'denied' WHERE connection_id = $1`,
+    [connectionId],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup expired connections
+// ---------------------------------------------------------------------------
+
+/**
+ * Delete expired pending connections that have passed the jti grace
+ * period (24 hours after expires_at). This preserves jti uniqueness
+ * for replay prevention during the grace window.
+ */
+export async function cleanupExpiredConnections(pool: Pool): Promise<number> {
+  const result = await pool.query(
+    `DELETE FROM pending_connections
+     WHERE expires_at < NOW() - INTERVAL '${JTI_GRACE_PERIOD_HOURS} hours'
+     RETURNING connection_id`,
+  );
+  return result.rowCount ?? 0;
+}

--- a/src/lib/auth/context-token.ts
+++ b/src/lib/auth/context-token.ts
@@ -1,0 +1,137 @@
+import "server-only";
+
+import { importJWK, jwtVerify } from "jose";
+import type { Pool } from "pg";
+import { lookupTrustRegistryKey } from "./trust-registry";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ContextTokenClaims {
+  iss: string;
+  aud: string;
+  sub: string;
+  aiceId: string;
+  customerIds: string[];
+  iat: number;
+  exp: number;
+  jti: string;
+}
+
+// ---------------------------------------------------------------------------
+// Limits
+// ---------------------------------------------------------------------------
+
+const MAX_CUSTOMER_IDS = 20;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify a context token JWT from aice-web-next.
+ *
+ * Steps:
+ * 1. Decode header to extract `kid` and `alg`
+ * 2. Decode payload (unverified) to extract `aice_id` and `iss`
+ * 3. Look up public key from trust registry
+ * 4. Verify JWT signature + standard claims
+ * 5. Validate `customer_ids` size limit
+ * 6. Return verified claims
+ *
+ * Throws on any verification failure.
+ */
+export async function verifyContextToken(
+  pool: Pool,
+  token: string,
+): Promise<ContextTokenClaims> {
+  // Decode header and payload without verification to extract routing info
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new Error("Invalid context token format");
+  }
+
+  const header = JSON.parse(
+    Buffer.from(parts[0], "base64url").toString("utf8"),
+  );
+  const unverifiedPayload = JSON.parse(
+    Buffer.from(parts[1], "base64url").toString("utf8"),
+  );
+
+  const kid = header.kid;
+  const alg = header.alg;
+  if (typeof kid !== "string" || typeof alg !== "string") {
+    throw new Error("Context token header missing kid or alg");
+  }
+
+  const aiceId = unverifiedPayload.aice_id;
+  const iss = unverifiedPayload.iss;
+  if (typeof aiceId !== "string" || typeof iss !== "string") {
+    throw new Error("Context token missing aice_id or iss");
+  }
+
+  // Look up public key from trust registry
+  const entry = await lookupTrustRegistryKey(pool, aiceId, iss, kid);
+  if (!entry) {
+    throw new Error(
+      `Trust registry: unknown key (aice_id=${aiceId}, iss=${iss}, kid=${kid})`,
+    );
+  }
+
+  const publicKey = await importJWK(entry.publicKey, alg);
+
+  // Verify JWT signature + standard claims
+  const { payload } = await jwtVerify(token, publicKey, {
+    issuer: iss,
+    audience: "aimer-web",
+  });
+
+  // Validate required claims
+  const sub = payload.sub;
+  const jti = payload.jti;
+  const verifiedAiceId = payload.aice_id;
+  const customerIds = payload.customer_ids;
+  const iat = payload.iat;
+  const exp = payload.exp;
+
+  if (typeof sub !== "string") {
+    throw new Error("Context token missing sub");
+  }
+  if (typeof jti !== "string") {
+    throw new Error("Context token missing jti");
+  }
+  if (typeof verifiedAiceId !== "string") {
+    throw new Error("Context token missing aice_id");
+  }
+  if (typeof iat !== "number" || typeof exp !== "number") {
+    throw new Error("Context token missing iat or exp");
+  }
+
+  if (!Array.isArray(customerIds)) {
+    throw new Error("Context token missing customer_ids array");
+  }
+  for (const id of customerIds) {
+    if (typeof id !== "string") {
+      throw new Error("Context token customer_ids must be strings");
+    }
+  }
+
+  // Size limit — DoS prevention
+  if (customerIds.length > MAX_CUSTOMER_IDS) {
+    throw new Error(
+      `Context token customer_ids exceeds maximum (${customerIds.length} > ${MAX_CUSTOMER_IDS})`,
+    );
+  }
+
+  return {
+    iss: iss as string,
+    aud: "aimer-web",
+    sub,
+    aiceId: verifiedAiceId,
+    customerIds: customerIds as string[],
+    iat,
+    exp,
+    jti,
+  };
+}

--- a/src/lib/auth/cookies.ts
+++ b/src/lib/auth/cookies.ts
@@ -92,10 +92,25 @@ export async function clearInvitationTokenCookie(): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Cleanup for temporary flow cookies (prevent stale cookies)
+// Bridge connection_id cookie (SameSite=Lax for cross-site redirect)
 // ---------------------------------------------------------------------------
 
-export async function clearFlowCookies(): Promise<void> {
+const CONNECTION_ID_MAX_AGE = 300; // 5 minutes
+
+export async function setConnectionIdCookie(
+  connectionId: string,
+): Promise<void> {
+  const jar = await cookies();
+  jar.set("connection_id", connectionId, {
+    httpOnly: true,
+    secure: isSecure,
+    sameSite: "lax",
+    path: "/",
+    maxAge: CONNECTION_ID_MAX_AGE,
+  });
+}
+
+export async function clearConnectionIdCookie(): Promise<void> {
   const jar = await cookies();
   jar.delete("connection_id");
 }

--- a/src/lib/auth/events-envelope.ts
+++ b/src/lib/auth/events-envelope.ts
@@ -1,0 +1,171 @@
+import "server-only";
+
+import { createHash } from "node:crypto";
+import { compactVerify, importJWK } from "jose";
+import type { Pool } from "pg";
+import type { ContextTokenClaims } from "./context-token";
+import { lookupTrustRegistryKey } from "./trust-registry";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface EventsEnvelopeClaims {
+  iss: string;
+  aiceId: string;
+  customerIds: string[];
+  contextJti: string;
+  payloadHash: string;
+  eventCount: number;
+  schemaVersion: string;
+}
+
+// ---------------------------------------------------------------------------
+// Limits
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MAX_PAYLOAD_BYTES = 50 * 1024 * 1024; // 50 MB
+
+function getMaxPayloadBytes(): number {
+  const envVal = process.env.BRIDGE_MAX_PAYLOAD_BYTES;
+  if (envVal) {
+    const parsed = Number(envVal);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_MAX_PAYLOAD_BYTES;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify a detection event envelope (JWS compact serialization) and
+ * its associated binary payload.
+ *
+ * Steps:
+ * 1. Check payload size cap (before any crypto)
+ * 2. Verify JWS signature using trust registry key
+ * 3. Parse envelope claims
+ * 4. Verify payload_hash matches SHA-256 of events_data
+ * 5. Verify context_jti matches context token's jti
+ * 6. Verify iss, aice_id, customer_ids match context token
+ *
+ * Throws on any verification failure.
+ */
+export async function verifyEventsEnvelope(
+  pool: Pool,
+  envelope: string,
+  eventsData: Uint8Array,
+  contextClaims: ContextTokenClaims,
+): Promise<EventsEnvelopeClaims> {
+  // 1. Size cap check — before any crypto
+  const maxBytes = getMaxPayloadBytes();
+  if (eventsData.byteLength > maxBytes) {
+    throw new Error(
+      `Events data exceeds size cap (${eventsData.byteLength} > ${maxBytes} bytes)`,
+    );
+  }
+
+  // 2. Verify JWS signature
+  // Decode protected header to extract kid and alg
+  const envelopeParts = envelope.split(".");
+  if (envelopeParts.length !== 3) {
+    throw new Error("Invalid events envelope format");
+  }
+
+  const header = JSON.parse(
+    Buffer.from(envelopeParts[0], "base64url").toString("utf8"),
+  );
+  const kid = header.kid;
+  const alg = header.alg;
+  if (typeof kid !== "string" || typeof alg !== "string") {
+    throw new Error("Events envelope header missing kid or alg");
+  }
+
+  const entry = await lookupTrustRegistryKey(
+    pool,
+    contextClaims.aiceId,
+    contextClaims.iss,
+    kid,
+  );
+  if (!entry) {
+    throw new Error("Events envelope: unknown key in trust registry");
+  }
+
+  const publicKey = await importJWK(entry.publicKey, alg);
+  const { payload: rawPayload } = await compactVerify(envelope, publicKey);
+
+  // 3. Parse envelope claims
+  const claims = JSON.parse(new TextDecoder().decode(rawPayload));
+
+  const iss = claims.iss;
+  const aiceId = claims.aice_id;
+  const customerIds = claims.customer_ids;
+  const contextJti = claims.context_jti;
+  const payloadHash = claims.payload_hash;
+  const eventCount = claims.event_count;
+  const schemaVersion = claims.schema_version;
+
+  if (typeof iss !== "string") {
+    throw new Error("Events envelope missing iss");
+  }
+  if (typeof aiceId !== "string") {
+    throw new Error("Events envelope missing aice_id");
+  }
+  if (!Array.isArray(customerIds)) {
+    throw new Error("Events envelope missing customer_ids");
+  }
+  if (typeof contextJti !== "string") {
+    throw new Error("Events envelope missing context_jti");
+  }
+  if (typeof payloadHash !== "string") {
+    throw new Error("Events envelope missing payload_hash");
+  }
+  if (typeof eventCount !== "number") {
+    throw new Error("Events envelope missing event_count");
+  }
+  if (typeof schemaVersion !== "string") {
+    throw new Error("Events envelope missing schema_version");
+  }
+
+  // 4. Verify payload_hash matches SHA-256 of events_data
+  const computedHash = createHash("sha256").update(eventsData).digest("hex");
+  if (computedHash !== payloadHash) {
+    throw new Error("Events envelope payload_hash mismatch");
+  }
+
+  // 5. Verify context_jti binding
+  if (contextJti !== contextClaims.jti) {
+    throw new Error("Events envelope context_jti does not match context token");
+  }
+
+  // 6. Verify iss, aice_id, customer_ids match context token exactly
+  if (iss !== contextClaims.iss) {
+    throw new Error("Events envelope iss does not match context token");
+  }
+  if (aiceId !== contextClaims.aiceId) {
+    throw new Error("Events envelope aice_id does not match context token");
+  }
+
+  const contextSet = new Set(contextClaims.customerIds);
+  const envelopeSet = new Set(customerIds as string[]);
+  if (
+    contextSet.size !== envelopeSet.size ||
+    ![...contextSet].every((id) => envelopeSet.has(id))
+  ) {
+    throw new Error(
+      "Events envelope customer_ids does not match context token",
+    );
+  }
+
+  return {
+    iss,
+    aiceId,
+    customerIds: customerIds as string[],
+    contextJti,
+    payloadHash,
+    eventCount,
+    schemaVersion,
+  };
+}

--- a/src/lib/auth/trust-registry.ts
+++ b/src/lib/auth/trust-registry.ts
@@ -1,0 +1,79 @@
+import "server-only";
+
+import type { Pool } from "pg";
+import { query } from "../db/client";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TrustRegistryEntry {
+  aiceId: string;
+  issuer: string;
+  kid: string;
+  publicKey: JsonWebKey;
+}
+
+// ---------------------------------------------------------------------------
+// Cache — 60-second TTL, full table load
+// ---------------------------------------------------------------------------
+
+let cache: Map<string, TrustRegistryEntry> | null = null;
+let cacheExpiresAt = 0;
+
+const CACHE_TTL_MS = 60_000;
+
+function cacheKey(aiceId: string, issuer: string, kid: string): string {
+  return `${aiceId}\0${issuer}\0${kid}`;
+}
+
+async function loadAll(pool: Pool): Promise<Map<string, TrustRegistryEntry>> {
+  const rows = await query<{
+    aice_id: string;
+    issuer: string;
+    kid: string;
+    public_key: JsonWebKey;
+  }>(
+    pool,
+    `SELECT aice_id, issuer, kid, public_key FROM trust_registry WHERE enabled = true`,
+  );
+
+  const map = new Map<string, TrustRegistryEntry>();
+  for (const row of rows) {
+    map.set(cacheKey(row.aice_id, row.issuer, row.kid), {
+      aiceId: row.aice_id,
+      issuer: row.issuer,
+      kid: row.kid,
+      publicKey: row.public_key,
+    });
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up a public key from the trust registry by (aice_id, issuer, kid).
+ * Returns null if the key is not found or is disabled.
+ */
+export async function lookupTrustRegistryKey(
+  pool: Pool,
+  aiceId: string,
+  issuer: string,
+  kid: string,
+): Promise<TrustRegistryEntry | null> {
+  const now = Date.now();
+  if (!cache || now >= cacheExpiresAt) {
+    cache = await loadAll(pool);
+    cacheExpiresAt = now + CACHE_TTL_MS;
+  }
+  return cache.get(cacheKey(aiceId, issuer, kid)) ?? null;
+}
+
+/** Invalidate the cache (useful after admin key management operations). */
+export function invalidateTrustRegistryCache(): void {
+  cache = null;
+  cacheExpiresAt = 0;
+}


### PR DESCRIPTION
## Summary

- Add trust registry with 60s TTL cached public key lookup and key rotation support
- Add context token JWT verification (signature, audience, expiry, customer_ids size limit, jti replay prevention)
- Add events envelope JWS verification (size cap before crypto, SHA-256 payload hash binding, context_jti binding)
- Add bridge entry endpoint (`POST /api/auth/bridge`): multipart parsing, pending connection creation, events staging, connection_id cookie, OIDC redirect
- Add bridge callback processing: atomic consume, customer mapping (external_key → internal UUID), status/access verification, bridge session creation, staged events linking — all within a single transaction for recoverability
- Add 5 bridge deny reasons to deny page (expired, customer mismatch, customer inactive, environment inactive, no access)
- Add selective flow cookie cleanup via `?flow=` query parameter to preserve cookies across sign-in redirect
- Add expired connection cleanup with 24-hour jti grace period

## Test plan

- [x] Unit tests: trust registry (6), context token (11), events envelope (12), bridge entry (9), callback bridge (10) — 48 tests total
- [x] DB integration tests: pending connections, atomic consume, bridge session constraints, customer mapping, staged events, cleanup, trust registry (15 tests, requires PostgreSQL)
- [x] E2E tests: bridge API endpoint (3), bridge deny page reasons (6)
- [x] Typecheck and Biome lint pass
- [x] Verify bridge deny clears auth cookies (at, csrf, token_exp)

Closes #33