### PR TITLE
Add staged event encryption and approval flow

### DIFF
--- a/e2e/fixtures/db.ts
+++ b/e2e/fixtures/db.ts
@@ -278,6 +278,10 @@ export async function cleanupTestData(data: TestData): Promise<void> {
     `DELETE FROM analyst_customer_assignments WHERE account_id = ANY($1)`,
     [accountIds],
   );
+  await p.query(
+    `DELETE FROM staged_event_payloads WHERE session_id IN (SELECT sid FROM sessions WHERE account_id = ANY($1))`,
+    [accountIds],
+  );
   await p.query(`DELETE FROM sessions WHERE account_id = ANY($1)`, [
     accountIds,
   ]);

--- a/e2e/staged-events-api.spec.ts
+++ b/e2e/staged-events-api.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Unauthenticated boundary tests for staged events API.
+// Verify that endpoints enforce auth and reject incorrect methods.
+// ---------------------------------------------------------------------------
+
+const DUMMY_UUID = "00000000-0000-0000-0000-000000000001";
+const ORIGIN = "http://localhost:3000";
+
+// =========================================================================
+// GET /api/events/staged
+// =========================================================================
+
+test.describe("GET /api/events/staged", () => {
+  test("returns 401 without auth cookie", async ({ request }) => {
+    const res = await request.get("/api/events/staged");
+    expect(res.status()).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  test("returns 401 with invalid auth cookie", async ({ context }) => {
+    await context.addCookies([
+      {
+        name: "at",
+        value: "invalid-jwt-token",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+
+    const res = await context.request.get("/api/events/staged");
+    expect(res.status()).toBe(401);
+  });
+
+  test("returns 405 for POST method", async ({ request }) => {
+    const res = await request.post("/api/events/staged", {
+      headers: { origin: ORIGIN },
+      data: {},
+    });
+    expect(res.status()).toBe(405);
+  });
+});
+
+// =========================================================================
+// GET /api/events/staged/:payloadId
+// =========================================================================
+
+test.describe("GET /api/events/staged/:payloadId", () => {
+  test("returns 401 without auth cookie", async ({ request }) => {
+    const res = await request.get(`/api/events/staged/${DUMMY_UUID}`);
+    expect(res.status()).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+});
+
+// =========================================================================
+// PATCH /api/events/staged/:payloadId/customers/:customerId
+// =========================================================================
+
+test.describe("PATCH /api/events/staged/:payloadId/customers/:customerId", () => {
+  test("returns 401 without auth cookie", async ({ request }) => {
+    const res = await request.patch(
+      `/api/events/staged/${DUMMY_UUID}/customers/${DUMMY_UUID}`,
+      {
+        headers: { origin: ORIGIN, "content-type": "application/json" },
+        data: { action: "approve" },
+      },
+    );
+    expect(res.status()).toBe(401);
+  });
+});
+
+// =========================================================================
+// POST /api/events/ingest
+// =========================================================================
+
+test.describe("POST /api/events/ingest", () => {
+  test("returns 401 without auth cookie", async ({ request }) => {
+    const res = await request.post("/api/events/ingest", {
+      headers: { origin: ORIGIN },
+      multipart: {
+        events_data: {
+          name: "events.bin",
+          mimeType: "application/octet-stream",
+          buffer: Buffer.from("test"),
+        },
+        customer_id: DUMMY_UUID,
+        aice_id: "aice-1",
+        schema_version: "1.0",
+        event_count: "5",
+      },
+    });
+    expect(res.status()).toBe(401);
+  });
+
+  test("returns 405 for GET method", async ({ request }) => {
+    const res = await request.get("/api/events/ingest");
+    expect(res.status()).toBe(405);
+  });
+});

--- a/e2e/staged-events-flow.spec.ts
+++ b/e2e/staged-events-flow.spec.ts
@@ -1,0 +1,230 @@
+import { expect, getTestPool, test } from "./fixtures";
+
+// ---------------------------------------------------------------------------
+// Authenticated E2E tests for staged events: list, detail, approve, reject.
+//
+// Each test seeds its own staged_event_payloads and staged_event_customers
+// rows using its own testData fixture, ensuring fixture-scoped isolation.
+// Manual upload (POST /api/events/ingest) is excluded because it requires
+// OpenBao Transit to be running for real encryption.
+// ---------------------------------------------------------------------------
+
+async function seedPayload(
+  sessionId: string,
+  customerId: string,
+  opts?: { customerBId?: string; status?: string },
+): Promise<string> {
+  const pool = getTestPool();
+  const p = await pool.query<{ id: string }>(
+    `INSERT INTO staged_event_payloads
+       (session_id, aice_id, payload_hash, payload, wrapped_dek, event_count, schema_version, expires_at)
+     VALUES ($1, 'aice-e2e', md5(random()::text), $2, 'vault:v1:e2edek', 10, '1.0', NOW() + INTERVAL '1 hour')
+     RETURNING id`,
+    [sessionId, Buffer.from("e2e-encrypted-payload")],
+  );
+  const payloadId = p.rows[0].id;
+
+  const status = opts?.status ?? "pending";
+  if (opts?.customerBId) {
+    await pool.query(
+      `INSERT INTO staged_event_customers (payload_id, customer_id, status)
+       VALUES ($1, $2, $3), ($1, $4, $3)`,
+      [payloadId, customerId, status, opts.customerBId],
+    );
+  } else {
+    await pool.query(
+      `INSERT INTO staged_event_customers (payload_id, customer_id, status)
+       VALUES ($1, $2, $3)`,
+      [payloadId, customerId, status],
+    );
+  }
+
+  return payloadId;
+}
+
+async function deletePayload(payloadId: string): Promise<void> {
+  const pool = getTestPool();
+  await pool.query(`DELETE FROM staged_event_payloads WHERE id = $1`, [
+    payloadId,
+  ]);
+}
+
+test.describe("Staged events — authenticated flow", () => {
+  test("GET /api/events/staged returns staged events for the session", async ({
+    managerPage,
+    testData,
+  }) => {
+    const id1 = await seedPayload(
+      testData.manager.sessionId,
+      testData.customer.id,
+      {
+        customerBId: testData.customerB.id,
+      },
+    );
+    const id2 = await seedPayload(
+      testData.manager.sessionId,
+      testData.customer.id,
+    );
+
+    try {
+      const res = await managerPage.request.get("/api/events/staged");
+      expect(res.status()).toBe(200);
+
+      const body = await res.json();
+      expect(body.events).toBeDefined();
+      expect(body.events.length).toBeGreaterThanOrEqual(2);
+
+      const multi = body.events.find(
+        (e: { payloadId: string }) => e.payloadId === id1,
+      );
+      expect(multi).toBeDefined();
+      expect(multi.eventCount).toBe(10);
+      expect(multi.customers).toHaveLength(2);
+    } finally {
+      await deletePayload(id1);
+      await deletePayload(id2);
+    }
+  });
+
+  test("GET /api/events/staged/:payloadId returns payload details", async ({
+    managerPage,
+    testData,
+  }) => {
+    const id = await seedPayload(
+      testData.manager.sessionId,
+      testData.customer.id,
+      {
+        customerBId: testData.customerB.id,
+      },
+    );
+
+    try {
+      const res = await managerPage.request.get(`/api/events/staged/${id}`);
+      expect(res.status()).toBe(200);
+
+      const body = await res.json();
+      expect(body.event.payloadId).toBe(id);
+      expect(body.event.customers).toHaveLength(2);
+    } finally {
+      await deletePayload(id);
+    }
+  });
+
+  test("GET /api/events/staged/:payloadId returns 404 for other session's payload", async ({
+    userPage,
+    testData,
+  }) => {
+    // Seed with manager's session, query with user's page
+    const id = await seedPayload(
+      testData.manager.sessionId,
+      testData.customer.id,
+    );
+
+    try {
+      const res = await userPage.request.get(`/api/events/staged/${id}`);
+      expect(res.status()).toBe(404);
+    } finally {
+      await deletePayload(id);
+    }
+  });
+
+  test("PATCH approve and reject update customer status", async ({
+    managerPage,
+    testData,
+  }) => {
+    const id = await seedPayload(
+      testData.manager.sessionId,
+      testData.customer.id,
+      {
+        customerBId: testData.customerB.id,
+      },
+    );
+
+    try {
+      const csrf = (await managerPage.context().cookies()).find(
+        (c) => c.name === "csrf",
+      )?.value;
+
+      // Approve customer A
+      const approveRes = await managerPage.request.patch(
+        `/api/events/staged/${id}/customers/${testData.customer.id}`,
+        {
+          headers: {
+            origin: "http://localhost:3000",
+            "x-csrf-token": csrf ?? "",
+          },
+          data: { action: "approve" },
+        },
+      );
+      expect(approveRes.status()).toBe(200);
+      const approveBody = await approveRes.json();
+      expect(approveBody.status).toBe("approved");
+
+      // Reject customer B
+      const rejectRes = await managerPage.request.patch(
+        `/api/events/staged/${id}/customers/${testData.customerB.id}`,
+        {
+          headers: {
+            origin: "http://localhost:3000",
+            "x-csrf-token": csrf ?? "",
+          },
+          data: { action: "reject" },
+        },
+      );
+      expect(rejectRes.status()).toBe(200);
+      const rejectBody = await rejectRes.json();
+      expect(rejectBody.status).toBe("rejected");
+    } finally {
+      // Payload may have been auto-deleted (all customers terminal)
+      await deletePayload(id).catch(() => {});
+    }
+  });
+
+  test("PATCH approve on non-pending customer returns 409", async ({
+    managerPage,
+    testData,
+  }) => {
+    // Seed a pre-approved customer
+    const pool = getTestPool();
+    const p = await pool.query<{ id: string }>(
+      `INSERT INTO staged_event_payloads
+         (session_id, aice_id, payload_hash, payload, wrapped_dek, event_count, schema_version, expires_at)
+       VALUES ($1, 'aice-e2e', md5(random()::text), $2, 'vault:v1:e2edek', 5, '2.0', NOW() + INTERVAL '1 hour')
+       RETURNING id`,
+      [testData.manager.sessionId, Buffer.from("e2e-encrypted-409")],
+    );
+    const id = p.rows[0].id;
+
+    // Insert two customers: one approved, one pending (so payload is not auto-cleaned)
+    await pool.query(
+      `INSERT INTO staged_event_customers (payload_id, customer_id, status, approved_at)
+       VALUES ($1, $2, 'approved', NOW())`,
+      [id, testData.customer.id],
+    );
+    await pool.query(
+      `INSERT INTO staged_event_customers (payload_id, customer_id, status)
+       VALUES ($1, $2, 'pending')`,
+      [id, testData.customerB.id],
+    );
+
+    try {
+      const csrf = (await managerPage.context().cookies()).find(
+        (c) => c.name === "csrf",
+      )?.value;
+
+      const res = await managerPage.request.patch(
+        `/api/events/staged/${id}/customers/${testData.customer.id}`,
+        {
+          headers: {
+            origin: "http://localhost:3000",
+            "x-csrf-token": csrf ?? "",
+          },
+          data: { action: "approve" },
+        },
+      );
+      expect(res.status()).toBe(409);
+    } finally {
+      await deletePayload(id);
+    }
+  });
+});

--- a/migrations/auth/0014_staged_events_encryption.sql
+++ b/migrations/auth/0014_staged_events_encryption.sql
@@ -1,0 +1,9 @@
+-- Add wrapped DEK column for OpenBao Transit envelope encryption.
+-- The payload column now stores AES-256-GCM ciphertext instead of plaintext.
+
+-- Remove any existing plaintext rows (dev-only; production has no staging data yet)
+DELETE FROM staged_event_customers;
+DELETE FROM staged_event_payloads;
+
+ALTER TABLE staged_event_payloads
+  ADD COLUMN wrapped_dek TEXT NOT NULL;

--- a/src/app/api/events/__tests__/ingest.unit.test.ts
+++ b/src/app/api/events/__tests__/ingest.unit.test.ts
@@ -1,0 +1,311 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockStageManualUpload = vi.fn();
+const mockEncryptPayload = vi.fn();
+const mockPoolQuery = vi.fn();
+const mockWithAuth = vi.fn(
+  // biome-ignore lint/complexity/noBannedTypes: test mock needs generic callable
+  (handler: Function) => (req: NextRequest) =>
+    handler(req, {
+      accountId: "acct-1",
+      sessionId: "sess-1",
+      authContext: "general",
+      tokenVersion: 1,
+      iat: 1000,
+      meta: { ipAddress: "127.0.0.1", userAgent: "test" },
+      bridgeAiceId: null,
+      bridgeCustomerIds: null,
+    }),
+);
+
+vi.mock("@/lib/auth/staged-events", () => ({
+  stageManualUpload: (...args: unknown[]) => mockStageManualUpload(...args),
+}));
+
+vi.mock("@/lib/crypto/envelope", () => ({
+  encryptPayload: (...args: unknown[]) => mockEncryptPayload(...args),
+}));
+
+vi.mock("@/lib/auth/audit-stub", () => ({
+  auditLog: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/auth/guards", () => ({
+  // biome-ignore lint/complexity/noBannedTypes: test mock needs generic callable
+  withAuth: (handler: Function) => mockWithAuth(handler),
+  verifyOrigin: () => null,
+  verifyCsrf: () => null,
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  getAuthPool: vi.fn(() => ({ query: mockPoolQuery })),
+}));
+
+const CUSTOMER_ID = "a0000000-0000-0000-0000-000000000001";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeIngestRequest(fields: Record<string, string | File>): NextRequest {
+  const form = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    form.append(key, value);
+  }
+  return new NextRequest("http://localhost:3000/api/events/ingest", {
+    method: "POST",
+    body: form,
+    headers: { origin: "http://localhost:3000" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/events/ingest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEncryptPayload.mockResolvedValue({
+      ciphertext: Buffer.from("encrypted"),
+      wrappedDek: "vault:v1:testkey",
+    });
+    mockStageManualUpload.mockResolvedValue("payload-id-1");
+    // Default: account has access to the customer
+    mockPoolQuery.mockResolvedValue({ rows: [{ "?column?": 1 }] });
+  });
+
+  async function callPOST(req: NextRequest) {
+    const { POST } = await import("../ingest/route");
+    return POST(req);
+  }
+
+  it("stages a manually uploaded file", async () => {
+    const file = new File([new Uint8Array([1, 2, 3])], "events.bin");
+    const req = makeIngestRequest({
+      events_data: file,
+      customer_id: CUSTOMER_ID,
+      aice_id: "aice-1",
+      schema_version: "1.0",
+      event_count: "5",
+    });
+
+    const res = await callPOST(req);
+    expect(res.status).toBe(201);
+
+    const body = await res.json();
+    expect(body.payloadId).toBe("payload-id-1");
+    expect(body.eventCount).toBe(5);
+
+    expect(mockEncryptPayload).toHaveBeenCalledOnce();
+    expect(mockStageManualUpload).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        sessionId: "sess-1",
+        aiceId: "aice-1",
+        customerIds: [CUSTOMER_ID],
+      }),
+    );
+  });
+
+  it("returns 400 when events_data is missing", async () => {
+    const req = makeIngestRequest({
+      customer_id: CUSTOMER_ID,
+      aice_id: "aice-1",
+      schema_version: "1.0",
+      event_count: "5",
+    });
+
+    const res = await callPOST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("events_data");
+  });
+
+  it("returns 400 when customer_id is invalid", async () => {
+    const file = new File([new Uint8Array([1])], "events.bin");
+    const req = makeIngestRequest({
+      events_data: file,
+      customer_id: "not-a-uuid",
+      aice_id: "aice-1",
+      schema_version: "1.0",
+      event_count: "5",
+    });
+
+    const res = await callPOST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("customer_id");
+  });
+
+  it("returns 400 when aice_id is missing", async () => {
+    const file = new File([new Uint8Array([1])], "events.bin");
+    const req = makeIngestRequest({
+      events_data: file,
+      customer_id: CUSTOMER_ID,
+      schema_version: "1.0",
+      event_count: "5",
+    });
+
+    const res = await callPOST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("aice_id");
+  });
+
+  it("returns 400 when event_count is invalid", async () => {
+    const file = new File([new Uint8Array([1])], "events.bin");
+    const req = makeIngestRequest({
+      events_data: file,
+      customer_id: CUSTOMER_ID,
+      aice_id: "aice-1",
+      schema_version: "1.0",
+      event_count: "abc",
+    });
+
+    const res = await callPOST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("event_count");
+  });
+
+  it("returns 400 when schema_version is missing", async () => {
+    const file = new File([new Uint8Array([1])], "events.bin");
+    const req = makeIngestRequest({
+      events_data: file,
+      customer_id: CUSTOMER_ID,
+      aice_id: "aice-1",
+      event_count: "5",
+    });
+
+    const res = await callPOST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("schema_version");
+  });
+
+  it("returns 413 when payload exceeds size cap", async () => {
+    // Create a file that exceeds the default 50MB cap
+    const originalEnv = process.env.BRIDGE_MAX_PAYLOAD_BYTES;
+    process.env.BRIDGE_MAX_PAYLOAD_BYTES = "10"; // 10 bytes cap
+
+    try {
+      const file = new File(
+        [new Uint8Array(20)], // 20 bytes > 10 byte cap
+        "events.bin",
+      );
+      const req = makeIngestRequest({
+        events_data: file,
+        customer_id: CUSTOMER_ID,
+        aice_id: "aice-1",
+        schema_version: "1.0",
+        event_count: "5",
+      });
+
+      const res = await callPOST(req);
+      expect(res.status).toBe(413);
+      const body = await res.json();
+      expect(body.error).toContain("size");
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.BRIDGE_MAX_PAYLOAD_BYTES;
+      } else {
+        process.env.BRIDGE_MAX_PAYLOAD_BYTES = originalEnv;
+      }
+    }
+  });
+
+  it("returns 403 when account has no access to customer", async () => {
+    // Non-bridge session: access check query returns no rows
+    mockPoolQuery.mockResolvedValue({ rows: [] });
+
+    const file = new File([new Uint8Array([1, 2, 3])], "events.bin");
+    const req = makeIngestRequest({
+      events_data: file,
+      customer_id: CUSTOMER_ID,
+      aice_id: "aice-1",
+      schema_version: "1.0",
+      event_count: "5",
+    });
+
+    const res = await callPOST(req);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when aice_id does not match bridge scope", async () => {
+    mockWithAuth.mockImplementation(
+      // biome-ignore lint/complexity/noBannedTypes: test mock needs generic callable
+      (handler: Function) => (req: NextRequest) =>
+        handler(req, {
+          accountId: "acct-1",
+          sessionId: "sess-1",
+          authContext: "general",
+          tokenVersion: 1,
+          iat: 1000,
+          meta: { ipAddress: "127.0.0.1", userAgent: "test" },
+          bridgeAiceId: "aice-real",
+          bridgeCustomerIds: [CUSTOMER_ID],
+        }),
+    );
+
+    vi.resetModules();
+    const { POST } = await import("../ingest/route");
+
+    const file = new File([new Uint8Array([1, 2, 3])], "events.bin");
+    const form = new FormData();
+    form.append("events_data", file);
+    form.append("customer_id", CUSTOMER_ID);
+    form.append("aice_id", "aice-wrong");
+    form.append("schema_version", "1.0");
+    form.append("event_count", "5");
+    const req = new NextRequest("http://localhost:3000/api/events/ingest", {
+      method: "POST",
+      body: form,
+      headers: { origin: "http://localhost:3000" },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("aice_id");
+  });
+
+  it("returns 403 when customer not in bridgeCustomerIds", async () => {
+    // Override the mock to include bridgeCustomerIds that exclude CUSTOMER_ID
+    mockWithAuth.mockImplementation(
+      // biome-ignore lint/complexity/noBannedTypes: test mock needs generic callable
+      (handler: Function) => (req: NextRequest) =>
+        handler(req, {
+          accountId: "acct-1",
+          sessionId: "sess-1",
+          authContext: "general",
+          tokenVersion: 1,
+          iat: 1000,
+          meta: { ipAddress: "127.0.0.1", userAgent: "test" },
+          bridgeAiceId: "aice-1",
+          bridgeCustomerIds: ["b0000000-0000-0000-0000-000000000099"],
+        }),
+    );
+
+    // Reset module cache so the route re-evaluates withAuth
+    vi.resetModules();
+    const { POST } = await import("../ingest/route");
+
+    const file = new File([new Uint8Array([1, 2, 3])], "events.bin");
+    const req = makeIngestRequest({
+      events_data: file,
+      customer_id: CUSTOMER_ID,
+      aice_id: "aice-1",
+      schema_version: "1.0",
+      event_count: "5",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/app/api/events/__tests__/staged-approve.unit.test.ts
+++ b/src/app/api/events/__tests__/staged-approve.unit.test.ts
@@ -1,0 +1,208 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockUpdateCustomerStatus = vi.fn();
+const mockPoolQuery = vi.fn();
+const mockAuditLog = vi.fn();
+
+vi.mock("@/lib/auth/staged-events", () => ({
+  updateCustomerStatus: (...args: unknown[]) =>
+    mockUpdateCustomerStatus(...args),
+  expireStagedEvents: vi.fn(async () => 0),
+}));
+
+vi.mock("@/lib/auth/audit-stub", () => ({
+  auditLog: mockAuditLog,
+}));
+
+vi.mock("@/lib/auth/guards", () => ({
+  // biome-ignore lint/complexity/noBannedTypes: test mock needs generic callable
+  withAuth: (handler: Function) => (req: NextRequest) =>
+    handler(req, {
+      accountId: "acct-1",
+      sessionId: "sess-1",
+      authContext: "general",
+      tokenVersion: 1,
+      iat: 1000,
+      meta: { ipAddress: "127.0.0.1", userAgent: "test" },
+      bridgeAiceId: "aice-1",
+      bridgeCustomerIds: [
+        "b0000000-0000-0000-0000-000000000001",
+        "b0000000-0000-0000-0000-000000000002",
+      ],
+    }),
+  verifyOrigin: () => null,
+  verifyCsrf: () => null,
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  getAuthPool: vi.fn(() => ({ query: mockPoolQuery })),
+  withTransaction: vi.fn((_pool: unknown, fn: (client: unknown) => unknown) =>
+    fn({}),
+  ),
+}));
+
+const PAYLOAD_ID = "a0000000-0000-0000-0000-000000000001";
+const CUSTOMER_ID = "b0000000-0000-0000-0000-000000000001";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PATCH /api/events/staged/[payloadId]/customers/[customerId]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: payload belongs to session
+    mockPoolQuery.mockResolvedValue({ rows: [{ id: PAYLOAD_ID }] });
+  });
+
+  async function callPATCH(
+    payloadId: string,
+    customerId: string,
+    body: unknown,
+  ) {
+    const { PATCH } = await import(
+      "../staged/[payloadId]/customers/[customerId]/route"
+    );
+    const req = new NextRequest(
+      `http://localhost:3000/api/events/staged/${payloadId}/customers/${customerId}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify(body),
+      },
+    );
+    return PATCH(req);
+  }
+
+  it("approves a pending customer", async () => {
+    mockUpdateCustomerStatus.mockResolvedValue({
+      updated: true,
+      newStatus: "approved",
+    });
+
+    const res = await callPATCH(PAYLOAD_ID, CUSTOMER_ID, {
+      action: "approve",
+    });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.status).toBe("approved");
+    expect(mockUpdateCustomerStatus).toHaveBeenCalledWith(
+      expect.anything(),
+      PAYLOAD_ID,
+      CUSTOMER_ID,
+      "approve",
+    );
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "staged_event.approve",
+        targetId: PAYLOAD_ID,
+        customerId: CUSTOMER_ID,
+      }),
+    );
+  });
+
+  it("rejects a pending customer", async () => {
+    mockUpdateCustomerStatus.mockResolvedValue({
+      updated: true,
+      newStatus: "rejected",
+    });
+
+    const res = await callPATCH(PAYLOAD_ID, CUSTOMER_ID, {
+      action: "reject",
+    });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.status).toBe("rejected");
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "staged_event.reject",
+        targetId: PAYLOAD_ID,
+        customerId: CUSTOMER_ID,
+      }),
+    );
+  });
+
+  it("returns 400 for invalid action", async () => {
+    const res = await callPATCH(PAYLOAD_ID, CUSTOMER_ID, {
+      action: "delete",
+    });
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toContain("approve");
+  });
+
+  it("returns 400 for invalid payloadId UUID", async () => {
+    const res = await callPATCH("not-uuid", CUSTOMER_ID, {
+      action: "approve",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when payload not owned by session", async () => {
+    mockPoolQuery.mockResolvedValue({ rows: [] });
+
+    const res = await callPATCH(PAYLOAD_ID, CUSTOMER_ID, {
+      action: "approve",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when customer not in bridge scope", async () => {
+    const res = await callPATCH(PAYLOAD_ID, "not-in-scope-id", {
+      action: "approve",
+    });
+    // "not-in-scope-id" is not a valid UUID, so it returns 400 first
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 for customer not in bridgeCustomerIds", async () => {
+    const otherCust = "b0000000-0000-0000-0000-000000000099";
+    const res = await callPATCH(PAYLOAD_ID, otherCust, {
+      action: "approve",
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 409 when no pending approval exists", async () => {
+    mockUpdateCustomerStatus.mockResolvedValue({
+      updated: false,
+      newStatus: "unchanged",
+    });
+
+    const res = await callPATCH(PAYLOAD_ID, CUSTOMER_ID, {
+      action: "approve",
+    });
+    expect(res.status).toBe(409);
+    expect(mockAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const { PATCH } = await import(
+      "../staged/[payloadId]/customers/[customerId]/route"
+    );
+    const req = new NextRequest(
+      `http://localhost:3000/api/events/staged/${PAYLOAD_ID}/customers/${CUSTOMER_ID}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: "not json",
+      },
+    );
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/events/__tests__/staged-detail.unit.test.ts
+++ b/src/app/api/events/__tests__/staged-detail.unit.test.ts
@@ -1,0 +1,93 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockGetStagedPayloadById = vi.fn();
+const mockPoolQuery = vi.fn();
+
+vi.mock("@/lib/auth/staged-events", () => ({
+  getStagedPayloadById: (...args: unknown[]) =>
+    mockGetStagedPayloadById(...args),
+  expireStagedEvents: vi.fn(async () => 0),
+}));
+
+vi.mock("@/lib/auth/guards", () => ({
+  // biome-ignore lint/complexity/noBannedTypes: test mock needs generic callable
+  withAuth: (handler: Function) => (req: NextRequest) =>
+    handler(req, {
+      accountId: "acct-1",
+      sessionId: "sess-1",
+      authContext: "general",
+      tokenVersion: 1,
+      iat: 1000,
+      meta: { ipAddress: "127.0.0.1", userAgent: "test" },
+      bridgeAiceId: null,
+      bridgeCustomerIds: null,
+    }),
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  getAuthPool: vi.fn(() => ({ query: mockPoolQuery })),
+}));
+
+const VALID_UUID = "a0000000-0000-0000-0000-000000000001";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/events/staged/[payloadId]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function callGET(payloadId: string) {
+    const { GET } = await import("../staged/[payloadId]/route");
+    const req = new NextRequest(
+      `http://localhost:3000/api/events/staged/${payloadId}`,
+    );
+    return GET(req);
+  }
+
+  it("returns payload details when owned by session", async () => {
+    mockPoolQuery.mockResolvedValue({ rows: [{ id: VALID_UUID }] });
+    mockGetStagedPayloadById.mockResolvedValue({
+      payloadId: VALID_UUID,
+      aiceId: "aice-1",
+      eventCount: 5,
+      schemaVersion: "1.0",
+      createdAt: new Date(),
+      expiresAt: new Date(),
+      customers: [
+        {
+          customerId: "c1",
+          customerName: "Customer A",
+          status: "pending",
+          approvedAt: null,
+        },
+      ],
+    });
+
+    const res = await callGET(VALID_UUID);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.event.payloadId).toBe(VALID_UUID);
+    expect(body.event.customers).toHaveLength(1);
+  });
+
+  it("returns 404 when payload not owned by session", async () => {
+    mockPoolQuery.mockResolvedValue({ rows: [] });
+
+    const res = await callGET(VALID_UUID);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for invalid UUID", async () => {
+    const res = await callGET("not-a-uuid");
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/events/__tests__/staged-list.unit.test.ts
+++ b/src/app/api/events/__tests__/staged-list.unit.test.ts
@@ -1,0 +1,91 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockListStagedEventsBySession = vi.fn();
+
+vi.mock("@/lib/auth/staged-events", () => ({
+  listStagedEventsBySession: (...args: unknown[]) =>
+    mockListStagedEventsBySession(...args),
+}));
+
+vi.mock("@/lib/auth/guards", () => ({
+  // biome-ignore lint/complexity/noBannedTypes: test mock needs generic callable
+  withAuth: (handler: Function) => (req: NextRequest) =>
+    handler(req, {
+      accountId: "acct-1",
+      sessionId: "sess-1",
+      authContext: "general",
+      tokenVersion: 1,
+      iat: 1000,
+      meta: { ipAddress: "127.0.0.1", userAgent: "test" },
+      bridgeAiceId: null,
+      bridgeCustomerIds: null,
+    }),
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  getAuthPool: vi.fn(() => ({})),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/events/staged", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function callGET() {
+    const { GET } = await import("../staged/route");
+    const req = new NextRequest("http://localhost:3000/api/events/staged");
+    return GET(req);
+  }
+
+  it("returns staged events for the session", async () => {
+    const events = [
+      {
+        payloadId: "p1",
+        aiceId: "aice-1",
+        eventCount: 10,
+        schemaVersion: "1.0",
+        createdAt: new Date(),
+        expiresAt: new Date(),
+        customers: [
+          {
+            customerId: "c1",
+            customerName: "Customer A",
+            status: "pending",
+            approvedAt: null,
+          },
+        ],
+      },
+    ];
+    mockListStagedEventsBySession.mockResolvedValue(events);
+
+    const res = await callGET();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].payloadId).toBe("p1");
+    expect(mockListStagedEventsBySession).toHaveBeenCalledWith(
+      expect.anything(),
+      "sess-1",
+    );
+  });
+
+  it("returns empty list when no staged events", async () => {
+    mockListStagedEventsBySession.mockResolvedValue([]);
+
+    const res = await callGET();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.events).toEqual([]);
+  });
+});

--- a/src/app/api/events/ingest/route.ts
+++ b/src/app/api/events/ingest/route.ts
@@ -1,0 +1,151 @@
+import { createHash } from "node:crypto";
+import type { NextRequest } from "next/server";
+import { auditLog } from "@/lib/auth/audit-stub";
+import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
+import { stageManualUpload } from "@/lib/auth/staged-events";
+import { encryptPayload } from "@/lib/crypto/envelope";
+import { getAuthPool } from "@/lib/db/client";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const DEFAULT_MAX_PAYLOAD_BYTES = 50 * 1024 * 1024; // 50 MB
+
+function getMaxPayloadBytes(): number {
+  const envVal = process.env.BRIDGE_MAX_PAYLOAD_BYTES;
+  if (envVal) {
+    const parsed = Number(envVal);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_MAX_PAYLOAD_BYTES;
+}
+
+export const POST = withAuth(async (req: NextRequest, auth) => {
+  const originErr = verifyOrigin(req);
+  if (originErr) return originErr;
+
+  const csrfErr = verifyCsrf(req, {
+    ctx: "general",
+    sid: auth.sessionId,
+    iat: auth.iat,
+  });
+  if (csrfErr) return csrfErr;
+
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch {
+    return Response.json(
+      { error: "Invalid multipart form data" },
+      { status: 400 },
+    );
+  }
+
+  // Extract required fields
+  const eventsDataField = formData.get("events_data");
+  const customerIdField = formData.get("customer_id");
+  const aiceIdField = formData.get("aice_id");
+  const schemaVersionField = formData.get("schema_version");
+  const eventCountField = formData.get("event_count");
+
+  if (!(eventsDataField instanceof File)) {
+    return Response.json(
+      { error: "Missing events_data file" },
+      { status: 400 },
+    );
+  }
+  if (typeof customerIdField !== "string" || !UUID_RE.test(customerIdField)) {
+    return Response.json(
+      { error: "Missing or invalid customer_id" },
+      { status: 400 },
+    );
+  }
+  if (typeof aiceIdField !== "string" || !aiceIdField) {
+    return Response.json({ error: "Missing aice_id" }, { status: 400 });
+  }
+  if (typeof schemaVersionField !== "string" || !schemaVersionField) {
+    return Response.json({ error: "Missing schema_version" }, { status: 400 });
+  }
+
+  const eventCount = Number(eventCountField);
+  if (!Number.isFinite(eventCount) || eventCount < 1) {
+    return Response.json(
+      { error: "Missing or invalid event_count" },
+      { status: 400 },
+    );
+  }
+
+  // Size check
+  const eventsDataBytes = new Uint8Array(await eventsDataField.arrayBuffer());
+  const maxBytes = getMaxPayloadBytes();
+  if (eventsDataBytes.byteLength > maxBytes) {
+    return Response.json(
+      { error: `Payload exceeds size cap (${maxBytes} bytes)` },
+      { status: 413 },
+    );
+  }
+
+  // Verify caller has access to the customer
+  if (auth.bridgeCustomerIds) {
+    if (!auth.bridgeCustomerIds.includes(customerIdField)) {
+      return Response.json({ error: "Forbidden" }, { status: 403 });
+    }
+    // Verify aice_id matches bridge scope
+    if (auth.bridgeAiceId && auth.bridgeAiceId !== aiceIdField) {
+      return Response.json(
+        { error: "aice_id does not match bridge scope" },
+        { status: 403 },
+      );
+    }
+  } else {
+    // Non-bridge session: verify account has access to the customer
+    const pool = getAuthPool();
+    const accessCheck = await pool.query(
+      `SELECT 1 FROM account_customer_memberships
+       WHERE account_id = $1 AND customer_id = $2
+       UNION ALL
+       SELECT 1 FROM analyst_customer_assignments aca
+       JOIN accounts a ON a.id = aca.account_id AND a.analyst_eligible = true
+       WHERE aca.account_id = $1 AND aca.customer_id = $2
+       LIMIT 1`,
+      [auth.accountId, customerIdField],
+    );
+    if (accessCheck.rows.length === 0) {
+      return Response.json({ error: "Forbidden" }, { status: 403 });
+    }
+  }
+
+  const payloadBuffer = Buffer.from(eventsDataBytes);
+  const payloadHash = createHash("sha256").update(payloadBuffer).digest("hex");
+  const { ciphertext, wrappedDek } = await encryptPayload(payloadBuffer);
+
+  const pool = getAuthPool();
+  const payloadId = await stageManualUpload(pool, {
+    sessionId: auth.sessionId,
+    aiceId: aiceIdField,
+    payloadHash,
+    ciphertext,
+    wrappedDek,
+    eventCount,
+    schemaVersion: schemaVersionField,
+    customerIds: [customerIdField],
+  });
+
+  await auditLog({
+    actorId: auth.accountId,
+    authContext: "general",
+    action: "staged_event.manual_upload",
+    targetType: "staged_event_payload",
+    targetId: payloadId,
+    details: {
+      customerId: customerIdField,
+      aiceId: aiceIdField,
+      eventCount,
+    },
+    ipAddress: auth.meta.ipAddress,
+    sid: auth.sessionId,
+    customerId: customerIdField,
+  });
+
+  return Response.json({ payloadId, eventCount }, { status: 201 });
+});

--- a/src/app/api/events/staged/[payloadId]/customers/[customerId]/route.ts
+++ b/src/app/api/events/staged/[payloadId]/customers/[customerId]/route.ts
@@ -1,0 +1,114 @@
+import type { NextRequest } from "next/server";
+import { auditLog } from "@/lib/auth/audit-stub";
+import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
+import {
+  expireStagedEvents,
+  updateCustomerStatus,
+} from "@/lib/auth/staged-events";
+import { getAuthPool, withTransaction } from "@/lib/db/client";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const PATCH = withAuth(async (req: NextRequest, auth) => {
+  const originErr = verifyOrigin(req);
+  if (originErr) return originErr;
+
+  const csrfErr = verifyCsrf(req, {
+    ctx: "general",
+    sid: auth.sessionId,
+    iat: auth.iat,
+  });
+  if (csrfErr) return csrfErr;
+
+  // Extract path params
+  const segments = req.nextUrl.pathname.split("/");
+  // /api/events/staged/[payloadId]/customers/[customerId]
+  const customerIdIdx = segments.length - 1;
+  const payloadIdIdx = segments.length - 3;
+  const customerId = segments[customerIdIdx];
+  const payloadId = segments[payloadIdIdx];
+
+  if (!payloadId || !UUID_RE.test(payloadId)) {
+    return Response.json(
+      { error: "Invalid payloadId format" },
+      { status: 400 },
+    );
+  }
+  if (!customerId || !UUID_RE.test(customerId)) {
+    return Response.json(
+      { error: "Invalid customerId format" },
+      { status: 400 },
+    );
+  }
+
+  // Parse body
+  let body: { action?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (body.action !== "approve" && body.action !== "reject") {
+    return Response.json(
+      { error: 'action must be "approve" or "reject"' },
+      { status: 400 },
+    );
+  }
+
+  const pool = getAuthPool();
+
+  // Expire stale payloads before checking
+  await expireStagedEvents(pool);
+
+  // Verify the payload belongs to the caller's session and is not expired
+  const ownership = await pool.query<{ id: string }>(
+    `SELECT id FROM staged_event_payloads
+     WHERE id = $1 AND session_id = $2 AND expires_at > NOW()`,
+    [payloadId, auth.sessionId],
+  );
+  if (ownership.rows.length === 0) {
+    return Response.json({ error: "Not found" }, { status: 404 });
+  }
+
+  // Verify the caller has access to this customer
+  if (auth.bridgeCustomerIds) {
+    if (!auth.bridgeCustomerIds.includes(customerId)) {
+      return Response.json({ error: "Forbidden" }, { status: 403 });
+    }
+  }
+
+  const result = await withTransaction(pool, (client) =>
+    updateCustomerStatus(
+      client,
+      payloadId,
+      customerId,
+      body.action as "approve" | "reject",
+    ),
+  );
+
+  if (!result.updated) {
+    return Response.json(
+      { error: "No pending approval found" },
+      { status: 409 },
+    );
+  }
+
+  await auditLog({
+    actorId: auth.accountId,
+    authContext: "general",
+    action: `staged_event.${body.action}`,
+    targetType: "staged_event_customer",
+    targetId: payloadId,
+    details: { customerId, newStatus: result.newStatus },
+    ipAddress: auth.meta.ipAddress,
+    sid: auth.sessionId,
+    customerId,
+  });
+
+  // TODO(#52): On approve, re-encrypt with customer-specific DEK and
+  // store in customer_db. For now, only the status is updated.
+
+  return Response.json({ status: result.newStatus });
+});

--- a/src/app/api/events/staged/[payloadId]/route.ts
+++ b/src/app/api/events/staged/[payloadId]/route.ts
@@ -1,0 +1,44 @@
+import type { NextRequest } from "next/server";
+import { withAuth } from "@/lib/auth/guards";
+import {
+  expireStagedEvents,
+  getStagedPayloadById,
+} from "@/lib/auth/staged-events";
+import { getAuthPool } from "@/lib/db/client";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const GET = withAuth(async (req: NextRequest, auth) => {
+  const segments = req.nextUrl.pathname.split("/");
+  const payloadId = segments[segments.length - 1];
+
+  if (!payloadId || !UUID_RE.test(payloadId)) {
+    return Response.json(
+      { error: "Invalid payloadId format" },
+      { status: 400 },
+    );
+  }
+
+  const pool = getAuthPool();
+
+  // Expire stale payloads before checking
+  await expireStagedEvents(pool);
+
+  // Verify the payload belongs to the caller's session and is not expired
+  const ownership = await pool.query<{ id: string }>(
+    `SELECT id FROM staged_event_payloads
+     WHERE id = $1 AND session_id = $2 AND expires_at > NOW()`,
+    [payloadId, auth.sessionId],
+  );
+  if (ownership.rows.length === 0) {
+    return Response.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const event = await getStagedPayloadById(pool, payloadId);
+  if (!event) {
+    return Response.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return Response.json({ event });
+});

--- a/src/app/api/events/staged/route.ts
+++ b/src/app/api/events/staged/route.ts
@@ -1,0 +1,9 @@
+import type { NextRequest } from "next/server";
+import { withAuth } from "@/lib/auth/guards";
+import { listStagedEventsBySession } from "@/lib/auth/staged-events";
+import { getAuthPool } from "@/lib/db/client";
+
+export const GET = withAuth(async (_req: NextRequest, auth) => {
+  const events = await listStagedEventsBySession(getAuthPool(), auth.sessionId);
+  return Response.json({ events });
+});

--- a/src/lib/auth/__tests__/bridge.db.test.ts
+++ b/src/lib/auth/__tests__/bridge.db.test.ts
@@ -248,7 +248,7 @@ describe.skipIf(!hasPostgres)("bridge DB integration", () => {
   // -- Staged events --
 
   describe("staged event payloads", () => {
-    it("stores and links staged events to session", async () => {
+    it("stores encrypted payload with wrapped_dek and links to session", async () => {
       // Create connection
       const conn = await pool.query<{ connection_id: string }>(
         `INSERT INTO pending_connections (jti, issuer, aice_id, customer_ids, sub, expires_at)
@@ -258,12 +258,13 @@ describe.skipIf(!hasPostgres)("bridge DB integration", () => {
       );
       const connId = conn.rows[0].connection_id;
 
-      // Stage payload
+      // Stage encrypted payload (includes wrapped_dek)
       const staged = await pool.query<{ id: string }>(
-        `INSERT INTO staged_event_payloads (connection_id, aice_id, payload_hash, payload, event_count, schema_version, expires_at)
-         VALUES ($1, 'aice-test-1', 'hash123', $2, 5, '1.0', NOW() + INTERVAL '5 minutes')
+        `INSERT INTO staged_event_payloads
+           (connection_id, aice_id, payload_hash, payload, wrapped_dek, event_count, schema_version, expires_at)
+         VALUES ($1, 'aice-test-1', 'hash123', $2, 'vault:v1:testdek', 5, '1.0', NOW() + INTERVAL '5 minutes')
          RETURNING id`,
-        [connId, Buffer.from("test payload")],
+        [connId, Buffer.from("encrypted-test-payload")],
       );
       expect(staged.rows).toHaveLength(1);
 
@@ -276,18 +277,120 @@ describe.skipIf(!hasPostgres)("bridge DB integration", () => {
       );
       const sid = session.rows[0].sid;
 
-      // Link
-      await pool.query(
-        `UPDATE staged_event_payloads SET session_id = $1 WHERE connection_id = $2`,
+      // Link staged events to session (simulates processBridgeCallback step 6)
+      const linked = await pool.query<{ id: string }>(
+        `UPDATE staged_event_payloads SET session_id = $1 WHERE connection_id = $2 RETURNING id`,
         [sid, connId],
       );
+      expect(linked.rows).toHaveLength(1);
 
-      // Verify link
-      const linked = await pool.query<{ session_id: string }>(
-        `SELECT session_id FROM staged_event_payloads WHERE id = $1`,
+      // Verify wrapped_dek stored
+      const verify = await pool.query<{
+        session_id: string;
+        wrapped_dek: string;
+      }>(
+        `SELECT session_id, wrapped_dek FROM staged_event_payloads WHERE id = $1`,
         [staged.rows[0].id],
       );
-      expect(linked.rows[0].session_id).toBe(sid);
+      expect(verify.rows[0].session_id).toBe(sid);
+      expect(verify.rows[0].wrapped_dek).toBe("vault:v1:testdek");
+    });
+
+    it("creates staged_event_customers rows for each payload-customer pair", async () => {
+      // Create connection with two customers
+      const conn = await pool.query<{ connection_id: string }>(
+        `INSERT INTO pending_connections (jti, issuer, aice_id, customer_ids, sub, expires_at)
+         VALUES ('jti-staged-cust-1', 'https://aice.test', 'aice-test-1', $1, 'user-1', NOW() + INTERVAL '5 minutes')
+         RETURNING connection_id`,
+        [["ext-cust-a", "ext-cust-b"]],
+      );
+      const connId = conn.rows[0].connection_id;
+
+      // Stage payload
+      const staged = await pool.query<{ id: string }>(
+        `INSERT INTO staged_event_payloads
+           (connection_id, aice_id, payload_hash, payload, wrapped_dek, event_count, schema_version, expires_at)
+         VALUES ($1, 'aice-test-1', 'hash-multi', $2, 'vault:v1:multi', 10, '1.0', NOW() + INTERVAL '5 minutes')
+         RETURNING id`,
+        [connId, Buffer.from("encrypted-multi-customer")],
+      );
+      const payloadId = staged.rows[0].id;
+
+      // Create customer rows (simulates processBridgeCallback step 7)
+      for (const custId of [customerId, customerIdB]) {
+        await pool.query(
+          `INSERT INTO staged_event_customers (payload_id, customer_id, status)
+           VALUES ($1, $2, 'pending')
+           ON CONFLICT (payload_id, customer_id) DO NOTHING`,
+          [payloadId, custId],
+        );
+      }
+
+      // Verify customer rows
+      const custRows = await pool.query<{
+        customer_id: string;
+        status: string;
+      }>(
+        `SELECT customer_id, status FROM staged_event_customers
+         WHERE payload_id = $1 ORDER BY customer_id`,
+        [payloadId],
+      );
+      expect(custRows.rows).toHaveLength(2);
+      for (const row of custRows.rows) {
+        expect(row.status).toBe("pending");
+      }
+      const ids = new Set(custRows.rows.map((r) => r.customer_id));
+      expect(ids.has(customerId)).toBe(true);
+      expect(ids.has(customerIdB)).toBe(true);
+    });
+
+    it("ON CONFLICT DO NOTHING prevents duplicate customer rows", async () => {
+      const conn = await pool.query<{ connection_id: string }>(
+        `INSERT INTO pending_connections (jti, issuer, aice_id, customer_ids, sub, expires_at)
+         VALUES ('jti-staged-dup-1', 'https://aice.test', 'aice-test-1', $1, 'user-1', NOW() + INTERVAL '5 minutes')
+         RETURNING connection_id`,
+        [["ext-cust-a"]],
+      );
+      const connId = conn.rows[0].connection_id;
+
+      const staged = await pool.query<{ id: string }>(
+        `INSERT INTO staged_event_payloads
+           (connection_id, aice_id, payload_hash, payload, wrapped_dek, event_count, schema_version, expires_at)
+         VALUES ($1, 'aice-test-1', 'hash-dup', $2, 'vault:v1:dup', 1, '1.0', NOW() + INTERVAL '5 minutes')
+         RETURNING id`,
+        [connId, Buffer.from("encrypted-dup")],
+      );
+
+      // Insert twice — second should be a no-op
+      await pool.query(
+        `INSERT INTO staged_event_customers (payload_id, customer_id, status)
+         VALUES ($1, $2, 'pending')
+         ON CONFLICT (payload_id, customer_id) DO NOTHING`,
+        [staged.rows[0].id, customerId],
+      );
+      await pool.query(
+        `INSERT INTO staged_event_customers (payload_id, customer_id, status)
+         VALUES ($1, $2, 'pending')
+         ON CONFLICT (payload_id, customer_id) DO NOTHING`,
+        [staged.rows[0].id, customerId],
+      );
+
+      const count = await pool.query(
+        `SELECT COUNT(*) AS cnt FROM staged_event_customers WHERE payload_id = $1`,
+        [staged.rows[0].id],
+      );
+      expect(Number(count.rows[0].cnt)).toBe(1);
+    });
+
+    it("rejects NULL wrapped_dek on insert", async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO staged_event_payloads
+             (aice_id, payload_hash, payload, wrapped_dek, event_count, schema_version, expires_at)
+           VALUES ('aice-test-1', 'hash-null', $1, NULL, 1, '1.0', NOW() + INTERVAL '5 minutes')`,
+          [Buffer.from("data")],
+        ),
+      ).rejects.toThrow();
     });
   });
 

--- a/src/lib/auth/__tests__/staged-events.db.test.ts
+++ b/src/lib/auth/__tests__/staged-events.db.test.ts
@@ -1,0 +1,488 @@
+import type { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeAdminPool,
+  createTestDatabase,
+  dropTestDatabase,
+} from "../../db/__tests__/db-test-helpers";
+import { withTransaction } from "../../db/client";
+
+const hasPostgres = !!process.env.DATABASE_ADMIN_URL;
+
+describe.skipIf(!hasPostgres)("staged events DB integration", () => {
+  let pool: Pool;
+  let dbName: string;
+  let accountId: string;
+  let customerId: string;
+  let customerIdB: string;
+  let sessionId: string;
+
+  beforeAll(async () => {
+    const result = await createTestDatabase("staged_events", "auth");
+    pool = result.pool;
+    dbName = result.dbName;
+
+    // Seed data
+    const acct = await pool.query<{ id: string }>(
+      `INSERT INTO accounts (oidc_issuer, oidc_subject, username, display_name, email)
+       VALUES ('test-issuer', 'staged-user', 'stageduser', 'Staged User', 'staged@test.com')
+       RETURNING id`,
+    );
+    accountId = acct.rows[0].id;
+
+    const custA = await pool.query<{ id: string }>(
+      `INSERT INTO customers (external_key, name, status, database_status)
+       VALUES ('ext-staged-a', 'Customer A', 'active', 'active')
+       RETURNING id`,
+    );
+    customerId = custA.rows[0].id;
+
+    const custB = await pool.query<{ id: string }>(
+      `INSERT INTO customers (external_key, name, status, database_status)
+       VALUES ('ext-staged-b', 'Customer B', 'active', 'active')
+       RETURNING id`,
+    );
+    customerIdB = custB.rows[0].id;
+
+    // Create a session for tests
+    const sess = await pool.query<{ sid: string }>(
+      `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent)
+       VALUES ($1, 'general', '127.0.0.1', 'test')
+       RETURNING sid`,
+      [accountId],
+    );
+    sessionId = sess.rows[0].sid;
+  });
+
+  afterAll(async () => {
+    await dropTestDatabase(dbName, pool, "auth");
+    await closeAdminPool();
+  });
+
+  // -- Helper to insert a staged payload --
+
+  async function insertPayload(opts?: {
+    sessionId?: string;
+    expiresInterval?: string;
+  }): Promise<string> {
+    const sid = opts?.sessionId ?? sessionId;
+    const interval = opts?.expiresInterval ?? "1 hour";
+    const result = await pool.query<{ id: string }>(
+      `INSERT INTO staged_event_payloads
+         (session_id, aice_id, payload_hash, payload, wrapped_dek, event_count, schema_version, expires_at)
+       VALUES ($1, 'aice-test', 'hash-abc', $2, 'vault:v1:wrappedkey', 10, '1.0', NOW() + INTERVAL '${interval}')
+       RETURNING id`,
+      [sid, Buffer.from("encrypted-payload-data")],
+    );
+    return result.rows[0].id;
+  }
+
+  async function insertCustomerRow(
+    payloadId: string,
+    custId: string,
+    status = "pending",
+  ): Promise<void> {
+    await pool.query(
+      `INSERT INTO staged_event_customers (payload_id, customer_id, status)
+       VALUES ($1, $2, $3)`,
+      [payloadId, custId, status],
+    );
+  }
+
+  // -- List staged events --
+
+  describe("listStagedEventsBySession", () => {
+    it("returns payloads with customer summaries", async () => {
+      const payloadId = await insertPayload();
+      await insertCustomerRow(payloadId, customerId);
+      await insertCustomerRow(payloadId, customerIdB);
+
+      // Query manually (module uses server-only import)
+      const rows = await pool.query<{
+        payload_id: string;
+        customer_id: string;
+        customer_name: string;
+        status: string;
+      }>(
+        `SELECT p.id AS payload_id, sec.customer_id, c.name AS customer_name, sec.status
+         FROM staged_event_payloads p
+         JOIN staged_event_customers sec ON sec.payload_id = p.id
+         JOIN customers c ON c.id = sec.customer_id
+         WHERE p.session_id = $1
+         ORDER BY c.name`,
+        [sessionId],
+      );
+
+      expect(rows.rows.length).toBeGreaterThanOrEqual(2);
+      const forPayload = rows.rows.filter((r) => r.payload_id === payloadId);
+      expect(forPayload).toHaveLength(2);
+      expect(forPayload.map((r) => r.status)).toEqual(["pending", "pending"]);
+    });
+  });
+
+  // -- Update customer status --
+
+  describe("updateCustomerStatus", () => {
+    it("approves a pending customer", async () => {
+      const payloadId = await insertPayload();
+      await insertCustomerRow(payloadId, customerId);
+
+      const result = await withTransaction(pool, async (client) => {
+        const res = await client.query<{ status: string; approved_at: Date }>(
+          `UPDATE staged_event_customers
+           SET status = 'approved', approved_at = NOW()
+           WHERE payload_id = $1 AND customer_id = $2 AND status = 'pending'
+           RETURNING status, approved_at`,
+          [payloadId, customerId],
+        );
+        return res;
+      });
+
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].status).toBe("approved");
+      expect(result.rows[0].approved_at).toBeInstanceOf(Date);
+    });
+
+    it("rejects a pending customer", async () => {
+      const payloadId = await insertPayload();
+      await insertCustomerRow(payloadId, customerId);
+
+      const result = await withTransaction(pool, async (client) => {
+        const res = await client.query<{ status: string }>(
+          `UPDATE staged_event_customers
+           SET status = 'rejected'
+           WHERE payload_id = $1 AND customer_id = $2 AND status = 'pending'
+           RETURNING status`,
+          [payloadId, customerId],
+        );
+        return res;
+      });
+
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].status).toBe("rejected");
+    });
+
+    it("does not update non-pending rows", async () => {
+      const payloadId = await insertPayload();
+      await insertCustomerRow(payloadId, customerId, "approved");
+
+      const result = await pool.query(
+        `UPDATE staged_event_customers
+         SET status = 'rejected'
+         WHERE payload_id = $1 AND customer_id = $2 AND status = 'pending'
+         RETURNING status`,
+        [payloadId, customerId],
+      );
+
+      expect(result.rows).toHaveLength(0);
+    });
+
+    it("respects unique constraint on (payload_id, customer_id)", async () => {
+      const payloadId = await insertPayload();
+      await insertCustomerRow(payloadId, customerId);
+
+      await expect(
+        pool.query(
+          `INSERT INTO staged_event_customers (payload_id, customer_id, status)
+           VALUES ($1, $2, 'pending')`,
+          [payloadId, customerId],
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  // -- Expire staged events --
+
+  describe("expireStagedEvents", () => {
+    it("marks pending customers as expired when payload has expired", async () => {
+      const payloadId = await insertPayload({ expiresInterval: "-1 second" });
+      await insertCustomerRow(payloadId, customerId);
+
+      const result = await pool.query(
+        `UPDATE staged_event_customers
+         SET status = 'expired'
+         FROM staged_event_payloads
+         WHERE staged_event_customers.payload_id = staged_event_payloads.id
+           AND staged_event_payloads.expires_at <= NOW()
+           AND staged_event_customers.status = 'pending'`,
+      );
+
+      expect(result.rowCount).toBeGreaterThanOrEqual(1);
+
+      const check = await pool.query<{ status: string }>(
+        `SELECT status FROM staged_event_customers WHERE payload_id = $1 AND customer_id = $2`,
+        [payloadId, customerId],
+      );
+      expect(check.rows[0].status).toBe("expired");
+    });
+
+    it("does not expire customers on non-expired payloads", async () => {
+      const payloadId = await insertPayload({ expiresInterval: "1 hour" });
+      await insertCustomerRow(payloadId, customerIdB);
+
+      await pool.query(
+        `UPDATE staged_event_customers
+         SET status = 'expired'
+         FROM staged_event_payloads
+         WHERE staged_event_customers.payload_id = staged_event_payloads.id
+           AND staged_event_payloads.expires_at <= NOW()
+           AND staged_event_customers.status = 'pending'`,
+      );
+
+      const check = await pool.query<{ status: string }>(
+        `SELECT status FROM staged_event_customers WHERE payload_id = $1 AND customer_id = $2`,
+        [payloadId, customerIdB],
+      );
+      expect(check.rows[0].status).toBe("pending");
+    });
+  });
+
+  // -- Cleanup terminal payloads --
+
+  describe("cleanupTerminalPayloads", () => {
+    it("deletes payloads where all customers are terminal", async () => {
+      const payloadId = await insertPayload();
+      await insertCustomerRow(payloadId, customerId, "approved");
+      await insertCustomerRow(payloadId, customerIdB, "rejected");
+
+      const result = await pool.query(
+        `DELETE FROM staged_event_payloads
+         WHERE id IN (
+           SELECT p.id
+           FROM staged_event_payloads p
+           WHERE NOT EXISTS (
+             SELECT 1 FROM staged_event_customers c
+             WHERE c.payload_id = p.id AND c.status = 'pending'
+           )
+           AND EXISTS (
+             SELECT 1 FROM staged_event_customers c2
+             WHERE c2.payload_id = p.id
+           )
+         )
+         RETURNING id`,
+      );
+
+      const deleted = result.rows.map((r: { id: string }) => r.id);
+      expect(deleted).toContain(payloadId);
+    });
+
+    it("preserves payloads with pending customers", async () => {
+      const payloadId = await insertPayload();
+      await insertCustomerRow(payloadId, customerId, "approved");
+      await insertCustomerRow(payloadId, customerIdB, "pending");
+
+      const result = await pool.query(
+        `DELETE FROM staged_event_payloads
+         WHERE id = $1
+           AND id IN (
+             SELECT p.id
+             FROM staged_event_payloads p
+             WHERE NOT EXISTS (
+               SELECT 1 FROM staged_event_customers c
+               WHERE c.payload_id = p.id AND c.status = 'pending'
+             )
+             AND EXISTS (
+               SELECT 1 FROM staged_event_customers c2
+               WHERE c2.payload_id = p.id
+             )
+           )
+         RETURNING id`,
+        [payloadId],
+      );
+
+      expect(result.rows).toHaveLength(0);
+    });
+  });
+
+  // -- Manual upload staging --
+
+  describe("manual upload staging", () => {
+    it("stages a payload with no connection_id and creates customer rows", async () => {
+      const payloadId = await insertPayload();
+      await insertCustomerRow(payloadId, customerId);
+
+      // Verify connection_id is NULL for this payload
+      const check = await pool.query<{ connection_id: string | null }>(
+        `SELECT connection_id FROM staged_event_payloads WHERE id = $1`,
+        [payloadId],
+      );
+      expect(check.rows[0].connection_id).toBeNull();
+
+      // Verify customer row
+      const custCheck = await pool.query<{
+        customer_id: string;
+        status: string;
+      }>(
+        `SELECT customer_id, status FROM staged_event_customers WHERE payload_id = $1`,
+        [payloadId],
+      );
+      expect(custCheck.rows.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // -- wrapped_dek column --
+
+  describe("wrapped_dek column", () => {
+    it("stores and retrieves wrapped DEK", async () => {
+      const result = await pool.query<{ wrapped_dek: string }>(
+        `INSERT INTO staged_event_payloads
+           (session_id, aice_id, payload_hash, payload, wrapped_dek, event_count, schema_version, expires_at)
+         VALUES ($1, 'aice-test', 'hash-dek', $2, 'vault:v1:testkey123', 5, '1.0', NOW() + INTERVAL '1 hour')
+         RETURNING wrapped_dek`,
+        [sessionId, Buffer.from("ciphertext-data")],
+      );
+      expect(result.rows[0].wrapped_dek).toBe("vault:v1:testkey123");
+    });
+
+    it("rejects NULL wrapped_dek", async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO staged_event_payloads
+             (session_id, aice_id, payload_hash, payload, wrapped_dek, event_count, schema_version, expires_at)
+           VALUES ($1, 'aice-test', 'hash-null', $2, NULL, 5, '1.0', NOW() + INTERVAL '1 hour')`,
+          [sessionId, Buffer.from("data")],
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  // -- Edge cases: mixed customer statuses --
+
+  describe("mixed customer statuses on single payload", () => {
+    it("one approved + one pending = payload NOT cleaned up", async () => {
+      const payloadId = await insertPayload();
+      await insertCustomerRow(payloadId, customerId, "approved");
+      await insertCustomerRow(payloadId, customerIdB, "pending");
+
+      const result = await pool.query(
+        `SELECT p.id FROM staged_event_payloads p
+         WHERE p.id = $1
+           AND NOT EXISTS (
+             SELECT 1 FROM staged_event_customers c
+             WHERE c.payload_id = p.id AND c.status = 'pending'
+           )`,
+        [payloadId],
+      );
+      expect(result.rows).toHaveLength(0); // pending still exists
+    });
+
+    it("one approved + one rejected = all terminal, eligible for cleanup", async () => {
+      const payloadId = await insertPayload();
+      await insertCustomerRow(payloadId, customerId, "approved");
+      await insertCustomerRow(payloadId, customerIdB, "rejected");
+
+      const result = await pool.query(
+        `SELECT p.id FROM staged_event_payloads p
+         WHERE p.id = $1
+           AND NOT EXISTS (
+             SELECT 1 FROM staged_event_customers c
+             WHERE c.payload_id = p.id AND c.status = 'pending'
+           )
+           AND EXISTS (
+             SELECT 1 FROM staged_event_customers c2
+             WHERE c2.payload_id = p.id
+           )`,
+        [payloadId],
+      );
+      expect(result.rows).toHaveLength(1);
+    });
+
+    it("one approved + one expired = all terminal, eligible for cleanup", async () => {
+      const payloadId = await insertPayload();
+      await insertCustomerRow(payloadId, customerId, "approved");
+      await insertCustomerRow(payloadId, customerIdB, "expired");
+
+      const result = await pool.query(
+        `SELECT p.id FROM staged_event_payloads p
+         WHERE p.id = $1
+           AND NOT EXISTS (
+             SELECT 1 FROM staged_event_customers c
+             WHERE c.payload_id = p.id AND c.status = 'pending'
+           )
+           AND EXISTS (
+             SELECT 1 FROM staged_event_customers c2
+             WHERE c2.payload_id = p.id
+           )`,
+        [payloadId],
+      );
+      expect(result.rows).toHaveLength(1);
+    });
+  });
+
+  // -- CASCADE deletion --
+
+  describe("CASCADE deletion", () => {
+    it("deleting a payload cascades to staged_event_customers", async () => {
+      const payloadId = await insertPayload();
+      await insertCustomerRow(payloadId, customerId, "approved");
+      await insertCustomerRow(payloadId, customerIdB, "rejected");
+
+      await pool.query(`DELETE FROM staged_event_payloads WHERE id = $1`, [
+        payloadId,
+      ]);
+
+      const check = await pool.query(
+        `SELECT COUNT(*) AS cnt FROM staged_event_customers WHERE payload_id = $1`,
+        [payloadId],
+      );
+      expect(Number(check.rows[0].cnt)).toBe(0);
+    });
+  });
+
+  // -- Session isolation --
+
+  describe("session isolation", () => {
+    it("payloads from different sessions are not mixed", async () => {
+      // Create a second session
+      const sess2 = await pool.query<{ sid: string }>(
+        `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent)
+         VALUES ($1, 'general', '127.0.0.1', 'test')
+         RETURNING sid`,
+        [accountId],
+      );
+      const sessionId2 = sess2.rows[0].sid;
+
+      const payload1 = await insertPayload({ sessionId });
+      const payload2 = await insertPayload({ sessionId: sessionId2 });
+      await insertCustomerRow(payload1, customerId);
+      await insertCustomerRow(payload2, customerId);
+
+      // Query session 1
+      const rows1 = await pool.query(
+        `SELECT p.id FROM staged_event_payloads p
+         JOIN staged_event_customers sec ON sec.payload_id = p.id
+         WHERE p.session_id = $1`,
+        [sessionId],
+      );
+      const ids1 = rows1.rows.map((r: { id: string }) => r.id);
+      expect(ids1).toContain(payload1);
+      expect(ids1).not.toContain(payload2);
+
+      // Query session 2
+      const rows2 = await pool.query(
+        `SELECT p.id FROM staged_event_payloads p
+         JOIN staged_event_customers sec ON sec.payload_id = p.id
+         WHERE p.session_id = $1`,
+        [sessionId2],
+      );
+      const ids2 = rows2.rows.map((r: { id: string }) => r.id);
+      expect(ids2).toContain(payload2);
+      expect(ids2).not.toContain(payload1);
+    });
+  });
+
+  // -- Status CHECK constraint --
+
+  describe("status CHECK constraint", () => {
+    it("rejects invalid status values", async () => {
+      const payloadId = await insertPayload();
+      await expect(
+        pool.query(
+          `INSERT INTO staged_event_customers (payload_id, customer_id, status)
+           VALUES ($1, $2, 'invalid_status')`,
+          [payloadId, customerId],
+        ),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/src/lib/auth/bridge.ts
+++ b/src/lib/auth/bridge.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import type { Pool, PoolClient } from "pg";
+import { encryptPayload } from "../crypto/envelope";
 import { query, withTransaction } from "../db/client";
 
 // ---------------------------------------------------------------------------
@@ -65,7 +66,10 @@ export async function createPendingConnection(
 // ---------------------------------------------------------------------------
 
 /**
- * Store staged event payload linked to a pending connection.
+ * Encrypt and store a staged event payload linked to a pending connection.
+ * The payload is encrypted via OpenBao Transit envelope encryption before
+ * storage — the `payload` column holds AES-256-GCM ciphertext and
+ * `wrapped_dek` holds the Transit-wrapped data encryption key.
  */
 export async function stageEventsPayload(
   pool: Pool,
@@ -78,17 +82,20 @@ export async function stageEventsPayload(
     schemaVersion: string;
   },
 ): Promise<string> {
+  const { ciphertext, wrappedDek } = await encryptPayload(params.payload);
+
   const rows = await query<{ id: string }>(
     pool,
     `INSERT INTO staged_event_payloads
-       (connection_id, aice_id, payload_hash, payload, event_count, schema_version, expires_at)
-     VALUES ($1, $2, $3, $4, $5, $6, NOW() + INTERVAL '${CONNECTION_TTL_SECONDS} seconds')
+       (connection_id, aice_id, payload_hash, payload, wrapped_dek, event_count, schema_version, expires_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, NOW() + INTERVAL '${CONNECTION_TTL_SECONDS} seconds')
      RETURNING id`,
     [
       params.connectionId,
       params.aiceId,
       params.payloadHash,
-      params.payload,
+      ciphertext,
+      wrappedDek,
       params.eventCount,
       params.schemaVersion,
     ],
@@ -255,10 +262,22 @@ export async function processBridgeCallback(
     const sessionId = sessionResult.rows[0].sid;
 
     // 6. Link staged events to the new session
-    await client.query(
-      `UPDATE staged_event_payloads SET session_id = $1 WHERE connection_id = $2`,
+    const linkedPayloads = await client.query<{ id: string }>(
+      `UPDATE staged_event_payloads SET session_id = $1 WHERE connection_id = $2 RETURNING id`,
       [sessionId, connectionId],
     );
+
+    // 7. Create staged_event_customers rows for each (payload, customer) pair
+    for (const payload of linkedPayloads.rows) {
+      for (const custId of mappedCustomerIds) {
+        await client.query(
+          `INSERT INTO staged_event_customers (payload_id, customer_id, status)
+           VALUES ($1, $2, 'pending')
+           ON CONFLICT (payload_id, customer_id) DO NOTHING`,
+          [payload.id, custId],
+        );
+      }
+    }
 
     return {
       sessionId,

--- a/src/lib/auth/staged-events.ts
+++ b/src/lib/auth/staged-events.ts
@@ -1,0 +1,316 @@
+import "server-only";
+
+import type { Pool, PoolClient } from "pg";
+import { decryptPayload } from "../crypto/envelope";
+import { query, withTransaction } from "../db/client";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type StagedEventCustomerStatus =
+  | "pending"
+  | "approved"
+  | "rejected"
+  | "expired";
+
+export interface StagedEventCustomerSummary {
+  customerId: string;
+  customerName: string;
+  status: StagedEventCustomerStatus;
+  approvedAt: Date | null;
+}
+
+export interface StagedEventSummary {
+  payloadId: string;
+  aiceId: string;
+  eventCount: number;
+  schemaVersion: string;
+  createdAt: Date;
+  expiresAt: Date;
+  customers: StagedEventCustomerSummary[];
+}
+
+// ---------------------------------------------------------------------------
+// List staged events for a session
+// ---------------------------------------------------------------------------
+
+export async function listStagedEventsBySession(
+  pool: Pool,
+  sessionId: string,
+): Promise<StagedEventSummary[]> {
+  // Opportunistic cleanup: expire stale pending rows
+  await expireStagedEvents(pool);
+
+  const rows = await query<{
+    payload_id: string;
+    aice_id: string;
+    event_count: number;
+    schema_version: string;
+    created_at: Date;
+    expires_at: Date;
+    customer_id: string;
+    customer_name: string;
+    status: StagedEventCustomerStatus;
+    approved_at: Date | null;
+  }>(
+    pool,
+    `SELECT p.id AS payload_id,
+            p.aice_id,
+            p.event_count,
+            p.schema_version,
+            p.created_at,
+            p.expires_at,
+            sec.customer_id,
+            c.name AS customer_name,
+            sec.status,
+            sec.approved_at
+     FROM staged_event_payloads p
+     JOIN staged_event_customers sec ON sec.payload_id = p.id
+     JOIN customers c ON c.id = sec.customer_id
+     WHERE p.session_id = $1
+     ORDER BY p.created_at DESC, c.name`,
+    [sessionId],
+  );
+
+  // Group by payload_id
+  const map = new Map<string, StagedEventSummary>();
+  for (const row of rows) {
+    let summary = map.get(row.payload_id);
+    if (!summary) {
+      summary = {
+        payloadId: row.payload_id,
+        aiceId: row.aice_id,
+        eventCount: row.event_count,
+        schemaVersion: row.schema_version,
+        createdAt: row.created_at,
+        expiresAt: row.expires_at,
+        customers: [],
+      };
+      map.set(row.payload_id, summary);
+    }
+    summary.customers.push({
+      customerId: row.customer_id,
+      customerName: row.customer_name,
+      status: row.status,
+      approvedAt: row.approved_at,
+    });
+  }
+
+  return [...map.values()];
+}
+
+// ---------------------------------------------------------------------------
+// Get a single staged payload by ID (metadata + customers, no decryption)
+// ---------------------------------------------------------------------------
+
+export async function getStagedPayloadById(
+  pool: Pool,
+  payloadId: string,
+): Promise<StagedEventSummary | null> {
+  const rows = await query<{
+    payload_id: string;
+    aice_id: string;
+    event_count: number;
+    schema_version: string;
+    created_at: Date;
+    expires_at: Date;
+    customer_id: string;
+    customer_name: string;
+    status: StagedEventCustomerStatus;
+    approved_at: Date | null;
+  }>(
+    pool,
+    `SELECT p.id AS payload_id,
+            p.aice_id,
+            p.event_count,
+            p.schema_version,
+            p.created_at,
+            p.expires_at,
+            sec.customer_id,
+            c.name AS customer_name,
+            sec.status,
+            sec.approved_at
+     FROM staged_event_payloads p
+     JOIN staged_event_customers sec ON sec.payload_id = p.id
+     JOIN customers c ON c.id = sec.customer_id
+     WHERE p.id = $1
+     ORDER BY c.name`,
+    [payloadId],
+  );
+
+  if (rows.length === 0) return null;
+
+  const first = rows[0];
+  return {
+    payloadId: first.payload_id,
+    aiceId: first.aice_id,
+    eventCount: first.event_count,
+    schemaVersion: first.schema_version,
+    createdAt: first.created_at,
+    expiresAt: first.expires_at,
+    customers: rows.map((r) => ({
+      customerId: r.customer_id,
+      customerName: r.customer_name,
+      status: r.status,
+      approvedAt: r.approved_at,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Decrypt a staged payload
+// ---------------------------------------------------------------------------
+
+export async function getStagedPayloadDecrypted(
+  pool: Pool,
+  payloadId: string,
+): Promise<{ payload: Buffer; payloadHash: string } | null> {
+  const rows = await query<{
+    payload: Buffer;
+    wrapped_dek: string;
+    payload_hash: string;
+  }>(
+    pool,
+    `SELECT payload, wrapped_dek, payload_hash
+     FROM staged_event_payloads WHERE id = $1`,
+    [payloadId],
+  );
+
+  if (rows.length === 0) return null;
+
+  const { payload: ciphertext, wrapped_dek, payload_hash } = rows[0];
+  const plaintext = await decryptPayload(ciphertext, wrapped_dek);
+  return { payload: plaintext, payloadHash: payload_hash };
+}
+
+// ---------------------------------------------------------------------------
+// Update per-customer status (approve / reject)
+// ---------------------------------------------------------------------------
+
+export async function updateCustomerStatus(
+  client: PoolClient,
+  payloadId: string,
+  customerId: string,
+  action: "approve" | "reject",
+): Promise<{ updated: boolean; newStatus: string }> {
+  const newStatus = action === "approve" ? "approved" : "rejected";
+  const result = await client.query<{ status: string }>(
+    `UPDATE staged_event_customers
+     SET status = $3,
+         approved_at = CASE WHEN $3 = 'approved' THEN NOW() ELSE approved_at END
+     WHERE payload_id = $1
+       AND customer_id = $2
+       AND status = 'pending'
+     RETURNING status`,
+    [payloadId, customerId, newStatus],
+  );
+
+  if (result.rows.length === 0) {
+    return { updated: false, newStatus: "unchanged" };
+  }
+
+  // If all customers for this payload are now terminal, delete the payload
+  const pending = await client.query(
+    `SELECT 1 FROM staged_event_customers
+     WHERE payload_id = $1 AND status = 'pending' LIMIT 1`,
+    [payloadId],
+  );
+  if (pending.rows.length === 0) {
+    await client.query(`DELETE FROM staged_event_payloads WHERE id = $1`, [
+      payloadId,
+    ]);
+  }
+
+  return { updated: true, newStatus: result.rows[0].status };
+}
+
+// ---------------------------------------------------------------------------
+// Expire pending customers on expired payloads
+// ---------------------------------------------------------------------------
+
+export async function expireStagedEvents(pool: Pool): Promise<number> {
+  const result = await pool.query(
+    `UPDATE staged_event_customers
+     SET status = 'expired'
+     FROM staged_event_payloads
+     WHERE staged_event_customers.payload_id = staged_event_payloads.id
+       AND staged_event_payloads.expires_at <= NOW()
+       AND staged_event_customers.status = 'pending'`,
+  );
+  return result.rowCount ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup fully-resolved payloads
+// ---------------------------------------------------------------------------
+
+export async function cleanupTerminalPayloads(pool: Pool): Promise<number> {
+  const result = await pool.query(
+    `DELETE FROM staged_event_payloads
+     WHERE id IN (
+       SELECT p.id
+       FROM staged_event_payloads p
+       WHERE NOT EXISTS (
+         SELECT 1 FROM staged_event_customers c
+         WHERE c.payload_id = p.id AND c.status = 'pending'
+       )
+       AND EXISTS (
+         SELECT 1 FROM staged_event_customers c2
+         WHERE c2.payload_id = p.id
+       )
+     )`,
+  );
+  return result.rowCount ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// Stage events for manual upload (no bridge connection)
+// ---------------------------------------------------------------------------
+
+export async function stageManualUpload(
+  pool: Pool,
+  params: {
+    sessionId: string;
+    aiceId: string;
+    payloadHash: string;
+    ciphertext: Buffer;
+    wrappedDek: string;
+    eventCount: number;
+    schemaVersion: string;
+    customerIds: string[];
+    ttlSeconds?: number;
+  },
+): Promise<string> {
+  const ttl = params.ttlSeconds ?? 86400; // 24 hours default for manual uploads
+  return withTransaction(pool, async (client) => {
+    const result = await client.query<{ id: string }>(
+      `INSERT INTO staged_event_payloads
+         (session_id, aice_id, payload_hash, payload, wrapped_dek, event_count, schema_version, expires_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, NOW() + INTERVAL '1 second' * $8)
+       RETURNING id`,
+      [
+        params.sessionId,
+        params.aiceId,
+        params.payloadHash,
+        params.ciphertext,
+        params.wrappedDek,
+        params.eventCount,
+        params.schemaVersion,
+        ttl,
+      ],
+    );
+    const payloadId = result.rows[0].id;
+
+    for (const custId of params.customerIds) {
+      await client.query(
+        `INSERT INTO staged_event_customers (payload_id, customer_id, status)
+         VALUES ($1, $2, 'pending')
+         ON CONFLICT (payload_id, customer_id) DO NOTHING`,
+        [payloadId, custId],
+      );
+    }
+
+    return payloadId;
+  });
+}

--- a/src/lib/crypto/__tests__/envelope.unit.test.ts
+++ b/src/lib/crypto/__tests__/envelope.unit.test.ts
@@ -1,0 +1,147 @@
+import { randomBytes } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// Mock the transit module
+const mockGenerateDataKey = vi.fn();
+const mockDecryptDataKey = vi.fn();
+
+vi.mock("../transit", () => ({
+  getTransitConfig: () => ({ addr: "http://localhost:8200", token: "test" }),
+  generateDataKey: (...args: unknown[]) => mockGenerateDataKey(...args),
+  decryptDataKey: (...args: unknown[]) => mockDecryptDataKey(...args),
+}));
+
+import { decryptPayload, encryptPayload } from "../envelope";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function setupMockKeys() {
+  // Use a real 256-bit key for AES-256-GCM
+  const realKey = randomBytes(32);
+  const wrappedDek = "vault:v1:mockedwrappedkey";
+
+  mockGenerateDataKey.mockResolvedValue({
+    plaintext: Buffer.from(realKey),
+    wrappedDek,
+  });
+
+  // For decryption, return the same key
+  mockDecryptDataKey.mockResolvedValue(Buffer.from(realKey));
+
+  return { realKey, wrappedDek };
+}
+
+describe("encryptPayload", () => {
+  it("encrypts plaintext and returns ciphertext + wrappedDek", async () => {
+    const { wrappedDek } = setupMockKeys();
+    const plaintext = Buffer.from("hello world detection events");
+
+    const result = await encryptPayload(plaintext);
+
+    expect(result.wrappedDek).toBe(wrappedDek);
+    expect(result.ciphertext).toBeInstanceOf(Buffer);
+    // IV (12) + at least 1 byte of ciphertext + auth tag (16)
+    expect(result.ciphertext.length).toBeGreaterThanOrEqual(12 + 1 + 16);
+    // Ciphertext should differ from plaintext
+    expect(result.ciphertext.toString("hex")).not.toBe(
+      plaintext.toString("hex"),
+    );
+
+    expect(mockGenerateDataKey).toHaveBeenCalledWith(
+      { addr: "http://localhost:8200", token: "test" },
+      "staging-events",
+    );
+  });
+
+  it("uses custom key name when provided", async () => {
+    setupMockKeys();
+    const plaintext = Buffer.from("data");
+
+    await encryptPayload(plaintext, "custom-key");
+
+    expect(mockGenerateDataKey).toHaveBeenCalledWith(
+      expect.anything(),
+      "custom-key",
+    );
+  });
+});
+
+describe("decryptPayload", () => {
+  it("round-trips: encrypt then decrypt returns original plaintext", async () => {
+    setupMockKeys();
+    const original = Buffer.from(
+      "binary detection event payload with special chars: \x00\xff\xfe",
+    );
+
+    const encrypted = await encryptPayload(original);
+    const decrypted = await decryptPayload(
+      encrypted.ciphertext,
+      encrypted.wrappedDek,
+    );
+
+    expect(decrypted).toEqual(original);
+  });
+
+  it("round-trips large payloads", async () => {
+    setupMockKeys();
+    const original = randomBytes(1024 * 1024); // 1 MB
+
+    const encrypted = await encryptPayload(original);
+    const decrypted = await decryptPayload(
+      encrypted.ciphertext,
+      encrypted.wrappedDek,
+    );
+
+    expect(decrypted).toEqual(original);
+  });
+
+  it("throws on ciphertext too short", async () => {
+    setupMockKeys();
+
+    await expect(
+      decryptPayload(Buffer.from("short"), "vault:v1:key"),
+    ).rejects.toThrow("Ciphertext too short");
+  });
+
+  it("throws on tampered ciphertext", async () => {
+    setupMockKeys();
+    const original = Buffer.from("sensitive data");
+
+    const encrypted = await encryptPayload(original);
+    // Tamper with a byte in the middle of the ciphertext
+    const tampered = Buffer.from(encrypted.ciphertext);
+    tampered[14] ^= 0xff;
+
+    await expect(
+      decryptPayload(tampered, encrypted.wrappedDek),
+    ).rejects.toThrow();
+  });
+
+  it("encrypts empty buffer", async () => {
+    setupMockKeys();
+    const original = Buffer.alloc(0);
+
+    const encrypted = await encryptPayload(original);
+    const decrypted = await decryptPayload(
+      encrypted.ciphertext,
+      encrypted.wrappedDek,
+    );
+
+    expect(decrypted).toEqual(original);
+  });
+});
+
+describe("ciphertext format", () => {
+  it("starts with 12-byte IV and ends with 16-byte auth tag", async () => {
+    setupMockKeys();
+    const plaintext = Buffer.from("test data");
+    const encrypted = await encryptPayload(plaintext);
+
+    // Total length: 12 (IV) + plaintext.length (encrypted) + 16 (tag)
+    expect(encrypted.ciphertext.length).toBe(12 + plaintext.length + 16);
+  });
+});

--- a/src/lib/crypto/__tests__/transit.unit.test.ts
+++ b/src/lib/crypto/__tests__/transit.unit.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { decryptDataKey, generateDataKey, rewrapDataKey } from "../transit";
+
+const config = { addr: "http://localhost:8200", token: "test-token" };
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function transitOk(data: Record<string, unknown>) {
+  return new Response(JSON.stringify({ data }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("generateDataKey", () => {
+  it("calls transit/datakey/plaintext and returns key + wrapped DEK", async () => {
+    const plaintext = Buffer.from("0123456789abcdef0123456789abcdef").toString(
+      "base64",
+    );
+    const ciphertext = "vault:v1:wrappedkeydata";
+    mockFetch.mockResolvedValueOnce(transitOk({ plaintext, ciphertext }));
+
+    const result = await generateDataKey(config, "staging-events");
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe(
+      "http://localhost:8200/v1/transit/datakey/plaintext/staging-events",
+    );
+    expect(opts.method).toBe("POST");
+    expect(opts.headers["X-Vault-Token"]).toBe("test-token");
+
+    expect(result.plaintext).toBeInstanceOf(Buffer);
+    expect(result.wrappedDek).toBe(ciphertext);
+  });
+
+  it("throws on non-OK response", async () => {
+    mockFetch.mockResolvedValueOnce(new Response("forbidden", { status: 403 }));
+
+    await expect(generateDataKey(config, "staging-events")).rejects.toThrow(
+      "Transit datakey/plaintext/staging-events failed (403)",
+    );
+  });
+
+  it("throws on missing data in response", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+
+    await expect(generateDataKey(config, "staging-events")).rejects.toThrow(
+      "missing data in response",
+    );
+  });
+});
+
+describe("decryptDataKey", () => {
+  it("calls transit/decrypt and returns plaintext Buffer", async () => {
+    const plaintext = Buffer.from("secret-key-material").toString("base64");
+    mockFetch.mockResolvedValueOnce(transitOk({ plaintext }));
+
+    const result = await decryptDataKey(
+      config,
+      "staging-events",
+      "vault:v1:wrappedkey",
+    );
+
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result.toString()).toBe("secret-key-material");
+
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe("http://localhost:8200/v1/transit/decrypt/staging-events");
+    const body = JSON.parse(opts.body);
+    expect(body.ciphertext).toBe("vault:v1:wrappedkey");
+  });
+
+  it("throws on error response", async () => {
+    mockFetch.mockResolvedValueOnce(new Response("not found", { status: 404 }));
+
+    await expect(
+      decryptDataKey(config, "staging-events", "vault:v1:bad"),
+    ).rejects.toThrow("failed (404)");
+  });
+});
+
+describe("rewrapDataKey", () => {
+  it("calls transit/rewrap and returns new wrapped DEK", async () => {
+    mockFetch.mockResolvedValueOnce(
+      transitOk({ ciphertext: "vault:v2:newwrappedkey" }),
+    );
+
+    const result = await rewrapDataKey(
+      config,
+      "staging-events",
+      "vault:v1:oldwrappedkey",
+    );
+
+    expect(result).toBe("vault:v2:newwrappedkey");
+
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe("http://localhost:8200/v1/transit/rewrap/staging-events");
+    const body = JSON.parse(opts.body);
+    expect(body.ciphertext).toBe("vault:v1:oldwrappedkey");
+  });
+});

--- a/src/lib/crypto/envelope.ts
+++ b/src/lib/crypto/envelope.ts
@@ -1,0 +1,108 @@
+import "server-only";
+
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import {
+  type DataKey,
+  decryptDataKey,
+  generateDataKey,
+  getTransitConfig,
+} from "./transit";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const AES_ALGORITHM = "aes-256-gcm";
+const IV_BYTES = 12;
+const AUTH_TAG_BYTES = 16;
+const DEFAULT_KEY_NAME = "staging-events";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface EncryptedPayload {
+  /** IV (12B) || GCM ciphertext || auth tag (16B) */
+  ciphertext: Buffer;
+  /** Transit-wrapped DEK (base64 string) */
+  wrappedDek: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function zeroDek(dek: DataKey | Buffer): void {
+  const buf = Buffer.isBuffer(dek) ? dek : dek.plaintext;
+  buf.fill(0);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Encrypt a plaintext payload using envelope encryption.
+ *
+ * 1. Generate a fresh DEK via OpenBao Transit
+ * 2. AES-256-GCM encrypt the payload with the DEK
+ * 3. Zero the plaintext DEK
+ * 4. Return ciphertext + Transit-wrapped DEK
+ */
+export async function encryptPayload(
+  plaintext: Buffer,
+  keyName = DEFAULT_KEY_NAME,
+): Promise<EncryptedPayload> {
+  const config = getTransitConfig();
+  const dataKey = await generateDataKey(config, keyName);
+
+  try {
+    const iv = randomBytes(IV_BYTES);
+    const cipher = createCipheriv(AES_ALGORITHM, dataKey.plaintext, iv);
+    const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+
+    const ciphertext = Buffer.concat([iv, encrypted, authTag]);
+
+    return { ciphertext, wrappedDek: dataKey.wrappedDek };
+  } finally {
+    zeroDek(dataKey);
+  }
+}
+
+/**
+ * Decrypt a payload that was encrypted with `encryptPayload`.
+ *
+ * 1. Unwrap the DEK via OpenBao Transit
+ * 2. AES-256-GCM decrypt
+ * 3. Zero the DEK
+ * 4. Return plaintext
+ */
+export async function decryptPayload(
+  ciphertext: Buffer,
+  wrappedDek: string,
+  keyName = DEFAULT_KEY_NAME,
+): Promise<Buffer> {
+  const minLength = IV_BYTES + AUTH_TAG_BYTES;
+  if (ciphertext.length < minLength) {
+    throw new Error("Ciphertext too short");
+  }
+
+  const config = getTransitConfig();
+  const dek = await decryptDataKey(config, keyName, wrappedDek);
+
+  try {
+    const iv = ciphertext.subarray(0, IV_BYTES);
+    const authTag = ciphertext.subarray(ciphertext.length - AUTH_TAG_BYTES);
+    const encryptedData = ciphertext.subarray(
+      IV_BYTES,
+      ciphertext.length - AUTH_TAG_BYTES,
+    );
+
+    const decipher = createDecipheriv(AES_ALGORITHM, dek, iv);
+    decipher.setAuthTag(authTag);
+    return Buffer.concat([decipher.update(encryptedData), decipher.final()]);
+  } finally {
+    zeroDek(dek);
+  }
+}

--- a/src/lib/crypto/transit.ts
+++ b/src/lib/crypto/transit.ts
@@ -1,0 +1,122 @@
+import "server-only";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface TransitConfig {
+  addr: string;
+  token: string;
+}
+
+export interface DataKey {
+  /** Raw 256-bit AES key. Caller must zero after use. */
+  plaintext: Buffer;
+  /** Base64-encoded Transit-wrapped ciphertext of the key. */
+  wrappedDek: string;
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export function getTransitConfig(): TransitConfig {
+  const addr = process.env.BAO_ADDR;
+  const token = process.env.BAO_TOKEN;
+  if (!addr) throw new Error("BAO_ADDR environment variable is required");
+  if (!token) throw new Error("BAO_TOKEN environment variable is required");
+  return { addr, token };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function transitRequest(
+  config: TransitConfig,
+  path: string,
+  body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const url = `${config.addr}/v1/transit/${path}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "X-Vault-Token": config.token,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Transit ${path} failed (${res.status}): ${text}`);
+  }
+
+  const json = (await res.json()) as { data?: Record<string, unknown> };
+  if (!json.data) {
+    throw new Error(`Transit ${path}: missing data in response`);
+  }
+  return json.data;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a new data encryption key via Transit.
+ * Returns both the plaintext key (for local AES-GCM) and the
+ * Transit-wrapped form (for storage alongside ciphertext).
+ */
+export async function generateDataKey(
+  config: TransitConfig,
+  keyName: string,
+): Promise<DataKey> {
+  const data = await transitRequest(config, `datakey/plaintext/${keyName}`, {});
+  const plaintextB64 = data.plaintext as string;
+  const wrappedDek = data.ciphertext as string;
+  if (typeof plaintextB64 !== "string" || typeof wrappedDek !== "string") {
+    throw new Error("Transit datakey: unexpected response shape");
+  }
+  return {
+    plaintext: Buffer.from(plaintextB64, "base64"),
+    wrappedDek,
+  };
+}
+
+/**
+ * Decrypt (unwrap) a Transit-wrapped DEK back to plaintext.
+ */
+export async function decryptDataKey(
+  config: TransitConfig,
+  keyName: string,
+  wrappedDek: string,
+): Promise<Buffer> {
+  const data = await transitRequest(config, `decrypt/${keyName}`, {
+    ciphertext: wrappedDek,
+  });
+  const plaintextB64 = data.plaintext as string;
+  if (typeof plaintextB64 !== "string") {
+    throw new Error("Transit decrypt: unexpected response shape");
+  }
+  return Buffer.from(plaintextB64, "base64");
+}
+
+/**
+ * Re-wrap a DEK under the latest version of the named key.
+ * Used for key rotation without re-encrypting data.
+ */
+export async function rewrapDataKey(
+  config: TransitConfig,
+  keyName: string,
+  wrappedDek: string,
+): Promise<string> {
+  const data = await transitRequest(config, `rewrap/${keyName}`, {
+    ciphertext: wrappedDek,
+  });
+  const newWrapped = data.ciphertext as string;
+  if (typeof newWrapped !== "string") {
+    throw new Error("Transit rewrap: unexpected response shape");
+  }
+  return newWrapped;
+}

--- a/src/lib/db/__tests__/schema.db.test.ts
+++ b/src/lib/db/__tests__/schema.db.test.ts
@@ -31,11 +31,11 @@ describe.skipIf(!hasPostgres)("Schema verification (auth_db)", () => {
     await dropTestDatabase(dbName, pool);
   });
 
-  it("applies all 16 auth migrations cleanly", async () => {
+  it("applies all 17 auth migrations cleanly", async () => {
     const { rows } = await pool.query(
       "SELECT version FROM _migrations ORDER BY version",
     );
-    expect(rows).toHaveLength(16);
+    expect(rows).toHaveLength(17);
   });
 
   // -- Built-in roles --


### PR DESCRIPTION
## Summary

- Add OpenBao Transit envelope encryption (AES-256-GCM) for staged event payloads with a staging-specific DEK (`staging-events`)
- Add per-customer approval/rejection flow (`staged_event_customers` join table with `pending`/`approved`/`rejected`/`expired` lifecycle)
- Add manual upload endpoint (`POST /api/events/ingest`) with multipart form, size cap, and encryption
- Wire `staged_event_customers` row creation into `processBridgeCallback()` (step 7)
- Add TTL-based expiration and opportunistic cleanup of fully-resolved payloads

### API Routes

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/api/events/staged` | List staged events for current session |
| GET | `/api/events/staged/:payloadId` | Payload detail with customer statuses |
| PATCH | `/api/events/staged/:payloadId/customers/:customerId` | Approve/reject per customer |
| POST | `/api/events/ingest` | Manual file upload |

### Deferred

- `TODO(#52)`: On approve, re-encrypt with customer-specific DEK and store in `customer_db`

## Test plan

- [x] 38 unit tests pass (`pnpm vitest run` — transit, envelope, 4 route suites)
- [x] 18 DB integration tests pass (staged-events + bridge)
- [x] 12 E2E tests pass (5 authenticated flow + 7 boundary)
- [x] `pnpm tsc --noEmit` — no type errors
- [x] `pnpm biome check` — no lint errors

Closes #34