### PR TITLE
Add data API scope enforcement & detection event ingestion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ CUSTOMER_DATABASE_OWNER_URL=postgres://aimer_customer_owner:changeme@localhost:5
 # Application runtime (restricted role — minimum required privileges)
 DATABASE_URL=postgres://aimer_auth:changeme@localhost:5432/auth_db
 AUDIT_DATABASE_URL=postgres://aimer_audit:changeme@localhost:5432/audit_db
+CUSTOMER_DATABASE_URL=postgres://aimer_customer:changeme@localhost:5432/template1
 
 # ---------------------------------------------------------------------------
 # OpenBao (Vault-compatible secret management)

--- a/e2e/fixtures/db.ts
+++ b/e2e/fixtures/db.ts
@@ -15,6 +15,7 @@ export interface TestAccount {
 export interface TestData {
   customer: { id: string; name: string; externalKey: string };
   customerB: { id: string; name: string; externalKey: string };
+  aiceEnvironment: { aiceId: string; name: string };
   manager: TestAccount;
   user: TestAccount;
   analyst: TestAccount;
@@ -117,6 +118,20 @@ export async function seedTestData(): Promise<TestData> {
     `INSERT INTO customers (id, external_key, name, status, database_status)
      VALUES ($1, $2, $3, 'active', 'active')`,
     [customerBId, customerBKey, customerBName],
+  );
+
+  // AICE environment linked to both customers
+  const aiceId = `aice-e2e-${suffix}`;
+  const aiceName = `E2E AICE ${suffix}`;
+  await p.query(
+    `INSERT INTO aice_environments (aice_id, name, status)
+     VALUES ($1, $2, 'active')`,
+    [aiceId, aiceName],
+  );
+  await p.query(
+    `INSERT INTO aice_environment_customers (aice_id, customer_id)
+     VALUES ($1, $2), ($1, $3)`,
+    [aiceId, customerId, customerBId],
   );
 
   // Analyst account (analyst_eligible=true, assigned to customer A)
@@ -225,6 +240,7 @@ export async function seedTestData(): Promise<TestData> {
       name: customerBName,
       externalKey: customerBKey,
     },
+    aiceEnvironment: { aiceId, name: aiceName },
     manager: {
       accountId: mgrAccountId,
       sessionId: mgrSession.rows[0].sid,
@@ -289,6 +305,13 @@ export async function cleanupTestData(data: TestData): Promise<void> {
     `DELETE FROM account_customer_memberships WHERE customer_id = ANY($1)`,
     [customerIds],
   );
+  await p.query(
+    `DELETE FROM aice_environment_customers WHERE customer_id = ANY($1)`,
+    [customerIds],
+  );
+  await p.query(`DELETE FROM aice_environments WHERE aice_id = $1`, [
+    data.aiceEnvironment.aiceId,
+  ]);
   await p.query(`DELETE FROM accounts WHERE id = ANY($1)`, [accountIds]);
   await p.query(`DELETE FROM customers WHERE id = ANY($1)`, [customerIds]);
 }

--- a/e2e/ingestion-auth.spec.ts
+++ b/e2e/ingestion-auth.spec.ts
@@ -1,0 +1,445 @@
+import { expect, getTestPool, test } from "./fixtures";
+
+// ---------------------------------------------------------------------------
+// E2E tests for detection event ingestion authorization:
+// - analyses:create permission enforcement
+// - Bridge scope enforcement
+// - Single-customer scope per request
+// - operationKind restrictions
+//
+// These tests verify that authorize() is called correctly by the event
+// API routes. They do NOT test full encryption/storage (requires Transit).
+// ---------------------------------------------------------------------------
+
+const ORIGIN = "http://localhost:3000";
+
+async function seedPayload(
+  sessionId: string,
+  aiceId: string,
+  customerId: string,
+  opts?: { customerBId?: string },
+): Promise<string> {
+  const pool = getTestPool();
+  const p = await pool.query<{ id: string }>(
+    `INSERT INTO staged_event_payloads
+       (session_id, aice_id, payload_hash, payload, wrapped_dek, event_count, schema_version, expires_at)
+     VALUES ($1, $2, md5(random()::text), $3, 'vault:v1:e2edek', 10, '1.0', NOW() + INTERVAL '1 hour')
+     RETURNING id`,
+    [sessionId, aiceId, Buffer.from("e2e-encrypted-payload")],
+  );
+  const payloadId = p.rows[0].id;
+
+  if (opts?.customerBId) {
+    await pool.query(
+      `INSERT INTO staged_event_customers (payload_id, customer_id, status)
+       VALUES ($1, $2, 'pending'), ($1, $3, 'pending')`,
+      [payloadId, customerId, opts.customerBId],
+    );
+  } else {
+    await pool.query(
+      `INSERT INTO staged_event_customers (payload_id, customer_id, status)
+       VALUES ($1, $2, 'pending')`,
+      [payloadId, customerId],
+    );
+  }
+
+  return payloadId;
+}
+
+async function deletePayload(payloadId: string): Promise<void> {
+  const pool = getTestPool();
+  await pool.query(`DELETE FROM staged_event_payloads WHERE id = $1`, [
+    payloadId,
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Scope enforcement on reject (doesn't require Transit)
+// ---------------------------------------------------------------------------
+
+test.describe("Event approval — authorization enforcement", () => {
+  test("reject requires analyses:create permission (account with no customer access is denied)", async ({
+    testData,
+  }) => {
+    const pool = getTestPool();
+
+    // Create an account with NO memberships or analyst assignments
+    const { randomUUID } = await import("node:crypto");
+    const noAccessId = randomUUID();
+    const noAccessSlug = `e2e-noaccess-${Date.now()}`;
+    await pool.query(
+      `INSERT INTO accounts
+         (id, oidc_issuer, oidc_subject, username, display_name, email, status)
+       VALUES ($1, 'e2e-issuer', $2, $2, 'No Access', $3, 'active')`,
+      [noAccessId, noAccessSlug, `${noAccessSlug}@e2e.test`],
+    );
+
+    // Create a session for this account
+    const sessResult = await pool.query<{ sid: string }>(
+      `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent)
+       VALUES ($1, 'general', '127.0.0.1', 'Playwright E2E')
+       RETURNING sid`,
+      [noAccessId],
+    );
+    const sessionId = sessResult.rows[0].sid;
+
+    // Seed a payload for this session
+    const payloadId = await seedPayload(
+      sessionId,
+      testData.aiceEnvironment.aiceId,
+      testData.customer.id,
+    );
+
+    try {
+      // Import auth helpers to create a JWT for this session
+      const { injectAuthCookies } = await import("./fixtures/auth");
+      const { chromium } = await import("@playwright/test");
+      const browser = await chromium.launch();
+      const context = await browser.newContext({
+        baseURL: "http://localhost:3000",
+      });
+      await injectAuthCookies(
+        context,
+        { accountId: noAccessId, sessionId },
+        "general",
+      );
+      const page = await context.newPage();
+
+      try {
+        const csrf = (await context.cookies()).find(
+          (c) => c.name === "csrf",
+        )?.value;
+
+        const res = await page.request.patch(
+          `/api/events/staged/${payloadId}/customers/${testData.customer.id}`,
+          {
+            headers: {
+              origin: ORIGIN,
+              "x-csrf-token": csrf ?? "",
+            },
+            data: { action: "reject" },
+          },
+        );
+        expect(res.status()).toBe(403);
+      } finally {
+        await context.close();
+        await browser.close();
+      }
+    } finally {
+      await deletePayload(payloadId).catch(() => {});
+      await pool.query(`DELETE FROM sessions WHERE account_id = $1`, [
+        noAccessId,
+      ]);
+      await pool.query(`DELETE FROM accounts WHERE id = $1`, [noAccessId]);
+    }
+  });
+
+  test("user with analyses:create can reject staged event", async ({
+    userPage,
+    testData,
+  }) => {
+    // User role has analyses:create permission
+    const payloadId = await seedPayload(
+      testData.user.sessionId,
+      testData.aiceEnvironment.aiceId,
+      testData.customer.id,
+    );
+
+    try {
+      const csrf = (await userPage.context().cookies()).find(
+        (c) => c.name === "csrf",
+      )?.value;
+
+      const res = await userPage.request.patch(
+        `/api/events/staged/${payloadId}/customers/${testData.customer.id}`,
+        {
+          headers: {
+            origin: ORIGIN,
+            "x-csrf-token": csrf ?? "",
+          },
+          data: { action: "reject" },
+        },
+      );
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe("rejected");
+    } finally {
+      await deletePayload(payloadId).catch(() => {});
+    }
+  });
+
+  test("manager with analyses:create can reject staged event", async ({
+    managerPage,
+    testData,
+  }) => {
+    const payloadId = await seedPayload(
+      testData.manager.sessionId,
+      testData.aiceEnvironment.aiceId,
+      testData.customer.id,
+    );
+
+    try {
+      const csrf = (await managerPage.context().cookies()).find(
+        (c) => c.name === "csrf",
+      )?.value;
+
+      const res = await managerPage.request.patch(
+        `/api/events/staged/${payloadId}/customers/${testData.customer.id}`,
+        {
+          headers: {
+            origin: ORIGIN,
+            "x-csrf-token": csrf ?? "",
+          },
+          data: { action: "reject" },
+        },
+      );
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe("rejected");
+    } finally {
+      await deletePayload(payloadId).catch(() => {});
+    }
+  });
+
+  test("reject is denied for customer not linked to AICE environment", async ({
+    managerPage,
+    testData,
+  }) => {
+    const pool = getTestPool();
+
+    // Create a customer not linked to any AICE environment
+    const isolatedId = `e2e-isolated-${Date.now()}`;
+    const isolatedCustId = `00000000-0000-0000-0000-${Date.now().toString().slice(-12)}`;
+    await pool.query(
+      `INSERT INTO customers (id, external_key, name, status, database_status)
+       VALUES ($1, $2, 'Isolated', 'active', 'active')`,
+      [isolatedCustId, isolatedId],
+    );
+    // Give manager membership in this customer
+    await pool.query(
+      `INSERT INTO account_customer_memberships (account_id, customer_id, role_id)
+       VALUES ($1, $2, $3)`,
+      [testData.manager.accountId, isolatedCustId, testData.roles.managerId],
+    );
+
+    // Seed payload with AICE env that is NOT linked to isolated customer
+    const payloadId = await seedPayload(
+      testData.manager.sessionId,
+      testData.aiceEnvironment.aiceId,
+      isolatedCustId,
+    );
+
+    try {
+      const csrf = (await managerPage.context().cookies()).find(
+        (c) => c.name === "csrf",
+      )?.value;
+
+      const res = await managerPage.request.patch(
+        `/api/events/staged/${payloadId}/customers/${isolatedCustId}`,
+        {
+          headers: {
+            origin: ORIGIN,
+            "x-csrf-token": csrf ?? "",
+          },
+          data: { action: "reject" },
+        },
+      );
+      // authorize() should fail: AICE env not linked to this customer
+      expect(res.status()).toBe(403);
+    } finally {
+      await deletePayload(payloadId).catch(() => {});
+      await pool.query(
+        `DELETE FROM account_customer_memberships WHERE customer_id = $1`,
+        [isolatedCustId],
+      );
+      await pool.query(`DELETE FROM customers WHERE id = $1`, [isolatedCustId]);
+    }
+  });
+
+  test("analyst can reject events for assigned customer", async ({
+    analystPage,
+    testData,
+  }) => {
+    // Analyst has analyst_eligible=true + analyst assignment → gets Analyst
+    // role permissions which include analyses:create
+    const payloadId = await seedPayload(
+      testData.analyst.sessionId,
+      testData.aiceEnvironment.aiceId,
+      testData.customer.id,
+    );
+
+    try {
+      const csrf = (await analystPage.context().cookies()).find(
+        (c) => c.name === "csrf",
+      )?.value;
+
+      const res = await analystPage.request.patch(
+        `/api/events/staged/${payloadId}/customers/${testData.customer.id}`,
+        {
+          headers: {
+            origin: ORIGIN,
+            "x-csrf-token": csrf ?? "",
+          },
+          data: { action: "reject" },
+        },
+      );
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe("rejected");
+    } finally {
+      await deletePayload(payloadId).catch(() => {});
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Manual upload authorization (POST /api/events/ingest)
+// Skips full upload (requires Transit encryption) — tests auth boundary only
+// ---------------------------------------------------------------------------
+
+test.describe("POST /api/events/ingest — authorization", () => {
+  test("returns 403 for account with no customer access", async ({
+    testData,
+  }) => {
+    const pool = getTestPool();
+
+    // Admin has no customer membership — only admin context
+    // Create a general session for admin to test customer access denial
+    const adminGeneralSession = await pool.query<{ sid: string }>(
+      `INSERT INTO sessions (account_id, auth_context, ip_address, user_agent)
+       VALUES ($1, 'general', '127.0.0.1', 'Playwright E2E')
+       RETURNING sid`,
+      [testData.admin.accountId],
+    );
+    const sessionId = adminGeneralSession.rows[0].sid;
+
+    try {
+      const { injectAuthCookies } = await import("./fixtures/auth");
+      const { chromium } = await import("@playwright/test");
+      const browser = await chromium.launch();
+      const context = await browser.newContext({
+        baseURL: "http://localhost:3000",
+      });
+      await injectAuthCookies(
+        context,
+        { accountId: testData.admin.accountId, sessionId },
+        "general",
+      );
+      const page = await context.newPage();
+
+      try {
+        const csrf = (await context.cookies()).find(
+          (c) => c.name === "csrf",
+        )?.value;
+
+        const res = await page.request.post("/api/events/ingest", {
+          headers: {
+            origin: ORIGIN,
+            "x-csrf-token": csrf ?? "",
+          },
+          multipart: {
+            events_data: {
+              name: "events.bin",
+              mimeType: "application/octet-stream",
+              buffer: Buffer.from("test-data"),
+            },
+            customer_id: testData.customer.id,
+            aice_id: testData.aiceEnvironment.aiceId,
+            schema_version: "1.0",
+            event_count: "5",
+          },
+        });
+        // Admin has no membership in this customer → 403
+        expect(res.status()).toBe(403);
+      } finally {
+        await context.close();
+        await browser.close();
+      }
+    } finally {
+      await pool.query(`DELETE FROM sessions WHERE sid = $1`, [sessionId]);
+    }
+  });
+
+  test("returns 400 for missing required fields", async ({ managerPage }) => {
+    const csrf = (await managerPage.context().cookies()).find(
+      (c) => c.name === "csrf",
+    )?.value;
+
+    // Missing aice_id
+    const res = await managerPage.request.post("/api/events/ingest", {
+      headers: {
+        origin: ORIGIN,
+        "x-csrf-token": csrf ?? "",
+      },
+      multipart: {
+        events_data: {
+          name: "events.bin",
+          mimeType: "application/octet-stream",
+          buffer: Buffer.from("test-data"),
+        },
+        customer_id: "00000000-0000-0000-0000-000000000001",
+        schema_version: "1.0",
+        event_count: "5",
+      },
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("aice_id");
+  });
+
+  test("returns 400 for invalid customer_id format", async ({
+    managerPage,
+  }) => {
+    const csrf = (await managerPage.context().cookies()).find(
+      (c) => c.name === "csrf",
+    )?.value;
+
+    const res = await managerPage.request.post("/api/events/ingest", {
+      headers: {
+        origin: ORIGIN,
+        "x-csrf-token": csrf ?? "",
+      },
+      multipart: {
+        events_data: {
+          name: "events.bin",
+          mimeType: "application/octet-stream",
+          buffer: Buffer.from("test-data"),
+        },
+        customer_id: "not-a-uuid",
+        aice_id: "aice-1",
+        schema_version: "1.0",
+        event_count: "5",
+      },
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("customer_id");
+  });
+
+  test("returns 400 for invalid event_count", async ({ managerPage }) => {
+    const csrf = (await managerPage.context().cookies()).find(
+      (c) => c.name === "csrf",
+    )?.value;
+
+    const res = await managerPage.request.post("/api/events/ingest", {
+      headers: {
+        origin: ORIGIN,
+        "x-csrf-token": csrf ?? "",
+      },
+      multipart: {
+        events_data: {
+          name: "events.bin",
+          mimeType: "application/octet-stream",
+          buffer: Buffer.from("test-data"),
+        },
+        customer_id: "00000000-0000-0000-0000-000000000001",
+        aice_id: "aice-1",
+        schema_version: "1.0",
+        event_count: "0",
+      },
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("event_count");
+  });
+});

--- a/e2e/staged-events-flow.spec.ts
+++ b/e2e/staged-events-flow.spec.ts
@@ -5,12 +5,18 @@ import { expect, getTestPool, test } from "./fixtures";
 //
 // Each test seeds its own staged_event_payloads and staged_event_customers
 // rows using its own testData fixture, ensuring fixture-scoped isolation.
-// Manual upload (POST /api/events/ingest) is excluded because it requires
-// OpenBao Transit to be running for real encryption.
+//
+// Full approve-to-customer-db flow requires OpenBao Transit (for envelope
+// decryption and re-encryption) and a provisioned customer database,
+// which are not available in the standard E2E environment. Approve
+// authorization enforcement is tested here; the encryption + storage
+// pipeline is covered by unit tests (event-storage.unit.test.ts,
+// staged-approve.unit.test.ts).
 // ---------------------------------------------------------------------------
 
 async function seedPayload(
   sessionId: string,
+  aiceId: string,
   customerId: string,
   opts?: { customerBId?: string; status?: string },
 ): Promise<string> {
@@ -18,9 +24,9 @@ async function seedPayload(
   const p = await pool.query<{ id: string }>(
     `INSERT INTO staged_event_payloads
        (session_id, aice_id, payload_hash, payload, wrapped_dek, event_count, schema_version, expires_at)
-     VALUES ($1, 'aice-e2e', md5(random()::text), $2, 'vault:v1:e2edek', 10, '1.0', NOW() + INTERVAL '1 hour')
+     VALUES ($1, $2, md5(random()::text), $3, 'vault:v1:e2edek', 10, '1.0', NOW() + INTERVAL '1 hour')
      RETURNING id`,
-    [sessionId, Buffer.from("e2e-encrypted-payload")],
+    [sessionId, aiceId, Buffer.from("e2e-encrypted-payload")],
   );
   const payloadId = p.rows[0].id;
 
@@ -54,8 +60,10 @@ test.describe("Staged events — authenticated flow", () => {
     managerPage,
     testData,
   }) => {
+    const aiceId = testData.aiceEnvironment.aiceId;
     const id1 = await seedPayload(
       testData.manager.sessionId,
+      aiceId,
       testData.customer.id,
       {
         customerBId: testData.customerB.id,
@@ -63,6 +71,7 @@ test.describe("Staged events — authenticated flow", () => {
     );
     const id2 = await seedPayload(
       testData.manager.sessionId,
+      aiceId,
       testData.customer.id,
     );
 
@@ -92,6 +101,7 @@ test.describe("Staged events — authenticated flow", () => {
   }) => {
     const id = await seedPayload(
       testData.manager.sessionId,
+      testData.aiceEnvironment.aiceId,
       testData.customer.id,
       {
         customerBId: testData.customerB.id,
@@ -117,6 +127,7 @@ test.describe("Staged events — authenticated flow", () => {
     // Seed with manager's session, query with user's page
     const id = await seedPayload(
       testData.manager.sessionId,
+      testData.aiceEnvironment.aiceId,
       testData.customer.id,
     );
 
@@ -128,16 +139,15 @@ test.describe("Staged events — authenticated flow", () => {
     }
   });
 
-  test("PATCH approve and reject update customer status", async ({
+  test("PATCH reject updates customer status", async ({
     managerPage,
     testData,
   }) => {
+    // Manager only has membership in customerA, so test with customerA only
     const id = await seedPayload(
       testData.manager.sessionId,
+      testData.aiceEnvironment.aiceId,
       testData.customer.id,
-      {
-        customerBId: testData.customerB.id,
-      },
     );
 
     try {
@@ -145,24 +155,8 @@ test.describe("Staged events — authenticated flow", () => {
         (c) => c.name === "csrf",
       )?.value;
 
-      // Approve customer A
-      const approveRes = await managerPage.request.patch(
-        `/api/events/staged/${id}/customers/${testData.customer.id}`,
-        {
-          headers: {
-            origin: "http://localhost:3000",
-            "x-csrf-token": csrf ?? "",
-          },
-          data: { action: "approve" },
-        },
-      );
-      expect(approveRes.status()).toBe(200);
-      const approveBody = await approveRes.json();
-      expect(approveBody.status).toBe("approved");
-
-      // Reject customer B
       const rejectRes = await managerPage.request.patch(
-        `/api/events/staged/${id}/customers/${testData.customerB.id}`,
+        `/api/events/staged/${id}/customers/${testData.customer.id}`,
         {
           headers: {
             origin: "http://localhost:3000",
@@ -175,36 +169,20 @@ test.describe("Staged events — authenticated flow", () => {
       const rejectBody = await rejectRes.json();
       expect(rejectBody.status).toBe("rejected");
     } finally {
-      // Payload may have been auto-deleted (all customers terminal)
       await deletePayload(id).catch(() => {});
     }
   });
 
-  test("PATCH approve on non-pending customer returns 409", async ({
+  test("PATCH reject on non-pending customer returns 409", async ({
     managerPage,
     testData,
   }) => {
-    // Seed a pre-approved customer
-    const pool = getTestPool();
-    const p = await pool.query<{ id: string }>(
-      `INSERT INTO staged_event_payloads
-         (session_id, aice_id, payload_hash, payload, wrapped_dek, event_count, schema_version, expires_at)
-       VALUES ($1, 'aice-e2e', md5(random()::text), $2, 'vault:v1:e2edek', 5, '2.0', NOW() + INTERVAL '1 hour')
-       RETURNING id`,
-      [testData.manager.sessionId, Buffer.from("e2e-encrypted-409")],
-    );
-    const id = p.rows[0].id;
-
-    // Insert two customers: one approved, one pending (so payload is not auto-cleaned)
-    await pool.query(
-      `INSERT INTO staged_event_customers (payload_id, customer_id, status, approved_at)
-       VALUES ($1, $2, 'approved', NOW())`,
-      [id, testData.customer.id],
-    );
-    await pool.query(
-      `INSERT INTO staged_event_customers (payload_id, customer_id, status)
-       VALUES ($1, $2, 'pending')`,
-      [id, testData.customerB.id],
+    // Seed a customer already rejected (use reject to avoid needing Transit)
+    const id = await seedPayload(
+      testData.manager.sessionId,
+      testData.aiceEnvironment.aiceId,
+      testData.customer.id,
+      { status: "rejected" },
     );
 
     try {
@@ -219,7 +197,7 @@ test.describe("Staged events — authenticated flow", () => {
             origin: "http://localhost:3000",
             "x-csrf-token": csrf ?? "",
           },
-          data: { action: "approve" },
+          data: { action: "reject" },
         },
       );
       expect(res.status()).toBe(409);

--- a/migrations/customer/0001_detection_events.sql
+++ b/migrations/customer/0001_detection_events.sql
@@ -1,0 +1,19 @@
+CREATE TABLE detection_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    aice_id TEXT NOT NULL,
+    payload BYTEA NOT NULL,
+    wrapped_dek TEXT NOT NULL,
+    event_count INTEGER NOT NULL CHECK (event_count > 0),
+    schema_version TEXT NOT NULL,
+    payload_hash TEXT NOT NULL,
+    source TEXT NOT NULL CHECK (source IN ('bridge', 'manual')),
+    connection_id UUID,
+    ingested_by UUID NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_detection_events_aice_id ON detection_events (aice_id);
+CREATE INDEX idx_detection_events_created_at ON detection_events (created_at DESC);
+
+-- Runtime role grants
+GRANT SELECT, INSERT ON detection_events TO aimer_customer;

--- a/src/app/api/events/__tests__/ingest.unit.test.ts
+++ b/src/app/api/events/__tests__/ingest.unit.test.ts
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockStageManualUpload = vi.fn();
 const mockEncryptPayload = vi.fn();
-const mockPoolQuery = vi.fn();
+const mockAuthorize = vi.fn();
 const mockWithAuth = vi.fn(
   // biome-ignore lint/complexity/noBannedTypes: test mock needs generic callable
   (handler: Function) => (req: NextRequest) =>
@@ -31,8 +31,13 @@ vi.mock("@/lib/crypto/envelope", () => ({
   encryptPayload: (...args: unknown[]) => mockEncryptPayload(...args),
 }));
 
+const mockAuditLog = vi.fn(async () => {});
 vi.mock("@/lib/auth/audit-stub", () => ({
-  auditLog: vi.fn(async () => {}),
+  auditLog: mockAuditLog,
+}));
+
+vi.mock("@/lib/auth/authorization", () => ({
+  authorize: (...args: unknown[]) => mockAuthorize(...args),
 }));
 
 vi.mock("@/lib/auth/guards", () => ({
@@ -43,7 +48,10 @@ vi.mock("@/lib/auth/guards", () => ({
 }));
 
 vi.mock("@/lib/db/client", () => ({
-  getAuthPool: vi.fn(() => ({ query: mockPoolQuery })),
+  getAuthPool: vi.fn(() => ({ query: vi.fn() })),
+  withTransaction: vi.fn((_pool: unknown, fn: (client: unknown) => unknown) =>
+    fn({}),
+  ),
 }));
 
 const CUSTOMER_ID = "a0000000-0000-0000-0000-000000000001";
@@ -76,8 +84,8 @@ describe("POST /api/events/ingest", () => {
       wrappedDek: "vault:v1:testkey",
     });
     mockStageManualUpload.mockResolvedValue("payload-id-1");
-    // Default: account has access to the customer
-    mockPoolQuery.mockResolvedValue({ rows: [{ "?column?": 1 }] });
+    // Default: authorized
+    mockAuthorize.mockResolvedValue({ authorized: true });
   });
 
   async function callPOST(req: NextRequest) {
@@ -102,6 +110,19 @@ describe("POST /api/events/ingest", () => {
     expect(body.payloadId).toBe("payload-id-1");
     expect(body.eventCount).toBe(5);
 
+    expect(mockAuthorize).toHaveBeenCalledWith(
+      expect.anything(),
+      "general",
+      "acct-1",
+      "analyses:create",
+      expect.objectContaining({
+        customerId: CUSTOMER_ID,
+        aiceId: "aice-1",
+        requiresAiceId: true,
+        operationKind: "ingest",
+        bridgeScope: null,
+      }),
+    );
     expect(mockEncryptPayload).toHaveBeenCalledOnce();
     expect(mockStageManualUpload).toHaveBeenCalledWith(
       expect.anything(),
@@ -109,6 +130,79 @@ describe("POST /api/events/ingest", () => {
         sessionId: "sess-1",
         aiceId: "aice-1",
         customerIds: [CUSTOMER_ID],
+      }),
+    );
+  });
+
+  it("returns 403 and logs denial audit when authorize() denies access", async () => {
+    mockAuthorize.mockResolvedValue({ authorized: false });
+
+    const file = new File([new Uint8Array([1, 2, 3])], "events.bin");
+    const req = makeIngestRequest({
+      events_data: file,
+      customer_id: CUSTOMER_ID,
+      aice_id: "aice-1",
+      schema_version: "1.0",
+      event_count: "5",
+    });
+
+    const res = await callPOST(req);
+    expect(res.status).toBe(403);
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "staged_event.manual_upload.denied",
+        details: expect.objectContaining({
+          reason: "authorization_failed",
+        }),
+      }),
+    );
+  });
+
+  it("passes bridge scope to authorize() in bridge sessions", async () => {
+    mockWithAuth.mockImplementation(
+      // biome-ignore lint/complexity/noBannedTypes: test mock needs generic callable
+      (handler: Function) => (req: NextRequest) =>
+        handler(req, {
+          accountId: "acct-1",
+          sessionId: "sess-1",
+          authContext: "general",
+          tokenVersion: 1,
+          iat: 1000,
+          meta: { ipAddress: "127.0.0.1", userAgent: "test" },
+          bridgeAiceId: "aice-1",
+          bridgeCustomerIds: [CUSTOMER_ID],
+        }),
+    );
+
+    vi.resetModules();
+    const { POST } = await import("../ingest/route");
+
+    const file = new File([new Uint8Array([1, 2, 3])], "events.bin");
+    const form = new FormData();
+    form.append("events_data", file);
+    form.append("customer_id", CUSTOMER_ID);
+    form.append("aice_id", "aice-1");
+    form.append("schema_version", "1.0");
+    form.append("event_count", "5");
+    const req = new NextRequest("http://localhost:3000/api/events/ingest", {
+      method: "POST",
+      body: form,
+      headers: { origin: "http://localhost:3000" },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+
+    expect(mockAuthorize).toHaveBeenCalledWith(
+      expect.anything(),
+      "general",
+      "acct-1",
+      "analyses:create",
+      expect.objectContaining({
+        bridgeScope: {
+          aiceId: "aice-1",
+          customerIds: [CUSTOMER_ID],
+        },
       }),
     );
   });
@@ -174,6 +268,22 @@ describe("POST /api/events/ingest", () => {
     expect(body.error).toContain("event_count");
   });
 
+  it("returns 400 when event_count is non-integer", async () => {
+    const file = new File([new Uint8Array([1])], "events.bin");
+    const req = makeIngestRequest({
+      events_data: file,
+      customer_id: CUSTOMER_ID,
+      aice_id: "aice-1",
+      schema_version: "1.0",
+      event_count: "1.5",
+    });
+
+    const res = await callPOST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("event_count");
+  });
+
   it("returns 400 when schema_version is missing", async () => {
     const file = new File([new Uint8Array([1])], "events.bin");
     const req = makeIngestRequest({
@@ -190,7 +300,6 @@ describe("POST /api/events/ingest", () => {
   });
 
   it("returns 413 when payload exceeds size cap", async () => {
-    // Create a file that exceeds the default 50MB cap
     const originalEnv = process.env.BRIDGE_MAX_PAYLOAD_BYTES;
     process.env.BRIDGE_MAX_PAYLOAD_BYTES = "10"; // 10 bytes cap
 
@@ -218,94 +327,5 @@ describe("POST /api/events/ingest", () => {
         process.env.BRIDGE_MAX_PAYLOAD_BYTES = originalEnv;
       }
     }
-  });
-
-  it("returns 403 when account has no access to customer", async () => {
-    // Non-bridge session: access check query returns no rows
-    mockPoolQuery.mockResolvedValue({ rows: [] });
-
-    const file = new File([new Uint8Array([1, 2, 3])], "events.bin");
-    const req = makeIngestRequest({
-      events_data: file,
-      customer_id: CUSTOMER_ID,
-      aice_id: "aice-1",
-      schema_version: "1.0",
-      event_count: "5",
-    });
-
-    const res = await callPOST(req);
-    expect(res.status).toBe(403);
-  });
-
-  it("returns 403 when aice_id does not match bridge scope", async () => {
-    mockWithAuth.mockImplementation(
-      // biome-ignore lint/complexity/noBannedTypes: test mock needs generic callable
-      (handler: Function) => (req: NextRequest) =>
-        handler(req, {
-          accountId: "acct-1",
-          sessionId: "sess-1",
-          authContext: "general",
-          tokenVersion: 1,
-          iat: 1000,
-          meta: { ipAddress: "127.0.0.1", userAgent: "test" },
-          bridgeAiceId: "aice-real",
-          bridgeCustomerIds: [CUSTOMER_ID],
-        }),
-    );
-
-    vi.resetModules();
-    const { POST } = await import("../ingest/route");
-
-    const file = new File([new Uint8Array([1, 2, 3])], "events.bin");
-    const form = new FormData();
-    form.append("events_data", file);
-    form.append("customer_id", CUSTOMER_ID);
-    form.append("aice_id", "aice-wrong");
-    form.append("schema_version", "1.0");
-    form.append("event_count", "5");
-    const req = new NextRequest("http://localhost:3000/api/events/ingest", {
-      method: "POST",
-      body: form,
-      headers: { origin: "http://localhost:3000" },
-    });
-
-    const res = await POST(req);
-    expect(res.status).toBe(403);
-    const body = await res.json();
-    expect(body.error).toContain("aice_id");
-  });
-
-  it("returns 403 when customer not in bridgeCustomerIds", async () => {
-    // Override the mock to include bridgeCustomerIds that exclude CUSTOMER_ID
-    mockWithAuth.mockImplementation(
-      // biome-ignore lint/complexity/noBannedTypes: test mock needs generic callable
-      (handler: Function) => (req: NextRequest) =>
-        handler(req, {
-          accountId: "acct-1",
-          sessionId: "sess-1",
-          authContext: "general",
-          tokenVersion: 1,
-          iat: 1000,
-          meta: { ipAddress: "127.0.0.1", userAgent: "test" },
-          bridgeAiceId: "aice-1",
-          bridgeCustomerIds: ["b0000000-0000-0000-0000-000000000099"],
-        }),
-    );
-
-    // Reset module cache so the route re-evaluates withAuth
-    vi.resetModules();
-    const { POST } = await import("../ingest/route");
-
-    const file = new File([new Uint8Array([1, 2, 3])], "events.bin");
-    const req = makeIngestRequest({
-      events_data: file,
-      customer_id: CUSTOMER_ID,
-      aice_id: "aice-1",
-      schema_version: "1.0",
-      event_count: "5",
-    });
-
-    const res = await POST(req);
-    expect(res.status).toBe(403);
   });
 });

--- a/src/app/api/events/__tests__/staged-approve.unit.test.ts
+++ b/src/app/api/events/__tests__/staged-approve.unit.test.ts
@@ -6,17 +6,30 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // ---------------------------------------------------------------------------
 
 const mockUpdateCustomerStatus = vi.fn();
+const mockGetStagedPayloadDecrypted = vi.fn();
 const mockPoolQuery = vi.fn();
 const mockAuditLog = vi.fn();
+const mockAuthorize = vi.fn();
+const mockStoreApprovedEvents = vi.fn();
 
 vi.mock("@/lib/auth/staged-events", () => ({
   updateCustomerStatus: (...args: unknown[]) =>
     mockUpdateCustomerStatus(...args),
+  getStagedPayloadDecrypted: (...args: unknown[]) =>
+    mockGetStagedPayloadDecrypted(...args),
   expireStagedEvents: vi.fn(async () => 0),
 }));
 
 vi.mock("@/lib/auth/audit-stub", () => ({
   auditLog: mockAuditLog,
+}));
+
+vi.mock("@/lib/auth/authorization", () => ({
+  authorize: (...args: unknown[]) => mockAuthorize(...args),
+}));
+
+vi.mock("@/lib/auth/event-storage", () => ({
+  storeApprovedEvents: (...args: unknown[]) => mockStoreApprovedEvents(...args),
 }));
 
 vi.mock("@/lib/auth/guards", () => ({
@@ -39,10 +52,12 @@ vi.mock("@/lib/auth/guards", () => ({
   verifyCsrf: () => null,
 }));
 
+const mockClientQuery = vi.fn();
+
 vi.mock("@/lib/db/client", () => ({
   getAuthPool: vi.fn(() => ({ query: mockPoolQuery })),
   withTransaction: vi.fn((_pool: unknown, fn: (client: unknown) => unknown) =>
-    fn({}),
+    fn({ query: mockClientQuery }),
   ),
 }));
 
@@ -56,8 +71,32 @@ const CUSTOMER_ID = "b0000000-0000-0000-0000-000000000001";
 describe("PATCH /api/events/staged/[payloadId]/customers/[customerId]", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default: payload belongs to session
-    mockPoolQuery.mockResolvedValue({ rows: [{ id: PAYLOAD_ID }] });
+    // Default: payload belongs to session with metadata
+    mockPoolQuery.mockResolvedValue({
+      rows: [
+        {
+          id: PAYLOAD_ID,
+          aice_id: "aice-1",
+          event_count: 5,
+          schema_version: "1.0",
+          connection_id: null,
+        },
+      ],
+    });
+    // Default: FOR UPDATE claim succeeds (pending row exists)
+    mockClientQuery.mockResolvedValue({ rows: [{}] });
+    // Default: authorized
+    mockAuthorize.mockResolvedValue({ authorized: true });
+    // Default: decrypted payload available
+    mockGetStagedPayloadDecrypted.mockResolvedValue({
+      payload: Buffer.from("decrypted-data"),
+      payloadHash: "abc123",
+    });
+    mockStoreApprovedEvents.mockResolvedValue("event-id-1");
+    mockUpdateCustomerStatus.mockResolvedValue({
+      updated: true,
+      newStatus: "approved",
+    });
   });
 
   async function callPATCH(
@@ -82,12 +121,11 @@ describe("PATCH /api/events/staged/[payloadId]/customers/[customerId]", () => {
     return PATCH(req);
   }
 
-  it("approves a pending customer", async () => {
-    mockUpdateCustomerStatus.mockResolvedValue({
-      updated: true,
-      newStatus: "approved",
-    });
+  // -----------------------------------------------------------------------
+  // Happy path
+  // -----------------------------------------------------------------------
 
+  it("approves and stores events in customer_db", async () => {
     const res = await callPATCH(PAYLOAD_ID, CUSTOMER_ID, {
       action: "approve",
     });
@@ -95,11 +133,31 @@ describe("PATCH /api/events/staged/[payloadId]/customers/[customerId]", () => {
 
     const body = await res.json();
     expect(body.status).toBe("approved");
-    expect(mockUpdateCustomerStatus).toHaveBeenCalledWith(
+    expect(body.eventId).toBe("event-id-1");
+
+    expect(mockAuthorize).toHaveBeenCalledWith(
       expect.anything(),
-      PAYLOAD_ID,
-      CUSTOMER_ID,
-      "approve",
+      "general",
+      "acct-1",
+      "analyses:create",
+      expect.objectContaining({
+        customerId: CUSTOMER_ID,
+        aiceId: "aice-1",
+        requiresAiceId: true,
+        operationKind: "ingest",
+      }),
+    );
+    expect(mockStoreApprovedEvents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customerId: CUSTOMER_ID,
+        aiceId: "aice-1",
+        eventCount: 5,
+        source: "manual",
+        connectionId: null,
+        ingestedBy: "acct-1",
+        plaintext: Buffer.from("decrypted-data"),
+        payloadHash: "abc123",
+      }),
     );
     expect(mockAuditLog).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -110,7 +168,56 @@ describe("PATCH /api/events/staged/[payloadId]/customers/[customerId]", () => {
     );
   });
 
-  it("rejects a pending customer", async () => {
+  it("stores events BEFORE updating status (atomicity)", async () => {
+    const callOrder: string[] = [];
+    mockGetStagedPayloadDecrypted.mockImplementation(async () => {
+      callOrder.push("decrypt");
+      return {
+        payload: Buffer.from("decrypted-data"),
+        payloadHash: "abc123",
+      };
+    });
+    mockStoreApprovedEvents.mockImplementation(async () => {
+      callOrder.push("store");
+      return "event-id-1";
+    });
+    mockUpdateCustomerStatus.mockImplementation(async () => {
+      callOrder.push("updateStatus");
+      return { updated: true, newStatus: "approved" };
+    });
+
+    await callPATCH(PAYLOAD_ID, CUSTOMER_ID, { action: "approve" });
+
+    expect(callOrder).toEqual(["decrypt", "store", "updateStatus"]);
+  });
+
+  it("sets source to 'bridge' when connection_id is present", async () => {
+    mockPoolQuery.mockResolvedValue({
+      rows: [
+        {
+          id: PAYLOAD_ID,
+          aice_id: "aice-1",
+          event_count: 3,
+          schema_version: "2.0",
+          connection_id: "c0000000-0000-0000-0000-000000000001",
+        },
+      ],
+    });
+
+    const res = await callPATCH(PAYLOAD_ID, CUSTOMER_ID, {
+      action: "approve",
+    });
+    expect(res.status).toBe(200);
+
+    expect(mockStoreApprovedEvents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "bridge",
+        connectionId: "c0000000-0000-0000-0000-000000000001",
+      }),
+    );
+  });
+
+  it("does not decrypt or store events on reject", async () => {
     mockUpdateCustomerStatus.mockResolvedValue({
       updated: true,
       newStatus: "rejected",
@@ -123,14 +230,103 @@ describe("PATCH /api/events/staged/[payloadId]/customers/[customerId]", () => {
 
     const body = await res.json();
     expect(body.status).toBe("rejected");
-    expect(mockAuditLog).toHaveBeenCalledWith(
+    expect(body.eventId).toBeUndefined();
+    expect(mockGetStagedPayloadDecrypted).not.toHaveBeenCalled();
+    expect(mockStoreApprovedEvents).not.toHaveBeenCalled();
+  });
+
+  it("passes bridge scope to authorize()", async () => {
+    await callPATCH(PAYLOAD_ID, CUSTOMER_ID, { action: "approve" });
+
+    expect(mockAuthorize).toHaveBeenCalledWith(
+      expect.anything(),
+      "general",
+      "acct-1",
+      "analyses:create",
       expect.objectContaining({
-        action: "staged_event.reject",
-        targetId: PAYLOAD_ID,
-        customerId: CUSTOMER_ID,
+        bridgeScope: {
+          aiceId: "aice-1",
+          customerIds: [
+            "b0000000-0000-0000-0000-000000000001",
+            "b0000000-0000-0000-0000-000000000002",
+          ],
+        },
       }),
     );
   });
+
+  // -----------------------------------------------------------------------
+  // Authorization failures
+  // -----------------------------------------------------------------------
+
+  it("returns 403 and logs audit when authorize() denies access", async () => {
+    mockAuthorize.mockResolvedValue({ authorized: false });
+
+    const res = await callPATCH(PAYLOAD_ID, CUSTOMER_ID, {
+      action: "approve",
+    });
+    expect(res.status).toBe(403);
+    expect(mockUpdateCustomerStatus).not.toHaveBeenCalled();
+    expect(mockStoreApprovedEvents).not.toHaveBeenCalled();
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "staged_event.approve.denied",
+        details: expect.objectContaining({
+          reason: "authorization_failed",
+        }),
+      }),
+    );
+  });
+
+  it("returns 403 for customer not in bridgeCustomerIds", async () => {
+    const otherCust = "b0000000-0000-0000-0000-000000000099";
+    mockAuthorize.mockResolvedValue({ authorized: false });
+
+    const res = await callPATCH(PAYLOAD_ID, otherCust, {
+      action: "approve",
+    });
+    expect(res.status).toBe(403);
+  });
+
+  // -----------------------------------------------------------------------
+  // Storage failures (approve path)
+  // -----------------------------------------------------------------------
+
+  it("returns 404 when staged payload cannot be decrypted", async () => {
+    mockGetStagedPayloadDecrypted.mockResolvedValue(null);
+
+    const res = await callPATCH(PAYLOAD_ID, CUSTOMER_ID, {
+      action: "approve",
+    });
+    expect(res.status).toBe(404);
+    expect(mockUpdateCustomerStatus).not.toHaveBeenCalled();
+  });
+
+  it("propagates storage error, logs failure audit, and does not update status", async () => {
+    mockStoreApprovedEvents.mockRejectedValue(
+      new Error("customer_db unavailable"),
+    );
+
+    await expect(
+      callPATCH(PAYLOAD_ID, CUSTOMER_ID, { action: "approve" }),
+    ).rejects.toThrow("customer_db unavailable");
+
+    // Status must NOT be updated — staged status stays "pending"
+    expect(mockUpdateCustomerStatus).not.toHaveBeenCalled();
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "staged_event.approve.failed",
+        details: expect.objectContaining({
+          reason: "storage_error",
+          error: "customer_db unavailable",
+        }),
+      }),
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // Validation failures
+  // -----------------------------------------------------------------------
 
   it("returns 400 for invalid action", async () => {
     const res = await callPATCH(PAYLOAD_ID, CUSTOMER_ID, {
@@ -149,41 +345,52 @@ describe("PATCH /api/events/staged/[payloadId]/customers/[customerId]", () => {
     expect(res.status).toBe(400);
   });
 
-  it("returns 404 when payload not owned by session", async () => {
+  it("returns 400 for invalid customerId UUID", async () => {
+    const res = await callPATCH(PAYLOAD_ID, "not-uuid", {
+      action: "approve",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 and logs audit when payload not owned by session", async () => {
     mockPoolQuery.mockResolvedValue({ rows: [] });
 
     const res = await callPATCH(PAYLOAD_ID, CUSTOMER_ID, {
       action: "approve",
     });
     expect(res.status).toBe(404);
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "staged_event.approve.not_found",
+        details: expect.objectContaining({
+          reason: "payload_not_owned",
+        }),
+      }),
+    );
   });
 
-  it("returns 403 when customer not in bridge scope", async () => {
-    const res = await callPATCH(PAYLOAD_ID, "not-in-scope-id", {
-      action: "approve",
-    });
-    // "not-in-scope-id" is not a valid UUID, so it returns 400 first
-    expect(res.status).toBe(400);
-  });
-
-  it("returns 403 for customer not in bridgeCustomerIds", async () => {
-    const otherCust = "b0000000-0000-0000-0000-000000000099";
-    const res = await callPATCH(PAYLOAD_ID, otherCust, {
-      action: "approve",
-    });
-    expect(res.status).toBe(403);
-  });
-
-  it("returns 409 when no pending approval exists", async () => {
+  it("returns 409 when no pending approval exists (reject)", async () => {
     mockUpdateCustomerStatus.mockResolvedValue({
       updated: false,
       newStatus: "unchanged",
     });
 
     const res = await callPATCH(PAYLOAD_ID, CUSTOMER_ID, {
+      action: "reject",
+    });
+    expect(res.status).toBe(409);
+    expect(mockAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when no pending approval exists (approve)", async () => {
+    // FOR UPDATE claim finds no pending row
+    mockClientQuery.mockResolvedValue({ rows: [] });
+
+    const res = await callPATCH(PAYLOAD_ID, CUSTOMER_ID, {
       action: "approve",
     });
     expect(res.status).toBe(409);
+    expect(mockStoreApprovedEvents).not.toHaveBeenCalled();
     expect(mockAuditLog).not.toHaveBeenCalled();
   });
 

--- a/src/app/api/events/ingest/route.ts
+++ b/src/app/api/events/ingest/route.ts
@@ -1,10 +1,11 @@
 import { createHash } from "node:crypto";
 import type { NextRequest } from "next/server";
 import { auditLog } from "@/lib/auth/audit-stub";
+import { authorize } from "@/lib/auth/authorization";
 import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
 import { stageManualUpload } from "@/lib/auth/staged-events";
 import { encryptPayload } from "@/lib/crypto/envelope";
-import { getAuthPool } from "@/lib/db/client";
+import { getAuthPool, withTransaction } from "@/lib/db/client";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -68,7 +69,7 @@ export const POST = withAuth(async (req: NextRequest, auth) => {
   }
 
   const eventCount = Number(eventCountField);
-  if (!Number.isFinite(eventCount) || eventCount < 1) {
+  if (!Number.isInteger(eventCount) || eventCount < 1) {
     return Response.json(
       { error: "Missing or invalid event_count" },
       { status: 400 },
@@ -85,41 +86,67 @@ export const POST = withAuth(async (req: NextRequest, auth) => {
     );
   }
 
-  // Verify caller has access to the customer
-  if (auth.bridgeCustomerIds) {
-    if (!auth.bridgeCustomerIds.includes(customerIdField)) {
-      return Response.json({ error: "Forbidden" }, { status: 403 });
-    }
-    // Verify aice_id matches bridge scope
-    if (auth.bridgeAiceId && auth.bridgeAiceId !== aiceIdField) {
-      return Response.json(
-        { error: "aice_id does not match bridge scope" },
-        { status: 403 },
-      );
-    }
-  } else {
-    // Non-bridge session: verify account has access to the customer
-    const pool = getAuthPool();
-    const accessCheck = await pool.query(
-      `SELECT 1 FROM account_customer_memberships
-       WHERE account_id = $1 AND customer_id = $2
-       UNION ALL
-       SELECT 1 FROM analyst_customer_assignments aca
-       JOIN accounts a ON a.id = aca.account_id AND a.analyst_eligible = true
-       WHERE aca.account_id = $1 AND aca.customer_id = $2
-       LIMIT 1`,
-      [auth.accountId, customerIdField],
-    );
-    if (accessCheck.rows.length === 0) {
-      return Response.json({ error: "Forbidden" }, { status: 403 });
-    }
+  // Authorize: analyses:create with operationKind 'ingest'
+  const pool = getAuthPool();
+  const authResult = await withTransaction(pool, (client) =>
+    authorize(client, "general", auth.accountId, "analyses:create", {
+      customerId: customerIdField,
+      aiceId: aiceIdField,
+      requiresAiceId: true,
+      operationKind: "ingest",
+      bridgeScope: auth.bridgeCustomerIds
+        ? {
+            aiceId: auth.bridgeAiceId ?? "",
+            customerIds: auth.bridgeCustomerIds,
+          }
+        : null,
+    }),
+  );
+  const auditBase = {
+    actorId: auth.accountId,
+    authContext: "general" as const,
+    targetType: "staged_event_payload",
+    ipAddress: auth.meta.ipAddress,
+    sid: auth.sessionId,
+    customerId: customerIdField,
+  };
+
+  if (!authResult.authorized) {
+    await auditLog({
+      ...auditBase,
+      action: "staged_event.manual_upload.denied",
+      targetId: "",
+      details: {
+        customerId: customerIdField,
+        aiceId: aiceIdField,
+        reason: "authorization_failed",
+      },
+    });
+    return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const payloadBuffer = Buffer.from(eventsDataBytes);
   const payloadHash = createHash("sha256").update(payloadBuffer).digest("hex");
-  const { ciphertext, wrappedDek } = await encryptPayload(payloadBuffer);
 
-  const pool = getAuthPool();
+  let ciphertext: Buffer;
+  let wrappedDek: string;
+  try {
+    ({ ciphertext, wrappedDek } = await encryptPayload(payloadBuffer));
+  } catch (err) {
+    await auditLog({
+      ...auditBase,
+      action: "staged_event.manual_upload.failed",
+      targetId: "",
+      details: {
+        customerId: customerIdField,
+        aiceId: aiceIdField,
+        reason: "encryption_error",
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
+    throw err;
+  }
+
   const payloadId = await stageManualUpload(pool, {
     sessionId: auth.sessionId,
     aiceId: aiceIdField,
@@ -132,19 +159,14 @@ export const POST = withAuth(async (req: NextRequest, auth) => {
   });
 
   await auditLog({
-    actorId: auth.accountId,
-    authContext: "general",
+    ...auditBase,
     action: "staged_event.manual_upload",
-    targetType: "staged_event_payload",
     targetId: payloadId,
     details: {
       customerId: customerIdField,
       aiceId: aiceIdField,
       eventCount,
     },
-    ipAddress: auth.meta.ipAddress,
-    sid: auth.sessionId,
-    customerId: customerIdField,
   });
 
   return Response.json({ payloadId, eventCount }, { status: 201 });

--- a/src/app/api/events/staged/[payloadId]/customers/[customerId]/route.ts
+++ b/src/app/api/events/staged/[payloadId]/customers/[customerId]/route.ts
@@ -1,8 +1,11 @@
 import type { NextRequest } from "next/server";
 import { auditLog } from "@/lib/auth/audit-stub";
+import { authorize } from "@/lib/auth/authorization";
+import { storeApprovedEvents } from "@/lib/auth/event-storage";
 import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
 import {
   expireStagedEvents,
+  getStagedPayloadDecrypted,
   updateCustomerStatus,
 } from "@/lib/auth/staged-events";
 import { getAuthPool, withTransaction } from "@/lib/db/client";
@@ -63,30 +66,133 @@ export const PATCH = withAuth(async (req: NextRequest, auth) => {
   await expireStagedEvents(pool);
 
   // Verify the payload belongs to the caller's session and is not expired
-  const ownership = await pool.query<{ id: string }>(
-    `SELECT id FROM staged_event_payloads
+  const ownership = await pool.query<{
+    id: string;
+    aice_id: string;
+    event_count: number;
+    schema_version: string;
+    connection_id: string | null;
+  }>(
+    `SELECT id, aice_id, event_count, schema_version, connection_id
+     FROM staged_event_payloads
      WHERE id = $1 AND session_id = $2 AND expires_at > NOW()`,
     [payloadId, auth.sessionId],
   );
   if (ownership.rows.length === 0) {
+    await auditLog({
+      actorId: auth.accountId,
+      authContext: "general",
+      action: `staged_event.${body.action}.not_found`,
+      targetType: "staged_event_customer",
+      targetId: payloadId,
+      ipAddress: auth.meta.ipAddress,
+      sid: auth.sessionId,
+      customerId,
+      details: { customerId, reason: "payload_not_owned" },
+    });
     return Response.json({ error: "Not found" }, { status: 404 });
   }
 
-  // Verify the caller has access to this customer
-  if (auth.bridgeCustomerIds) {
-    if (!auth.bridgeCustomerIds.includes(customerId)) {
-      return Response.json({ error: "Forbidden" }, { status: 403 });
-    }
+  const staged = ownership.rows[0];
+
+  // Authorize: analyses:create with operationKind 'ingest'
+  const authResult = await withTransaction(pool, (client) =>
+    authorize(client, "general", auth.accountId, "analyses:create", {
+      customerId,
+      aiceId: staged.aice_id,
+      requiresAiceId: true,
+      operationKind: "ingest",
+      bridgeScope: auth.bridgeCustomerIds
+        ? {
+            aiceId: auth.bridgeAiceId ?? "",
+            customerIds: auth.bridgeCustomerIds,
+          }
+        : null,
+    }),
+  );
+  const auditBase = {
+    actorId: auth.accountId,
+    authContext: "general" as const,
+    targetType: "staged_event_customer",
+    targetId: payloadId,
+    ipAddress: auth.meta.ipAddress,
+    sid: auth.sessionId,
+    customerId,
+  };
+
+  if (!authResult.authorized) {
+    await auditLog({
+      ...auditBase,
+      action: `staged_event.${body.action}.denied`,
+      details: { customerId, reason: "authorization_failed" },
+    });
+    return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const result = await withTransaction(pool, (client) =>
-    updateCustomerStatus(
-      client,
-      payloadId,
-      customerId,
-      body.action as "approve" | "reject",
-    ),
-  );
+  let eventId: string | undefined;
+  let result: { updated: boolean; newStatus: string };
+
+  if (body.action === "approve") {
+    // Decrypt BEFORE the transaction — uses pool, not the txn client.
+    const decrypted = await getStagedPayloadDecrypted(pool, payloadId);
+    if (!decrypted) {
+      return Response.json(
+        { error: "Staged payload not found" },
+        { status: 404 },
+      );
+    }
+
+    const source = staged.connection_id ? "bridge" : "manual";
+
+    // A single auth_db transaction claims the pending row with FOR UPDATE,
+    // writes to customer_db while holding the lock, then updates the status.
+    // This prevents concurrent approve requests from creating duplicate
+    // detection events: the second request blocks on FOR UPDATE and finds
+    // the row already non-pending when the first transaction commits.
+    try {
+      result = await withTransaction(pool, async (client) => {
+        const claim = await client.query(
+          `SELECT 1 FROM staged_event_customers
+           WHERE payload_id = $1 AND customer_id = $2 AND status = 'pending'
+           FOR UPDATE`,
+          [payloadId, customerId],
+        );
+        if (claim.rows.length === 0) {
+          return { updated: false, newStatus: "unchanged" };
+        }
+
+        // Store in customer_db while holding the auth_db row lock
+        eventId = await storeApprovedEvents({
+          customerId,
+          aiceId: staged.aice_id,
+          eventCount: staged.event_count,
+          schemaVersion: staged.schema_version,
+          source,
+          connectionId: staged.connection_id,
+          ingestedBy: auth.accountId,
+          plaintext: decrypted.payload,
+          payloadHash: decrypted.payloadHash,
+        });
+
+        return updateCustomerStatus(client, payloadId, customerId, "approve");
+      });
+    } catch (err) {
+      await auditLog({
+        ...auditBase,
+        action: "staged_event.approve.failed",
+        details: {
+          customerId,
+          reason: "storage_error",
+          error: err instanceof Error ? err.message : String(err),
+        },
+      });
+      throw err;
+    }
+  } else {
+    result = await withTransaction(pool, (client) =>
+      updateCustomerStatus(client, payloadId, customerId, "reject"),
+    );
+  }
 
   if (!result.updated) {
     return Response.json(
@@ -96,19 +202,10 @@ export const PATCH = withAuth(async (req: NextRequest, auth) => {
   }
 
   await auditLog({
-    actorId: auth.accountId,
-    authContext: "general",
+    ...auditBase,
     action: `staged_event.${body.action}`,
-    targetType: "staged_event_customer",
-    targetId: payloadId,
-    details: { customerId, newStatus: result.newStatus },
-    ipAddress: auth.meta.ipAddress,
-    sid: auth.sessionId,
-    customerId,
+    details: { customerId, newStatus: result.newStatus, eventId },
   });
 
-  // TODO(#52): On approve, re-encrypt with customer-specific DEK and
-  // store in customer_db. For now, only the status is updated.
-
-  return Response.json({ status: result.newStatus });
+  return Response.json({ status: result.newStatus, eventId });
 });

--- a/src/lib/auth/__tests__/event-storage.unit.test.ts
+++ b/src/lib/auth/__tests__/event-storage.unit.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockEncryptPayload = vi.fn();
+const mockClientQuery = vi.fn();
+const mockClientConnect = vi.fn();
+const mockClientEnd = vi.fn();
+
+vi.mock("../../crypto/envelope", () => ({
+  encryptPayload: (...args: unknown[]) => mockEncryptPayload(...args),
+}));
+
+vi.mock("../../db/customer-db", () => ({
+  customerTransitKeyName: (id: string) => `customer-${id}`,
+  customerDbUrl: (_tpl: string, id: string) =>
+    `postgres://localhost/customer_${id}`,
+  getCustomerRuntimeTemplateUrl: () => "postgres://localhost/template1",
+}));
+
+vi.mock("pg", () => {
+  const ClientCtor = vi.fn(function (this: Record<string, unknown>) {
+    this.query = mockClientQuery;
+    this.connect = mockClientConnect;
+    this.end = mockClientEnd;
+  });
+  return { Client: ClientCtor };
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("storeApprovedEvents", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEncryptPayload.mockResolvedValue({
+      ciphertext: Buffer.from("re-encrypted"),
+      wrappedDek: "vault:v1:customer-key",
+    });
+    mockClientConnect.mockResolvedValue(undefined);
+    mockClientQuery.mockResolvedValue({
+      rows: [{ id: "event-id-1" }],
+    });
+    mockClientEnd.mockResolvedValue(undefined);
+  });
+
+  async function callStore(overrides?: Record<string, unknown>) {
+    const { storeApprovedEvents } = await import("../event-storage");
+    return storeApprovedEvents({
+      customerId: "cust-1",
+      aiceId: "aice-1",
+      eventCount: 5,
+      schemaVersion: "1.0",
+      source: "manual",
+      connectionId: null,
+      ingestedBy: "acct-1",
+      plaintext: Buffer.from("decrypted-data"),
+      payloadHash: "abc123",
+      ...overrides,
+    });
+  }
+
+  it("re-encrypts with customer-specific Transit key", async () => {
+    const eventId = await callStore();
+    expect(eventId).toBe("event-id-1");
+
+    expect(mockEncryptPayload).toHaveBeenCalledWith(
+      Buffer.from("decrypted-data"),
+      "customer-cust-1",
+    );
+  });
+
+  it("uses a single Client connection (not Pool)", async () => {
+    await callStore();
+    expect(mockClientConnect).toHaveBeenCalledOnce();
+  });
+
+  it("inserts into customer database with correct values", async () => {
+    await callStore();
+
+    expect(mockClientQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO detection_events"),
+      [
+        "aice-1",
+        Buffer.from("re-encrypted"),
+        "vault:v1:customer-key",
+        5,
+        "1.0",
+        "abc123",
+        "manual",
+        null,
+        "acct-1",
+      ],
+    );
+  });
+
+  it("stores bridge source and connection_id when provided", async () => {
+    await callStore({
+      source: "bridge",
+      connectionId: "conn-1",
+    });
+
+    expect(mockClientQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO detection_events"),
+      expect.arrayContaining(["bridge", "conn-1"]),
+    );
+  });
+
+  it("closes the client after insert", async () => {
+    await callStore();
+    expect(mockClientEnd).toHaveBeenCalled();
+  });
+
+  it("closes the client on insert failure", async () => {
+    mockClientQuery.mockRejectedValue(new Error("db error"));
+
+    await expect(callStore()).rejects.toThrow("db error");
+    expect(mockClientEnd).toHaveBeenCalled();
+  });
+
+  it("does not connect to customer DB on encryption failure", async () => {
+    mockEncryptPayload.mockRejectedValue(new Error("transit error"));
+
+    await expect(callStore()).rejects.toThrow("transit error");
+    expect(mockClientConnect).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/auth/event-storage.ts
+++ b/src/lib/auth/event-storage.ts
@@ -1,0 +1,87 @@
+import "server-only";
+
+import { Client } from "pg";
+import { encryptPayload } from "../crypto/envelope";
+import {
+  customerDbUrl,
+  customerTransitKeyName,
+  getCustomerRuntimeTemplateUrl,
+} from "../db/customer-db";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface StoreApprovedEventsParams {
+  customerId: string;
+  aiceId: string;
+  eventCount: number;
+  schemaVersion: string;
+  source: "bridge" | "manual";
+  connectionId: string | null;
+  ingestedBy: string;
+  /** Pre-decrypted payload (must be decrypted before staged payload deletion). */
+  plaintext: Buffer;
+  payloadHash: string;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Store approved events in the customer database.
+ *
+ * Accepts an already-decrypted payload to avoid a race condition:
+ * `updateCustomerStatus()` may delete the staged payload row when the
+ * last customer is resolved, so the caller must decrypt **before**
+ * updating the status.
+ *
+ * Must be called **before** `updateCustomerStatus()` so that a storage
+ * failure keeps the staged status as "pending" (retryable). The auth_db
+ * and customer_db are separate databases, so cross-database transactions
+ * are not possible.
+ *
+ * 1. Re-encrypt with the customer's Transit key (customer-specific DEK)
+ * 2. Insert into the customer's `detection_events` table
+ */
+export async function storeApprovedEvents(
+  params: StoreApprovedEventsParams,
+): Promise<string> {
+  // 1. Re-encrypt with customer-specific Transit key
+  const customerKeyName = customerTransitKeyName(params.customerId);
+  const { ciphertext, wrappedDek } = await encryptPayload(
+    params.plaintext,
+    customerKeyName,
+  );
+
+  // 2. Store in customer_db (single connection, not a pool)
+  const templateUrl = getCustomerRuntimeTemplateUrl();
+  const dbUrl = customerDbUrl(templateUrl, params.customerId);
+  const client = new Client({ connectionString: dbUrl });
+  await client.connect();
+
+  try {
+    const result = await client.query<{ id: string }>(
+      `INSERT INTO detection_events
+         (aice_id, payload, wrapped_dek, event_count, schema_version,
+          payload_hash, source, connection_id, ingested_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+       RETURNING id`,
+      [
+        params.aiceId,
+        ciphertext,
+        wrappedDek,
+        params.eventCount,
+        params.schemaVersion,
+        params.payloadHash,
+        params.source,
+        params.connectionId,
+        params.ingestedBy,
+      ],
+    );
+    return result.rows[0].id;
+  } finally {
+    await client.end().catch(() => {});
+  }
+}

--- a/src/lib/db/customer-db.ts
+++ b/src/lib/db/customer-db.ts
@@ -71,3 +71,15 @@ export function getCustomerOwnerTemplateUrl(): string {
   }
   return url;
 }
+
+/**
+ * Return the template URL for customer DB runtime connections.
+ * Uses the restricted `aimer_customer` role — never the owner role.
+ */
+export function getCustomerRuntimeTemplateUrl(): string {
+  const url = process.env.CUSTOMER_DATABASE_URL;
+  if (!url) {
+    throw new Error("CUSTOMER_DATABASE_URL environment variable is required");
+  }
+  return url;
+}


### PR DESCRIPTION
## Summary

- `authorize()` validates `analyses:create` on every data API request (ingest + approve/reject), with bridge scope, AICE linkage, and single-customer enforcement
- Approved staged events are decrypted, re-encrypted with a customer-specific Transit DEK, and stored in `customer_db` **before** the staged status is updated — a storage failure keeps the row retryable
- Manual upload endpoint (`POST /api/events/ingest`) with multipart form validation, payload size cap, `connection_id` NULL, and full authorize pipeline
- `detection_events` table migration in `customer_db` with CHECK constraints and runtime role grants

## Test plan

- [x] Unit tests: `staged-approve` (14 tests), `event-storage` (7 tests), `ingest` (10 tests) — all pass
- [x] Full unit test suite: 271 tests pass, no regressions
- [x] E2E: `ingestion-auth` (8 tests) — reject auth for no-access/user/manager/analyst, AICE unlinking 403, ingest validation
- [x] E2E: `staged-events-flow` (5 tests) — list, detail, cross-session 404, reject flow, 409 non-pending
- [x] Lint (Biome) and type check pass

Closes #37