### PR TITLE
Add KEK rotation and OpenBao deployment hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,8 +18,10 @@ CUSTOMER_DATABASE_URL=postgres://aimer_customer:changeme@localhost:5432/template
 # ---------------------------------------------------------------------------
 # OpenBao (Vault-compatible secret management)
 # ---------------------------------------------------------------------------
-BAO_DEV_ROOT_TOKEN_ID=dev-root-token
 BAO_ADDR=http://localhost:8200
+# Auto-generated on first `docker compose --profile dev up`.
+# Retrieve with: docker compose exec openbao cat /bao/init/keys.json
+BAO_TOKEN=
 
 # ---------------------------------------------------------------------------
 # Keycloak (Identity & Access Management)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,11 +190,30 @@ jobs:
           --health-interval 5s
           --health-timeout 3s
           --health-retries 5
-      # OpenBao and Keycloak services will be added when e2e tests require them.
+      openbao:
+        image: openbao/openbao:latest
+        env:
+          BAO_DEV_ROOT_TOKEN_ID: e2e-root-token
+          BAO_DEV_LISTEN_ADDRESS: "0.0.0.0:8200"
+        ports:
+          - 8200:8200
+        options: >-
+          --health-cmd "wget -q --spider http://127.0.0.1:8200/v1/sys/health || exit 1"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+      # Keycloak service will be added when e2e tests require it.
     steps:
       - uses: actions/checkout@v6
       - name: Create databases and roles
         run: psql "postgres://postgres:postgres@localhost:5432/auth_db" -f infra/postgres/init-databases.sql
+      - name: Configure OpenBao Transit
+        run: |
+          curl -sf -X POST http://localhost:8200/v1/sys/mounts/transit \
+            -H "X-Vault-Token: e2e-root-token" \
+            -d '{"type": "transit"}'
+          curl -sf -X POST http://localhost:8200/v1/transit/keys/staging-events \
+            -H "X-Vault-Token: e2e-root-token"
       - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
@@ -208,7 +227,10 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/auth_db
           DATABASE_MIGRATION_URL: postgres://postgres:postgres@localhost:5432/auth_db
           AUDIT_DATABASE_URL: postgres://postgres:postgres@localhost:5432/audit_db
+          CUSTOMER_DATABASE_OWNER_URL: postgres://postgres:postgres@localhost:5432/auth_db
           CSRF_SECRET: e2e-test-csrf-secret
+          BAO_ADDR: http://localhost:8200
+          BAO_TOKEN: e2e-root-token
       - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,26 +23,27 @@ services:
     cap_add:
       - IPC_LOCK
     environment:
-      BAO_DEV_ROOT_TOKEN_ID: ${BAO_DEV_ROOT_TOKEN_ID:-dev-root-token}
-      BAO_DEV_LISTEN_ADDRESS: "0.0.0.0:8200"
       BAO_ADDR: "http://127.0.0.1:8200"
     ports:
       - "8200:8200"
     volumes:
+      - ./infra/openbao/config.hcl:/bao/config/config.hcl:ro
       - ./infra/openbao/init-transit.sh:/usr/local/bin/init-transit.sh:ro
+      - bao-data:/bao/data
+      - bao-init:/bao/init
     entrypoint: /bin/sh
     command:
       - -c
       - |
-        bao server -dev &
+        bao server -config=/bao/config/config.hcl &
         BAO_PID=$$!
         /usr/local/bin/init-transit.sh
         wait $$BAO_PID
     healthcheck:
-      test: ["CMD", "bao", "status"]
+      test: ["CMD-SHELL", "BAO_ADDR=http://127.0.0.1:8200 bao status"]
       interval: 5s
       timeout: 3s
-      retries: 5
+      retries: 10
 
   keycloak:
     image: quay.io/keycloak/keycloak:26.0
@@ -157,3 +158,5 @@ services:
 
 volumes:
   pgdata:
+  bao-data:
+  bao-init:

--- a/e2e/kek-rotation-api.spec.ts
+++ b/e2e/kek-rotation-api.spec.ts
@@ -1,0 +1,259 @@
+import { randomUUID } from "node:crypto";
+import { expect, getTestPool, test } from "./fixtures";
+
+// ---------------------------------------------------------------------------
+// E2E tests for POST /api/admin/kek/rotate (KEK rotation).
+//
+// Requires a running OpenBao instance with Transit engine enabled and
+// a pre-created `staging-events` key.  CI provisions this via a dev-mode
+// OpenBao service container; locally, `docker compose --profile dev up`
+// provides the same.
+// ---------------------------------------------------------------------------
+
+const ORIGIN = "http://localhost:3000";
+
+// ---------------------------------------------------------------------------
+// Transit API helpers — direct calls to OpenBao for test setup / teardown
+// ---------------------------------------------------------------------------
+
+function baoAddr(): string {
+  return process.env.BAO_ADDR ?? "http://localhost:8200";
+}
+
+function baoToken(): string {
+  return process.env.BAO_TOKEN ?? "";
+}
+
+async function createTransitKey(keyName: string): Promise<void> {
+  const res = await fetch(`${baoAddr()}/v1/transit/keys/${keyName}`, {
+    method: "POST",
+    headers: { "X-Vault-Token": baoToken() },
+  });
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`Failed to create Transit key ${keyName}: ${res.status}`);
+  }
+}
+
+async function generateWrappedDek(keyName: string): Promise<string> {
+  const res = await fetch(
+    `${baoAddr()}/v1/transit/datakey/plaintext/${keyName}`,
+    {
+      method: "POST",
+      headers: {
+        "X-Vault-Token": baoToken(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({}),
+    },
+  );
+  if (!res.ok) {
+    throw new Error(
+      `Failed to generate data key for ${keyName}: ${res.status}`,
+    );
+  }
+  const json = (await res.json()) as { data: { ciphertext: string } };
+  return json.data.ciphertext;
+}
+
+async function decryptWrappedDek(
+  keyName: string,
+  wrappedDek: string,
+): Promise<string> {
+  const res = await fetch(`${baoAddr()}/v1/transit/decrypt/${keyName}`, {
+    method: "POST",
+    headers: {
+      "X-Vault-Token": baoToken(),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ ciphertext: wrappedDek }),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to decrypt DEK for ${keyName}: ${res.status}`);
+  }
+  const json = (await res.json()) as { data: { plaintext: string } };
+  return json.data.plaintext;
+}
+
+async function deleteTransitKey(keyName: string): Promise<void> {
+  // Enable deletion
+  await fetch(`${baoAddr()}/v1/transit/keys/${keyName}/config`, {
+    method: "POST",
+    headers: {
+      "X-Vault-Token": baoToken(),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ deletion_allowed: true }),
+  });
+  // Delete
+  await fetch(`${baoAddr()}/v1/transit/keys/${keyName}`, {
+    method: "DELETE",
+    headers: { "X-Vault-Token": baoToken() },
+  });
+}
+
+// =========================================================================
+// Auth boundary tests (no OpenBao needed)
+// =========================================================================
+
+test.describe("POST /api/admin/kek/rotate — auth boundary", () => {
+  test("returns 401 without admin auth cookie", async ({ request }) => {
+    const res = await request.post("/api/admin/kek/rotate", {
+      headers: { origin: ORIGIN },
+    });
+    expect(res.status()).toBe(401);
+  });
+
+  test("returns 401 with general auth cookie", async ({ context }) => {
+    await context.addCookies([
+      {
+        name: "at",
+        value: "some-general-jwt",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+    const res = await context.request.post("/api/admin/kek/rotate", {
+      headers: { origin: ORIGIN },
+    });
+    expect(res.status()).toBe(401);
+  });
+
+  test("returns 405 for GET method", async ({ request }) => {
+    const res = await request.get("/api/admin/kek/rotate");
+    expect(res.status()).toBe(405);
+  });
+});
+
+// =========================================================================
+// Authenticated rotation with real Transit
+// =========================================================================
+
+test.describe("POST /api/admin/kek/rotate — authenticated", () => {
+  test("rotates Transit keys and rewraps wrapped DEKs", async ({
+    adminPage,
+    testData,
+  }) => {
+    const pool = getTestPool();
+    const testCustomerId = randomUUID();
+    const testKeyName = `customer-${testCustomerId}`;
+
+    // --- Setup: hide fixture customers from rotation query ---
+    // Fixture customers have database_status='active' but no Transit keys.
+    // Temporarily mark them as 'provisioning' so rotation skips them.
+    const fixtureIds = [testData.customer.id, testData.customerB.id];
+    await pool.query(
+      `UPDATE customers SET database_status = 'provisioning' WHERE id = ANY($1)`,
+      [fixtureIds],
+    );
+
+    try {
+      // --- Setup: Transit key + customer with real wrapped DEK ---
+      await createTransitKey(testKeyName);
+      const customerWrappedDek = await generateWrappedDek(testKeyName);
+
+      await pool.query(
+        `INSERT INTO customers (id, external_key, name, status, database_status, wrapped_dek)
+         VALUES ($1, $2, $3, 'active', 'active', $4)`,
+        [
+          testCustomerId,
+          `e2e-rotate-${testCustomerId.slice(0, 8)}`,
+          "KEK Rotation Test",
+          customerWrappedDek,
+        ],
+      );
+
+      // --- Setup: staged_event_payloads with real wrapped DEK ---
+      const stagingWrappedDek = await generateWrappedDek("staging-events");
+      const { rows: payloadRows } = await pool.query<{ id: string }>(
+        `INSERT INTO staged_event_payloads
+           (session_id, aice_id, payload_hash, payload, wrapped_dek,
+            event_count, schema_version, expires_at)
+         VALUES ($1, $2, md5(random()::text), $3, $4, 1, '1.0',
+                 NOW() + INTERVAL '1 hour')
+         RETURNING id`,
+        [
+          testData.admin.sessionId,
+          testData.aiceEnvironment.aiceId,
+          Buffer.from("e2e-rotation-payload"),
+          stagingWrappedDek,
+        ],
+      );
+      const payloadId = payloadRows[0].id;
+
+      // --- Act: call rotation endpoint ---
+      const cookies = await adminPage.context().cookies();
+      const csrfValue = cookies.find((c) => c.name === "csrf_admin")?.value;
+
+      const res = await adminPage.request.post("/api/admin/kek/rotate", {
+        headers: {
+          origin: ORIGIN,
+          "x-csrf-token-admin": csrfValue as string,
+        },
+      });
+
+      expect(res.status()).toBe(200);
+      const result = await res.json();
+
+      // --- Assert: response structure ---
+      expect(result).toMatchObject({
+        customerDeksRewrapped: expect.any(Number),
+        eventDeksRewrapped: expect.any(Number),
+        stagingDeksRewrapped: expect.any(Number),
+        errors: expect.any(Array),
+      });
+
+      // Test customer has wrapped_dek → rewrapped.
+      // connectCustomerDb fails (no real customer DB) → customersErrored.
+      expect(result.customerDeksRewrapped).toBeGreaterThanOrEqual(1);
+      expect(result.stagingDeksRewrapped).toBeGreaterThanOrEqual(1);
+
+      // --- Assert: customer wrapped_dek changed in DB ---
+      const { rows: custRows } = await pool.query<{ wrapped_dek: string }>(
+        "SELECT wrapped_dek FROM customers WHERE id = $1",
+        [testCustomerId],
+      );
+      const newCustomerDek = custRows[0].wrapped_dek;
+      expect(newCustomerDek).not.toBe(customerWrappedDek);
+
+      // New wrapped DEK decrypts to the same plaintext (rewrap preserves key material)
+      const originalPlaintext = await decryptWrappedDek(
+        testKeyName,
+        customerWrappedDek,
+      );
+      const newPlaintext = await decryptWrappedDek(testKeyName, newCustomerDek);
+      expect(newPlaintext).toBe(originalPlaintext);
+
+      // --- Assert: staged payload wrapped_dek changed in DB ---
+      const { rows: stagedRows } = await pool.query<{ wrapped_dek: string }>(
+        "SELECT wrapped_dek FROM staged_event_payloads WHERE id = $1",
+        [payloadId],
+      );
+      const newStagingDek = stagedRows[0].wrapped_dek;
+      expect(newStagingDek).not.toBe(stagingWrappedDek);
+
+      // New staging wrapped DEK also decrypts to same plaintext
+      const origStagingPlaintext = await decryptWrappedDek(
+        "staging-events",
+        stagingWrappedDek,
+      );
+      const newStagingPlaintext = await decryptWrappedDek(
+        "staging-events",
+        newStagingDek,
+      );
+      expect(newStagingPlaintext).toBe(origStagingPlaintext);
+
+      // --- Cleanup ---
+      await pool.query("DELETE FROM staged_event_payloads WHERE id = $1", [
+        payloadId,
+      ]);
+      await pool.query("DELETE FROM customers WHERE id = $1", [testCustomerId]);
+      await deleteTransitKey(testKeyName);
+    } finally {
+      // Restore fixture customers
+      await pool.query(
+        `UPDATE customers SET database_status = 'active' WHERE id = ANY($1)`,
+        [fixtureIds],
+      );
+    }
+  });
+});

--- a/infra/openbao/config.hcl
+++ b/infra/openbao/config.hcl
@@ -1,0 +1,11 @@
+storage "file" {
+  path = "/bao/data"
+}
+
+listener "tcp" {
+  address     = "0.0.0.0:8200"
+  tls_disable = true
+}
+
+disable_mlock = true
+api_addr      = "http://127.0.0.1:8200"

--- a/infra/openbao/init-transit.sh
+++ b/infra/openbao/init-transit.sh
@@ -1,16 +1,56 @@
 #!/bin/sh
-# Wait for OpenBao to become ready, then enable the Transit secret engine.
+# Auto-initialize, unseal, and configure Transit on OpenBao startup.
+#
+# First boot:  init with single Shamir key, save keys to /bao/init/keys.json
+# Every boot:  unseal using saved key, enable Transit engine
 set -e
 
 export BAO_ADDR="http://127.0.0.1:8200"
-export BAO_TOKEN="${BAO_DEV_ROOT_TOKEN_ID:-dev-root-token}"
+KEYS_FILE="/bao/init/keys.json"
 
 echo "Waiting for OpenBao to start..."
-until bao status >/dev/null 2>&1; do
-    sleep 1
+# bao status exits 0 only when initialized+unsealed.  On a fresh server it
+# exits non-zero (uninitialized/sealed) but still prints output once the
+# HTTP API is reachable.  Wait for that output to appear.
+while ! bao status 2>&1 | grep -q "Seal Type"; do
+  sleep 1
 done
 
-echo "Enabling Transit secret engine..."
-bao secrets enable transit || echo "Transit engine already enabled"
+# Initialize if not yet done
+if bao status 2>/dev/null | grep -q "Initialized.*false"; then
+  echo "Initializing OpenBao (single Shamir key)..."
+  mkdir -p /bao/init
+  bao operator init -key-shares=1 -key-threshold=1 -format=json > "$KEYS_FILE"
+  echo "Keys saved to $KEYS_FILE"
+fi
 
-echo "Transit secret engine is ready."
+if [ ! -f "$KEYS_FILE" ]; then
+  echo "ERROR: $KEYS_FILE not found. Cannot unseal." >&2
+  exit 1
+fi
+
+# Parse unseal key and root token from JSON (works with BusyBox tools).
+FLAT=$(tr -d '\n ' < "$KEYS_FILE")
+UNSEAL_KEY=$(echo "$FLAT" | grep -o '"unseal_keys_b64":\["[^"]*"' | grep -o '\["[^"]*"' | tr -d '["')
+ROOT_TOKEN=$(echo "$FLAT" | grep -o '"root_token":"[^"]*"' | cut -d: -f2 | tr -d '"')
+
+if [ -z "$UNSEAL_KEY" ] || [ -z "$ROOT_TOKEN" ]; then
+  echo "ERROR: Failed to parse keys from $KEYS_FILE" >&2
+  exit 1
+fi
+
+# Unseal if sealed
+if bao status 2>/dev/null | grep -q "Sealed.*true"; then
+  echo "Unsealing OpenBao..."
+  bao operator unseal "$UNSEAL_KEY"
+fi
+
+export BAO_TOKEN="$ROOT_TOKEN"
+
+echo "Enabling Transit secret engine..."
+bao secrets enable transit 2>/dev/null || echo "Transit engine already enabled"
+
+echo "Creating staging-events key..."
+bao write -f transit/keys/staging-events 2>/dev/null || echo "staging-events key already exists"
+
+echo "OpenBao is ready. Root token: $ROOT_TOKEN"

--- a/src/app/api/admin/kek/rotate/route.ts
+++ b/src/app/api/admin/kek/rotate/route.ts
@@ -1,0 +1,40 @@
+import type { NextRequest } from "next/server";
+import { auditLog } from "@/lib/auth/audit-stub";
+import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
+import { rotateAllKeks } from "@/lib/auth/kek-rotation";
+import { getAuthPool } from "@/lib/db/client";
+
+export const POST = withAuth(
+  async (req: NextRequest, auth) => {
+    const originErr = verifyOrigin(req);
+    if (originErr) return originErr;
+
+    const csrfErr = verifyCsrf(req, {
+      ctx: "admin",
+      sid: auth.sessionId,
+      iat: auth.iat,
+    });
+    if (csrfErr) return csrfErr;
+
+    const result = await rotateAllKeks(getAuthPool());
+
+    await auditLog({
+      actorId: auth.accountId,
+      authContext: "admin",
+      action: "openbao.kek_rotated",
+      targetType: "system",
+      details: {
+        customersRotated: result.customersRotated,
+        customersErrored: result.customersErrored,
+        customerDeksRewrapped: result.customerDeksRewrapped,
+        eventDeksRewrapped: result.eventDeksRewrapped,
+        stagingDeksRewrapped: result.stagingDeksRewrapped,
+      },
+      ipAddress: auth.meta.ipAddress,
+      sid: auth.sessionId,
+    });
+
+    return Response.json(result);
+  },
+  { ctx: "admin" },
+);

--- a/src/lib/auth/__tests__/kek-rotation.unit.test.ts
+++ b/src/lib/auth/__tests__/kek-rotation.unit.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("../../db/customer-db", () => ({
+  customerTransitKeyName: (id: string) => `customer-${id}`,
+  customerDbUrl: (template: string, id: string) =>
+    template.replace(/\/[^/?]+(\?|$)/, `/customer_${id.replace(/-/g, "")}$1`),
+  getCustomerOwnerTemplateUrl: () =>
+    "postgres://owner:pass@localhost:5432/template1",
+}));
+
+import type { Pool, QueryResult } from "pg";
+import type { RotationDeps } from "../kek-rotation";
+import { rotateAllKeks } from "../kek-rotation";
+
+const transitConfig = { addr: "http://localhost:8200", token: "test-token" };
+
+function createDeps(overrides?: Partial<RotationDeps>): RotationDeps {
+  return {
+    transitConfig,
+    ownerTemplateUrl: "postgres://owner:pass@localhost:5432/template1",
+    rotateKey: vi.fn().mockResolvedValue(undefined),
+    rewrapDek: vi
+      .fn()
+      .mockImplementation((_c, _k, wrapped: string) =>
+        Promise.resolve(wrapped.replace("v1", "v2")),
+      ),
+    connectCustomerDb: vi.fn().mockResolvedValue({
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+      end: vi.fn().mockResolvedValue(undefined),
+    }),
+    clearCache: vi.fn(),
+    ...overrides,
+  };
+}
+
+function mockPool(
+  queryImpl: (sql: string, params?: unknown[]) => Partial<QueryResult>,
+) {
+  return {
+    query: vi.fn((sql: string, params?: unknown[]) =>
+      Promise.resolve(queryImpl(sql, params)),
+    ),
+  } as unknown as Pool;
+}
+
+describe("rotateAllKeks", () => {
+  it("rotates customer keys and rewraps DEKs", async () => {
+    const deps = createDeps();
+    const pool = mockPool((sql) => {
+      if (sql.includes("FROM customers"))
+        return {
+          rows: [
+            { id: "cust-1", wrapped_dek: "vault:v1:dek1" },
+            { id: "cust-2", wrapped_dek: "vault:v1:dek2" },
+          ],
+        };
+      return { rows: [] };
+    });
+
+    const result = await rotateAllKeks(pool, deps);
+
+    expect(result.customersRotated).toBe(2);
+    expect(result.customersErrored).toBe(0);
+    expect(result.customerDeksRewrapped).toBe(2);
+    expect(result.errors).toHaveLength(0);
+    expect(deps.rotateKey).toHaveBeenCalledTimes(3); // 2 customers + staging
+    expect(deps.rewrapDek).toHaveBeenCalledTimes(2);
+    expect(deps.clearCache).toHaveBeenCalledOnce();
+  });
+
+  it("rewraps detection_events in customer DBs", async () => {
+    const mockClientQuery = vi
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [
+          { id: "evt-1", wrapped_dek: "vault:v1:evtdek1" },
+          { id: "evt-2", wrapped_dek: "vault:v1:evtdek2" },
+        ],
+      })
+      .mockResolvedValue({ rows: [] });
+    const deps = createDeps({
+      connectCustomerDb: vi.fn().mockResolvedValue({
+        query: mockClientQuery,
+        end: vi.fn().mockResolvedValue(undefined),
+      }),
+    });
+    const pool = mockPool((sql) => {
+      if (sql.includes("FROM customers"))
+        return { rows: [{ id: "cust-1", wrapped_dek: "vault:v1:dek1" }] };
+      return { rows: [] };
+    });
+
+    const result = await rotateAllKeks(pool, deps);
+
+    expect(result.eventDeksRewrapped).toBe(2);
+    expect(deps.rewrapDek).toHaveBeenCalledTimes(3); // 1 customer + 2 events
+  });
+
+  it("rewraps staged_event_payloads", async () => {
+    const deps = createDeps();
+    const pool = mockPool((sql) => {
+      if (sql.includes("FROM staged_event_payloads"))
+        return {
+          rows: [
+            { id: "staged-1", wrapped_dek: "vault:v1:stageddek1" },
+            { id: "staged-2", wrapped_dek: "vault:v1:stageddek2" },
+          ],
+        };
+      return { rows: [] };
+    });
+
+    const result = await rotateAllKeks(pool, deps);
+
+    expect(result.stagingDeksRewrapped).toBe(2);
+    expect(deps.rotateKey).toHaveBeenCalledWith(
+      transitConfig,
+      "staging-events",
+    );
+  });
+
+  it("continues on per-customer failure and collects errors", async () => {
+    const rotateKey = vi
+      .fn()
+      .mockResolvedValueOnce(undefined) // cust-ok
+      .mockRejectedValueOnce(new Error("Transit unreachable")) // cust-fail
+      .mockResolvedValueOnce(undefined); // staging
+    const deps = createDeps({ rotateKey });
+    const pool = mockPool((sql) => {
+      if (sql.includes("FROM customers"))
+        return {
+          rows: [
+            { id: "cust-ok", wrapped_dek: "vault:v1:ok" },
+            { id: "cust-fail", wrapped_dek: "vault:v1:fail" },
+          ],
+        };
+      return { rows: [] };
+    });
+
+    const result = await rotateAllKeks(pool, deps);
+
+    expect(result.customersRotated).toBe(1);
+    expect(result.customersErrored).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].customerId).toBe("cust-fail");
+    expect(result.errors[0].error).toContain("Transit unreachable");
+  });
+
+  it("handles customers with null wrapped_dek", async () => {
+    const deps = createDeps();
+    const pool = mockPool((sql) => {
+      if (sql.includes("FROM customers"))
+        return { rows: [{ id: "cust-1", wrapped_dek: null }] };
+      return { rows: [] };
+    });
+
+    const result = await rotateAllKeks(pool, deps);
+
+    expect(result.customersRotated).toBe(1);
+    expect(result.customerDeksRewrapped).toBe(0);
+    expect(deps.rewrapDek).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/auth/kek-rotation.ts
+++ b/src/lib/auth/kek-rotation.ts
@@ -1,0 +1,203 @@
+import "server-only";
+
+import { Client, type Pool } from "pg";
+import { dekCache } from "../crypto/dek-cache";
+import {
+  getTransitConfig,
+  rewrapDataKey,
+  rotateTransitKey,
+  type TransitConfig,
+} from "../crypto/transit";
+import {
+  customerDbUrl,
+  customerTransitKeyName,
+  getCustomerOwnerTemplateUrl,
+} from "../db/customer-db";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RotationResult {
+  customersRotated: number;
+  customersErrored: number;
+  customerDeksRewrapped: number;
+  eventDeksRewrapped: number;
+  stagingDeksRewrapped: number;
+  errors: Array<{ customerId: string; error: string }>;
+}
+
+/** Injectable dependencies for testing. */
+export interface RotationDeps {
+  transitConfig: TransitConfig;
+  ownerTemplateUrl: string;
+  rotateKey: (config: TransitConfig, keyName: string) => Promise<void>;
+  rewrapDek: (
+    config: TransitConfig,
+    keyName: string,
+    wrappedDek: string,
+  ) => Promise<string>;
+  connectCustomerDb: (
+    url: string,
+  ) => Promise<{ query: Pool["query"]; end: () => Promise<void> }>;
+  clearCache: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+const BATCH_SIZE = 100;
+
+async function rewrapCustomerEvents(
+  client: { query: Pool["query"] },
+  customerId: string,
+  deps: Pick<RotationDeps, "transitConfig" | "rewrapDek">,
+): Promise<number> {
+  const keyName = customerTransitKeyName(customerId);
+  let totalRewrapped = 0;
+  let offset = 0;
+
+  for (;;) {
+    const batch = await client.query<{ id: string; wrapped_dek: string }>(
+      "SELECT id, wrapped_dek FROM detection_events ORDER BY id LIMIT $1 OFFSET $2",
+      [BATCH_SIZE, offset],
+    );
+
+    if (batch.rows.length === 0) break;
+
+    for (const row of batch.rows) {
+      const newWrapped = await deps.rewrapDek(
+        deps.transitConfig,
+        keyName,
+        row.wrapped_dek,
+      );
+      await client.query(
+        "UPDATE detection_events SET wrapped_dek = $1 WHERE id = $2",
+        [newWrapped, row.id],
+      );
+      totalRewrapped++;
+    }
+
+    offset += batch.rows.length;
+    if (batch.rows.length < BATCH_SIZE) break;
+  }
+
+  return totalRewrapped;
+}
+
+function defaultDeps(): RotationDeps {
+  return {
+    transitConfig: getTransitConfig(),
+    ownerTemplateUrl: getCustomerOwnerTemplateUrl(),
+    rotateKey: rotateTransitKey,
+    rewrapDek: rewrapDataKey,
+    connectCustomerDb: async (url: string) => {
+      const client = new Client({ connectionString: url });
+      await client.connect();
+      return {
+        query: client.query.bind(client) as Pool["query"],
+        end: () => client.end(),
+      };
+    },
+    clearCache: () => dekCache.clear(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Rotate all Transit keys and rewrap all DEKs.
+ *
+ * 1. For each active customer: rotate Transit key, rewrap auth_db
+ *    wrapped_dek, rewrap all detection_events in customer DB.
+ * 2. Rotate staging-events key, rewrap staged_event_payloads.
+ * 3. Clear DEK cache.
+ */
+export async function rotateAllKeks(
+  authPool: Pool,
+  deps?: RotationDeps,
+): Promise<RotationResult> {
+  const d = deps ?? defaultDeps();
+
+  const result: RotationResult = {
+    customersRotated: 0,
+    customersErrored: 0,
+    customerDeksRewrapped: 0,
+    eventDeksRewrapped: 0,
+    stagingDeksRewrapped: 0,
+    errors: [],
+  };
+
+  // 1. Customer keys
+  const customers = await authPool.query<{
+    id: string;
+    wrapped_dek: string | null;
+  }>("SELECT id, wrapped_dek FROM customers WHERE database_status = 'active'");
+
+  for (const customer of customers.rows) {
+    try {
+      const keyName = customerTransitKeyName(customer.id);
+
+      await d.rotateKey(d.transitConfig, keyName);
+
+      if (customer.wrapped_dek) {
+        const newWrapped = await d.rewrapDek(
+          d.transitConfig,
+          keyName,
+          customer.wrapped_dek,
+        );
+        await authPool.query(
+          "UPDATE customers SET wrapped_dek = $1 WHERE id = $2",
+          [newWrapped, customer.id],
+        );
+        result.customerDeksRewrapped++;
+      }
+
+      const dbUrl = customerDbUrl(d.ownerTemplateUrl, customer.id);
+      const conn = await d.connectCustomerDb(dbUrl);
+      try {
+        const eventCount = await rewrapCustomerEvents(conn, customer.id, d);
+        result.eventDeksRewrapped += eventCount;
+      } finally {
+        await conn.end().catch(() => {});
+      }
+
+      result.customersRotated++;
+    } catch (err) {
+      result.customersErrored++;
+      result.errors.push({
+        customerId: customer.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // 2. Staging-events key
+  const stagingKeyName = "staging-events";
+  await d.rotateKey(d.transitConfig, stagingKeyName);
+
+  const staged = await authPool.query<{ id: string; wrapped_dek: string }>(
+    "SELECT id, wrapped_dek FROM staged_event_payloads",
+  );
+
+  for (const row of staged.rows) {
+    const newWrapped = await d.rewrapDek(
+      d.transitConfig,
+      stagingKeyName,
+      row.wrapped_dek,
+    );
+    await authPool.query(
+      "UPDATE staged_event_payloads SET wrapped_dek = $1 WHERE id = $2",
+      [newWrapped, row.id],
+    );
+    result.stagingDeksRewrapped++;
+  }
+
+  // 3. Clear DEK cache
+  d.clearCache();
+
+  return result;
+}

--- a/src/lib/crypto/__tests__/dek-cache.unit.test.ts
+++ b/src/lib/crypto/__tests__/dek-cache.unit.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { DekCache } from "../dek-cache";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("DekCache", () => {
+  it("returns undefined for uncached keys", () => {
+    const cache = new DekCache();
+    expect(cache.get("key", "wrapped")).toBeUndefined();
+  });
+
+  it("returns cached plaintext after set", () => {
+    const cache = new DekCache();
+    const plaintext = Buffer.from("secret-key-material");
+    cache.set("key", "wrapped", plaintext);
+
+    const result = cache.get("key", "wrapped");
+    expect(result).toEqual(plaintext);
+    expect(cache.size).toBe(1);
+  });
+
+  it("returns a clone — modifying result does not affect cache", () => {
+    const cache = new DekCache();
+    const plaintext = Buffer.from("secret-key-material");
+    cache.set("key", "wrapped", plaintext);
+
+    const result = cache.get("key", "wrapped");
+    expect(result).toBeDefined();
+    result?.fill(0);
+
+    // Cache should still have the original value
+    const result2 = cache.get("key", "wrapped");
+    expect(result2).toEqual(Buffer.from("secret-key-material"));
+  });
+
+  it("stores a clone — zeroing the original does not affect cache", () => {
+    const cache = new DekCache();
+    const plaintext = Buffer.from("secret-key-material");
+    cache.set("key", "wrapped", plaintext);
+
+    plaintext.fill(0);
+
+    const result = cache.get("key", "wrapped");
+    expect(result).toEqual(Buffer.from("secret-key-material"));
+  });
+
+  it("evicts after TTL expires", () => {
+    const cache = new DekCache(1000);
+    cache.set("key", "wrapped", Buffer.from("secret"));
+
+    expect(cache.get("key", "wrapped")).toBeDefined();
+
+    vi.advanceTimersByTime(1001);
+
+    expect(cache.get("key", "wrapped")).toBeUndefined();
+    expect(cache.size).toBe(0);
+  });
+
+  it("invalidate removes and zeroes a specific entry", () => {
+    const cache = new DekCache();
+    cache.set("key-a", "wrapped-a", Buffer.from("secret-a"));
+    cache.set("key-b", "wrapped-b", Buffer.from("secret-b"));
+
+    cache.invalidate("key-a", "wrapped-a");
+
+    expect(cache.get("key-a", "wrapped-a")).toBeUndefined();
+    expect(cache.get("key-b", "wrapped-b")).toBeDefined();
+    expect(cache.size).toBe(1);
+  });
+
+  it("clear zeroes and removes all entries", () => {
+    const cache = new DekCache();
+    cache.set("key-a", "wrapped-a", Buffer.from("secret-a"));
+    cache.set("key-b", "wrapped-b", Buffer.from("secret-b"));
+
+    cache.clear();
+
+    expect(cache.size).toBe(0);
+    expect(cache.get("key-a", "wrapped-a")).toBeUndefined();
+    expect(cache.get("key-b", "wrapped-b")).toBeUndefined();
+  });
+
+  it("overwrites existing entry on re-set", () => {
+    const cache = new DekCache();
+    cache.set("key", "wrapped", Buffer.from("old-value"));
+    cache.set("key", "wrapped", Buffer.from("new-value"));
+
+    expect(cache.size).toBe(1);
+    expect(cache.get("key", "wrapped")).toEqual(Buffer.from("new-value"));
+  });
+});

--- a/src/lib/crypto/__tests__/envelope.unit.test.ts
+++ b/src/lib/crypto/__tests__/envelope.unit.test.ts
@@ -13,10 +13,12 @@ vi.mock("../transit", () => ({
   decryptDataKey: (...args: unknown[]) => mockDecryptDataKey(...args),
 }));
 
+import { dekCache } from "../dek-cache";
 import { decryptPayload, encryptPayload } from "../envelope";
 
 afterEach(() => {
   vi.clearAllMocks();
+  dekCache.clear();
 });
 
 function setupMockKeys() {

--- a/src/lib/crypto/__tests__/transit.unit.test.ts
+++ b/src/lib/crypto/__tests__/transit.unit.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-import { decryptDataKey, generateDataKey, rewrapDataKey } from "../transit";
+import {
+  decryptDataKey,
+  generateDataKey,
+  rewrapDataKey,
+  rotateTransitKey,
+} from "../transit";
 
 const config = { addr: "http://localhost:8200", token: "test-token" };
 
@@ -108,5 +113,29 @@ describe("rewrapDataKey", () => {
     expect(url).toBe("http://localhost:8200/v1/transit/rewrap/staging-events");
     const body = JSON.parse(opts.body);
     expect(body.ciphertext).toBe("vault:v1:oldwrappedkey");
+  });
+});
+
+describe("rotateTransitKey", () => {
+  it("calls POST transit/keys/<name>/rotate", async () => {
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    await rotateTransitKey(config, "customer-abc");
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe(
+      "http://localhost:8200/v1/transit/keys/customer-abc/rotate",
+    );
+    expect(opts.method).toBe("POST");
+    expect(opts.headers["X-Vault-Token"]).toBe("test-token");
+  });
+
+  it("throws on non-OK response", async () => {
+    mockFetch.mockResolvedValueOnce(new Response("forbidden", { status: 403 }));
+
+    await expect(rotateTransitKey(config, "customer-abc")).rejects.toThrow(
+      "Transit keys/customer-abc/rotate failed (403)",
+    );
   });
 });

--- a/src/lib/crypto/dek-cache.ts
+++ b/src/lib/crypto/dek-cache.ts
@@ -1,0 +1,95 @@
+import "server-only";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CacheEntry {
+  plaintext: Buffer;
+  timer: NodeJS.Timeout;
+}
+
+// ---------------------------------------------------------------------------
+// DEK Cache
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * In-memory cache for plaintext DEKs with automatic TTL eviction.
+ *
+ * - Clones Buffers on both `set()` and `get()` so caller zeroing
+ *   never corrupts the cache, and cache eviction never corrupts
+ *   a Buffer the caller is still using.
+ * - Zeroes internal Buffers on eviction and `clear()`.
+ * - Never persisted — lost on process restart by design.
+ */
+export class DekCache {
+  private readonly map = new Map<string, CacheEntry>();
+  private readonly ttlMs: number;
+
+  constructor(ttlMs = DEFAULT_TTL_MS) {
+    this.ttlMs = ttlMs;
+  }
+
+  private static cacheKey(keyName: string, wrappedDek: string): string {
+    return `${keyName}:${wrappedDek}`;
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+
+  get(keyName: string, wrappedDek: string): Buffer | undefined {
+    const entry = this.map.get(DekCache.cacheKey(keyName, wrappedDek));
+    if (!entry) return undefined;
+    // Return a clone so the caller can safely zero it
+    return Buffer.from(entry.plaintext);
+  }
+
+  set(keyName: string, wrappedDek: string, plaintext: Buffer): void {
+    const key = DekCache.cacheKey(keyName, wrappedDek);
+
+    // Evict existing entry if present
+    const existing = this.map.get(key);
+    if (existing) {
+      clearTimeout(existing.timer);
+      existing.plaintext.fill(0);
+    }
+
+    // Store a clone so the caller can safely zero the original
+    const clone = Buffer.from(plaintext);
+    const timer = setTimeout(() => {
+      clone.fill(0);
+      this.map.delete(key);
+    }, this.ttlMs);
+
+    // Allow the timer to not prevent process exit
+    if (typeof timer.unref === "function") {
+      timer.unref();
+    }
+
+    this.map.set(key, { plaintext: clone, timer });
+  }
+
+  invalidate(keyName: string, wrappedDek: string): void {
+    const key = DekCache.cacheKey(keyName, wrappedDek);
+    const entry = this.map.get(key);
+    if (entry) {
+      clearTimeout(entry.timer);
+      entry.plaintext.fill(0);
+      this.map.delete(key);
+    }
+  }
+
+  clear(): void {
+    for (const entry of this.map.values()) {
+      clearTimeout(entry.timer);
+      entry.plaintext.fill(0);
+    }
+    this.map.clear();
+  }
+}
+
+/** Module-level singleton. */
+export const dekCache = new DekCache();

--- a/src/lib/crypto/envelope.ts
+++ b/src/lib/crypto/envelope.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import { dekCache } from "./dek-cache";
 import {
   type DataKey,
   decryptDataKey,
@@ -88,8 +89,12 @@ export async function decryptPayload(
     throw new Error("Ciphertext too short");
   }
 
-  const config = getTransitConfig();
-  const dek = await decryptDataKey(config, keyName, wrappedDek);
+  const cached = dekCache.get(keyName, wrappedDek);
+  const dek =
+    cached ?? (await decryptDataKey(getTransitConfig(), keyName, wrappedDek));
+  if (!cached) {
+    dekCache.set(keyName, wrappedDek, dek);
+  }
 
   try {
     const iv = ciphertext.subarray(0, IV_BYTES);

--- a/src/lib/crypto/transit.ts
+++ b/src/lib/crypto/transit.ts
@@ -4,7 +4,7 @@ import "server-only";
 // Types
 // ---------------------------------------------------------------------------
 
-interface TransitConfig {
+export interface TransitConfig {
   addr: string;
   token: string;
 }
@@ -119,6 +119,28 @@ export async function rewrapDataKey(
     throw new Error("Transit rewrap: unexpected response shape");
   }
   return newWrapped;
+}
+
+/**
+ * Rotate a Transit named key to a new version.
+ * Existing ciphertext can still be decrypted; new encrypt/datakey
+ * operations will use the latest version.
+ */
+export async function rotateTransitKey(
+  config: TransitConfig,
+  keyName: string,
+): Promise<void> {
+  const url = `${config.addr}/v1/transit/keys/${keyName}/rotate`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "X-Vault-Token": config.token },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `Transit keys/${keyName}/rotate failed (${res.status}): ${text}`,
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `rotateTransitKey()` to Transit client for key version rotation
- Add in-memory DEK cache with TTL, buffer cloning, and automatic zeroing on eviction
- Integrate DEK cache into `decryptPayload` (cache-first pattern)
- Add `rotateAllKeks()` KEK rotation orchestrator: sequential per-customer Transit key rotation, batched event DEK rewrap (100 rows), staging-events rotation, error isolation per customer
- Add `POST /api/admin/kek/rotate` admin endpoint with CSRF, origin check, and audit logging
- Replace OpenBao dev mode with file storage backend (`infra/openbao/config.hcl`), auto-init with single Shamir key, auto-unseal on every boot
- Fix `init-transit.sh` wait loop (uninitialized server returned non-zero) and JSON parsing (BusyBox compatibility)
- Add OpenBao service to CI E2E job and E2E test with real Transit API calls

## Test plan

- [x] 32 unit tests pass (transit, dek-cache, envelope, kek-rotation, transit-delete)
- [x] E2E: auth boundary (401 unauthenticated, 401 general cookie, 405 GET)
- [x] E2E: authenticated rotation with real Transit — verifies wrapped DEKs change in DB and decrypt to same plaintext
- [x] `docker compose --profile dev up openbao` — auto-inits, unseals, Transit ready
- [x] `pnpm tsc --noEmit` and `pnpm biome check` clean

Closes #52