### PR TITLE
Add dashboard layout, sidebar & selectors

### DIFF
--- a/e2e/dashboard-layout.spec.ts
+++ b/e2e/dashboard-layout.spec.ts
@@ -1,0 +1,295 @@
+import { expect, test } from "./fixtures";
+
+// ---------------------------------------------------------------------------
+// Sidebar — rendering
+// ---------------------------------------------------------------------------
+
+test.describe("Dashboard sidebar", () => {
+  test("renders sidebar with logo and navigation items", async ({
+    managerPage,
+  }) => {
+    await managerPage.goto("/en");
+    await expect(managerPage.getByText("AIMER")).toBeVisible();
+
+    const nav = managerPage.getByRole("navigation", { name: "Main" });
+    await expect(nav.getByText("Home")).toBeVisible();
+    await expect(nav.getByText("Events")).toBeVisible();
+    await expect(nav.getByText("Analysis")).toBeVisible();
+    await expect(nav.getByText("Reports")).toBeVisible();
+    await expect(nav.getByText("Dashboard")).toBeVisible();
+  });
+
+  test("renders manager-only items for Manager role", async ({
+    managerPage,
+  }) => {
+    await managerPage.goto("/en");
+
+    const nav = managerPage.getByRole("navigation", { name: "Main" });
+    await expect(nav.getByText("Members")).toBeVisible();
+    await expect(nav.getByText("Customer Settings")).toBeVisible();
+  });
+
+  test("hides manager-only items for User role", async ({ userPage }) => {
+    await userPage.goto("/en");
+
+    const nav = userPage.getByRole("navigation", { name: "Main" });
+    await expect(nav.getByText("Home")).toBeVisible();
+    await expect(nav.getByText("Members")).toBeHidden();
+    await expect(nav.getByText("Customer Settings")).toBeHidden();
+  });
+
+  test("highlights active navigation item", async ({ managerPage }) => {
+    await managerPage.goto("/en/events");
+
+    const nav = managerPage.getByRole("navigation", { name: "Main" });
+    const activeLink = nav.locator('a[aria-current="page"]');
+    await expect(activeLink).toBeVisible();
+    await expect(activeLink).toHaveAttribute("href", /\/events$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sidebar — customer/environment selector
+// ---------------------------------------------------------------------------
+
+test.describe("Dashboard customer selector", () => {
+  test("renders customer selector with accessible customers", async ({
+    managerPage,
+    testData,
+  }) => {
+    await managerPage.goto("/en");
+
+    const select = managerPage.getByLabel("Customer");
+    await expect(select).toBeVisible();
+    await expect(select).toBeEnabled();
+    await expect(select.getByText(testData.customer.name)).toBeAttached();
+  });
+
+  test("renders environment selector", async ({ managerPage }) => {
+    await managerPage.goto("/en");
+
+    const select = managerPage.getByLabel("Environment");
+    await expect(select).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sidebar — collapse/expand
+// ---------------------------------------------------------------------------
+
+test.describe("Dashboard sidebar collapse", () => {
+  test("collapses sidebar and hides nav labels", async ({ managerPage }) => {
+    await managerPage.goto("/en");
+
+    // Dismiss any Next.js dev overlay that may intercept pointer events
+    await managerPage.evaluate(() => {
+      for (const el of document.querySelectorAll("nextjs-portal")) {
+        el.remove();
+      }
+    });
+
+    await managerPage.getByRole("button", { name: "Collapse sidebar" }).click();
+
+    // Customer selector should be hidden
+    await expect(managerPage.getByLabel("Customer")).toBeHidden();
+
+    // Expand button should appear
+    await expect(
+      managerPage.getByRole("button", { name: "Expand sidebar" }),
+    ).toBeVisible();
+
+    // Nav item text should be sr-only (not visually rendered as block text)
+    const nav = managerPage.getByRole("navigation", { name: "Main" });
+    await expect(nav.locator("a >> .sr-only").first()).toBeAttached();
+  });
+
+  test("expands sidebar and shows nav labels again", async ({
+    managerPage,
+  }) => {
+    await managerPage.goto("/en");
+
+    // Dismiss any Next.js dev overlay that may intercept pointer events
+    await managerPage.evaluate(() => {
+      for (const el of document.querySelectorAll("nextjs-portal")) {
+        el.remove();
+      }
+    });
+
+    // Collapse
+    await managerPage.getByRole("button", { name: "Collapse sidebar" }).click();
+
+    // Wait for collapse transition to settle
+    await expect(managerPage.getByLabel("Customer")).toBeHidden();
+
+    // Expand
+    await managerPage.getByRole("button", { name: "Expand sidebar" }).click();
+
+    // Labels and customer selector should be visible again
+    await expect(managerPage.getByLabel("Customer")).toBeVisible();
+    await expect(
+      managerPage.getByRole("button", { name: "Collapse sidebar" }),
+    ).toBeVisible();
+  });
+
+  test("persists collapsed state across navigation", async ({
+    managerPage,
+  }) => {
+    await managerPage.goto("/en");
+
+    // Dismiss any Next.js dev overlay that may intercept pointer events
+    await managerPage.evaluate(() => {
+      for (const el of document.querySelectorAll("nextjs-portal")) {
+        el.remove();
+      }
+    });
+
+    // Collapse
+    await managerPage.getByRole("button", { name: "Collapse sidebar" }).click();
+    await expect(managerPage.getByLabel("Customer")).toBeHidden();
+
+    // Navigate to a different page
+    await managerPage.goto("/en/events");
+
+    // Sidebar should still be collapsed
+    await expect(managerPage.getByLabel("Customer")).toBeHidden();
+    await expect(
+      managerPage.getByRole("button", { name: "Expand sidebar" }),
+    ).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Breadcrumbs
+// ---------------------------------------------------------------------------
+
+test.describe("Dashboard breadcrumbs", () => {
+  test("shows breadcrumbs for events page", async ({ managerPage }) => {
+    await managerPage.goto("/en/events");
+
+    const breadcrumb = managerPage.getByRole("navigation", {
+      name: "Breadcrumb",
+    });
+    await expect(breadcrumb).toBeVisible();
+    await expect(breadcrumb.getByText("Events")).toBeVisible();
+  });
+
+  test("shows nested breadcrumbs for settings/members", async ({
+    managerPage,
+  }) => {
+    await managerPage.goto("/en/settings/members");
+
+    const breadcrumb = managerPage.getByRole("navigation", {
+      name: "Breadcrumb",
+    });
+    await expect(breadcrumb.getByText("Settings")).toBeVisible();
+    await expect(breadcrumb.getByText("Members")).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// User profile section
+// ---------------------------------------------------------------------------
+
+test.describe("Dashboard user section", () => {
+  test("renders user display name and sign out", async ({
+    managerPage,
+    testData,
+  }) => {
+    await managerPage.goto("/en");
+
+    await expect(
+      managerPage.getByText(testData.manager.displayName),
+    ).toBeVisible();
+    await expect(managerPage.getByText("Sign Out")).toBeVisible();
+  });
+
+  test("renders theme toggle", async ({ managerPage }) => {
+    await managerPage.goto("/en");
+
+    // Theme toggle button should be in the sidebar
+    await expect(
+      managerPage.getByRole("button", { name: "Toggle theme" }),
+    ).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Placeholder pages
+// ---------------------------------------------------------------------------
+
+test.describe("Dashboard placeholder pages", () => {
+  test("events page renders", async ({ managerPage }) => {
+    await managerPage.goto("/en/events");
+    await expect(
+      managerPage.getByRole("heading", { name: "Events", level: 1 }),
+    ).toBeVisible();
+  });
+
+  test("analysis page renders", async ({ managerPage }) => {
+    await managerPage.goto("/en/analysis");
+    await expect(
+      managerPage.getByRole("heading", { name: "Analysis", level: 1 }),
+    ).toBeVisible();
+  });
+
+  test("reports page renders", async ({ managerPage }) => {
+    await managerPage.goto("/en/reports");
+    await expect(
+      managerPage.getByRole("heading", { name: "Reports", level: 1 }),
+    ).toBeVisible();
+  });
+
+  test("dashboard page renders", async ({ managerPage }) => {
+    await managerPage.goto("/en/dashboard");
+    await expect(
+      managerPage.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Navigation
+// ---------------------------------------------------------------------------
+
+test.describe("Dashboard navigation", () => {
+  test("navigates between pages via sidebar links", async ({ managerPage }) => {
+    await managerPage.goto("/en");
+
+    // Click Events link
+    await managerPage
+      .getByRole("navigation", { name: "Main" })
+      .getByText("Events")
+      .click();
+
+    await expect(
+      managerPage.getByRole("heading", { name: "Events", level: 1 }),
+    ).toBeVisible();
+    await expect(managerPage).toHaveURL(/\/en\/events/);
+  });
+
+  test("logo links to home page", async ({ managerPage }) => {
+    await managerPage.goto("/en/events");
+
+    // Click logo (the AIMER link)
+    await managerPage.getByText("AIMER").click();
+
+    await expect(managerPage).toHaveURL(/\/en$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Locale
+// ---------------------------------------------------------------------------
+
+test.describe("Dashboard locale", () => {
+  test("renders sidebar in Korean", async ({ managerPage }) => {
+    await managerPage.goto("/ko");
+
+    const nav = managerPage.getByRole("navigation", { name: "Main" });
+    await expect(nav.getByText("홈")).toBeVisible();
+    await expect(nav.getByText("이벤트")).toBeVisible();
+    await expect(nav.getByText("분석")).toBeVisible();
+    await expect(nav.getByText("보고서")).toBeVisible();
+    await expect(nav.getByText("대시보드")).toBeVisible();
+  });
+});

--- a/src/app/[locale]/(dashboard)/analysis/page.tsx
+++ b/src/app/[locale]/(dashboard)/analysis/page.tsx
@@ -1,0 +1,17 @@
+import { useTranslations } from "next-intl";
+
+export default function AnalysisPage() {
+  const t = useTranslations("nav");
+  const tCommon = useTranslations("common");
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6">
+      <h1 className="text-2xl font-semibold text-foreground">
+        {t("analysis")}
+      </h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {tCommon("comingSoon")}
+      </p>
+    </div>
+  );
+}

--- a/src/app/[locale]/(dashboard)/dashboard/page.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/page.tsx
@@ -1,0 +1,17 @@
+import { useTranslations } from "next-intl";
+
+export default function DashboardPage() {
+  const t = useTranslations("nav");
+  const tCommon = useTranslations("common");
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6">
+      <h1 className="text-2xl font-semibold text-foreground">
+        {t("dashboard")}
+      </h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {tCommon("comingSoon")}
+      </p>
+    </div>
+  );
+}

--- a/src/app/[locale]/(dashboard)/events/page.tsx
+++ b/src/app/[locale]/(dashboard)/events/page.tsx
@@ -1,0 +1,15 @@
+import { useTranslations } from "next-intl";
+
+export default function EventsPage() {
+  const t = useTranslations("nav");
+  const tCommon = useTranslations("common");
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6">
+      <h1 className="text-2xl font-semibold text-foreground">{t("events")}</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {tCommon("comingSoon")}
+      </p>
+    </div>
+  );
+}

--- a/src/app/[locale]/(dashboard)/layout.tsx
+++ b/src/app/[locale]/(dashboard)/layout.tsx
@@ -2,9 +2,9 @@
 
 import { useTranslations } from "next-intl";
 
-import { LocaleSwitcher } from "@/components/locale-switcher";
-import { Sidebar } from "@/components/sidebar";
-import { ThemeToggle } from "@/components/theme-toggle";
+import { Breadcrumbs } from "@/components/breadcrumbs";
+import { HEADER_HEIGHT } from "@/components/layout-constants";
+import { MobileSidebarTrigger, Sidebar } from "@/components/sidebar";
 import {
   CustomerContextProvider,
   useCustomerContext,
@@ -26,9 +26,11 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
     <div className="flex h-screen">
       <Sidebar />
       <div className="flex flex-1 flex-col overflow-hidden">
-        <header className="flex h-14 items-center justify-end gap-2 border-b border-border px-4">
-          <ThemeToggle />
-          <LocaleSwitcher />
+        <header
+          className={`flex ${HEADER_HEIGHT} shrink-0 items-center gap-2 border-b border-border px-4`}
+        >
+          <MobileSidebarTrigger />
+          <Breadcrumbs />
         </header>
         <main id="main-content" className="flex-1 overflow-y-auto">
           {children}

--- a/src/app/[locale]/(dashboard)/page.tsx
+++ b/src/app/[locale]/(dashboard)/page.tsx
@@ -2,9 +2,10 @@ import { useTranslations } from "next-intl";
 
 export default function HomePage() {
   const t = useTranslations("nav");
+
   return (
-    <div className="flex h-full items-center justify-center">
-      <h1 className="text-2xl font-bold text-foreground">{t("dashboard")}</h1>
+    <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6">
+      <h1 className="text-2xl font-semibold text-foreground">{t("home")}</h1>
     </div>
   );
 }

--- a/src/app/[locale]/(dashboard)/reports/page.tsx
+++ b/src/app/[locale]/(dashboard)/reports/page.tsx
@@ -1,0 +1,15 @@
+import { useTranslations } from "next-intl";
+
+export default function ReportsPage() {
+  const t = useTranslations("nav");
+  const tCommon = useTranslations("common");
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6">
+      <h1 className="text-2xl font-semibold text-foreground">{t("reports")}</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {tCommon("comingSoon")}
+      </p>
+    </div>
+  );
+}

--- a/src/components/__tests__/breadcrumbs.unit.test.tsx
+++ b/src/components/__tests__/breadcrumbs.unit.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(),
+}));
+
+vi.mock("next-intl", () => ({
+  useLocale: vi.fn(() => "en"),
+  useTranslations: vi.fn(() => (key: string) => {
+    const map: Record<string, string> = {
+      events: "Events",
+      analysis: "Analysis",
+      reports: "Reports",
+      dashboard: "Dashboard",
+      settings: "Settings",
+      members: "Members",
+      customerSettings: "Customer Settings",
+    };
+    return map[key] ?? key;
+  }),
+}));
+
+import { usePathname } from "next/navigation";
+import { Breadcrumbs } from "../breadcrumbs";
+
+const mockedUsePathname = vi.mocked(usePathname);
+
+describe("Breadcrumbs", () => {
+  it("renders only home link on the home page", () => {
+    mockedUsePathname.mockReturnValue("/en");
+
+    const { container } = render(<Breadcrumbs />);
+
+    const links = container.querySelectorAll("a");
+    expect(links.length).toBe(1);
+    expect(links[0].getAttribute("href")).toBe("/en");
+  });
+
+  it("renders crumbs for /en/events", () => {
+    mockedUsePathname.mockReturnValue("/en/events");
+
+    const { container } = render(<Breadcrumbs />);
+
+    const links = container.querySelectorAll("a");
+    expect(links.length).toBe(2);
+    expect(links[0].getAttribute("href")).toBe("/en");
+    expect(links[1].getAttribute("href")).toBe("/en/events");
+    expect(links[1].textContent).toBe("Events");
+  });
+
+  it("renders nested crumbs for /en/settings/members", () => {
+    mockedUsePathname.mockReturnValue("/en/settings/members");
+
+    const { container } = render(<Breadcrumbs />);
+
+    const links = container.querySelectorAll("a");
+    expect(links.length).toBe(3);
+    expect(links[1].getAttribute("href")).toBe("/en/settings");
+    expect(links[1].textContent).toBe("Settings");
+    expect(links[2].getAttribute("href")).toBe("/en/settings/members");
+    expect(links[2].textContent).toBe("Members");
+  });
+
+  it("skips unknown segments", () => {
+    mockedUsePathname.mockReturnValue("/en/unknown/path");
+
+    const { container } = render(<Breadcrumbs />);
+
+    const links = container.querySelectorAll("a");
+    // Only home link
+    expect(links.length).toBe(1);
+  });
+
+  it("has breadcrumb aria-label on nav element", () => {
+    mockedUsePathname.mockReturnValue("/en");
+
+    const { container } = render(<Breadcrumbs />);
+
+    const nav = container.querySelector('nav[aria-label="Breadcrumb"]');
+    expect(nav).not.toBeNull();
+  });
+
+  it("renders customer settings crumb for /en/settings/customer", () => {
+    mockedUsePathname.mockReturnValue("/en/settings/customer");
+
+    const { container } = render(<Breadcrumbs />);
+
+    const links = container.querySelectorAll("a");
+    expect(links.length).toBe(3);
+    expect(links[2].textContent).toBe("Customer Settings");
+  });
+
+  it("renders only known segments in a deep path with unknown parts", () => {
+    mockedUsePathname.mockReturnValue("/en/settings/members/some-id");
+
+    const { container } = render(<Breadcrumbs />);
+
+    const links = container.querySelectorAll("a");
+    // Home + Settings + Members (some-id is unknown and skipped)
+    expect(links.length).toBe(3);
+    expect(links[1].textContent).toBe("Settings");
+    expect(links[2].textContent).toBe("Members");
+  });
+
+  it("renders crumbs for each page route", () => {
+    const routes: Array<[string, string]> = [
+      ["/en/analysis", "Analysis"],
+      ["/en/reports", "Reports"],
+      ["/en/dashboard", "Dashboard"],
+    ];
+
+    for (const [path, label] of routes) {
+      mockedUsePathname.mockReturnValue(path);
+      const { container, unmount } = render(<Breadcrumbs />);
+
+      const links = container.querySelectorAll("a");
+      expect(links.length).toBe(2);
+      expect(links[1].textContent).toBe(label);
+
+      unmount();
+    }
+  });
+});

--- a/src/components/__tests__/sidebar.unit.test.tsx
+++ b/src/components/__tests__/sidebar.unit.test.tsx
@@ -1,0 +1,568 @@
+// @vitest-environment jsdom
+import { fireEvent, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------- Mocks ----------
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/en"),
+}));
+
+vi.mock("next-intl", () => {
+  const navMap: Record<string, string> = {
+    home: "Home",
+    events: "Events",
+    analysis: "Analysis",
+    reports: "Reports",
+    dashboard: "Dashboard",
+    members: "Members",
+    customerSettings: "Customer Settings",
+  };
+  const sidebarMap: Record<string, string> = {
+    selectCustomer: "Customer",
+    selectEnvironment: "Environment",
+    bridgeLocked: "Locked to bridge session",
+    expandSidebar: "Expand sidebar",
+    collapseSidebar: "Collapse sidebar",
+    openMenu: "Open navigation menu",
+  };
+  const authMap: Record<string, string> = {
+    signOut: "Sign Out",
+  };
+  return {
+    useLocale: vi.fn(() => "en"),
+    useTranslations: vi.fn((ns: string) => {
+      if (ns === "nav") return (key: string) => navMap[key] ?? key;
+      if (ns === "sidebar") return (key: string) => sidebarMap[key] ?? key;
+      if (ns === "auth") return (key: string) => authMap[key] ?? key;
+      return (key: string) => key;
+    }),
+  };
+});
+
+vi.mock("@/hooks/use-customer-context", () => ({
+  useCustomerContext: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-permissions", () => ({
+  usePermissions: vi.fn(),
+}));
+
+vi.mock("@/components/theme-toggle", () => ({
+  ThemeToggle: ({ className }: { className?: string }) => (
+    <button type="button" className={className} data-testid="theme-toggle">
+      Theme
+    </button>
+  ),
+}));
+
+vi.mock("@/components/locale-switcher", () => ({
+  LocaleSwitcher: () => <button type="button">Locale</button>,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({
+    children,
+  }: {
+    children: React.ReactNode;
+    asChild?: boolean;
+  }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="tooltip" hidden>
+      {children}
+    </span>
+  ),
+}));
+
+let lastOnOpenChange: ((v: boolean) => void) | undefined;
+
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({
+    children,
+    onOpenChange,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+    onOpenChange?: (v: boolean) => void;
+  }) => {
+    lastOnOpenChange = onOpenChange;
+    return <div data-testid="sheet">{children}</div>;
+  },
+  SheetTrigger: ({
+    children,
+  }: {
+    children: React.ReactNode;
+    asChild?: boolean;
+  }) => <div data-testid="sheet-trigger">{children}</div>,
+  SheetContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="sheet-content">{children}</div>
+  ),
+}));
+
+import { usePathname } from "next/navigation";
+import { useCustomerContext } from "@/hooks/use-customer-context";
+import { usePermissions } from "@/hooks/use-permissions";
+import { MobileSidebarTrigger, Sidebar } from "../sidebar";
+
+const mockedUseCustomerContext = vi.mocked(useCustomerContext);
+const mockedUsePermissions = vi.mocked(usePermissions);
+const mockedUsePathname = vi.mocked(usePathname);
+
+function mockDefaults(
+  overrides?: Partial<ReturnType<typeof useCustomerContext>>,
+) {
+  mockedUseCustomerContext.mockReturnValue({
+    me: {
+      accountId: "acc-1",
+      sessionId: "sess-1",
+      authContext: "general",
+      username: "tester",
+      displayName: "Test User",
+      email: "test@example.com",
+      locale: null,
+      timezone: null,
+      analystEligible: false,
+      bridge: { active: false, aiceId: null, customerIds: null },
+      memberships: [],
+    },
+    customers: [
+      {
+        id: "c1",
+        externalKey: "ext-1",
+        name: "Acme Corp",
+        role: "Manager",
+        isAnalyst: false,
+      },
+    ],
+    selectedCustomerId: "c1",
+    setSelectedCustomerId: vi.fn(),
+    environments: [{ aiceId: "env-1", name: "Production" }],
+    selectedEnvironmentId: "env-1",
+    setSelectedEnvironmentId: vi.fn(),
+    isBridgeSession: false,
+    loading: false,
+    ...overrides,
+  });
+}
+
+function mockPermissions(
+  overrides?: Partial<ReturnType<typeof usePermissions>>,
+) {
+  mockedUsePermissions.mockReturnValue({
+    role: "Manager",
+    isAnalyst: false,
+    isManager: true,
+    canViewMembers: true,
+    canViewCustomerSettings: true,
+    canUseAnalystFeatures: false,
+    ...overrides,
+  });
+}
+
+function setup() {
+  mockDefaults();
+  mockPermissions();
+}
+
+function assertDefined<T>(value: T | null | undefined): asserts value is T {
+  expect(value).not.toBeNull();
+}
+
+// ---------- Tests ----------
+
+describe("Sidebar", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockedUsePathname.mockReturnValue("/en");
+    setup();
+  });
+
+  it("renders logo text AIMER", () => {
+    const { container } = render(<Sidebar />);
+    const aside = container.querySelector("aside");
+    assertDefined(aside);
+    expect(aside.textContent).toContain("AIMER");
+  });
+
+  it("renders all general navigation items", () => {
+    const { container } = render(<Sidebar />);
+    const nav = container.querySelector('nav[aria-label="Main"]');
+    assertDefined(nav);
+    const text = nav.textContent ?? "";
+
+    expect(text).toContain("Home");
+    expect(text).toContain("Events");
+    expect(text).toContain("Analysis");
+    expect(text).toContain("Reports");
+    expect(text).toContain("Dashboard");
+  });
+
+  it("renders manager-only items when canViewMembers is true", () => {
+    const { container } = render(<Sidebar />);
+    const nav = container.querySelector('nav[aria-label="Main"]');
+    assertDefined(nav);
+    const text = nav.textContent ?? "";
+
+    expect(text).toContain("Members");
+    expect(text).toContain("Customer Settings");
+  });
+
+  it("hides manager-only items when canViewMembers is false", () => {
+    mockPermissions({
+      isManager: false,
+      canViewMembers: false,
+      canViewCustomerSettings: false,
+    });
+
+    const { container } = render(<Sidebar />);
+    const nav = container.querySelector('nav[aria-label="Main"]');
+    assertDefined(nav);
+    const text = nav.textContent ?? "";
+
+    expect(text).not.toContain("Members");
+    expect(text).not.toContain("Customer Settings");
+  });
+
+  it("renders customer selector with correct value", () => {
+    const { container } = render(<Sidebar />);
+    const selects = container.querySelectorAll("select");
+
+    expect(selects.length).toBe(2);
+    expect((selects[0] as HTMLSelectElement).value).toBe("c1");
+    expect(selects[0].textContent).toContain("Acme Corp");
+  });
+
+  it("renders environment selector", () => {
+    const { container } = render(<Sidebar />);
+    const selects = container.querySelectorAll("select");
+
+    expect(selects.length).toBe(2);
+    expect((selects[1] as HTMLSelectElement).value).toBe("env-1");
+    expect(selects[1].textContent).toContain("Production");
+  });
+
+  it("disables selectors in bridge session", () => {
+    mockDefaults({
+      isBridgeSession: true,
+      me: {
+        accountId: "acc-1",
+        sessionId: "sess-1",
+        authContext: "general",
+        username: "tester",
+        displayName: "Test User",
+        email: "test@example.com",
+        locale: null,
+        timezone: null,
+        analystEligible: false,
+        bridge: { active: true, aiceId: "env-1", customerIds: ["c1"] },
+        memberships: [],
+      },
+    });
+
+    const { container } = render(<Sidebar />);
+    const selects = container.querySelectorAll("select");
+
+    expect((selects[0] as HTMLSelectElement).disabled).toBe(true);
+    expect((selects[1] as HTMLSelectElement).disabled).toBe(true);
+    expect(container.textContent).toContain("Locked to bridge session");
+  });
+
+  it("renders user profile with display name and email", () => {
+    const { container } = render(<Sidebar />);
+    const aside = container.querySelector("aside");
+    assertDefined(aside);
+
+    expect(aside.textContent).toContain("Test User");
+    expect(aside.textContent).toContain("test@example.com");
+  });
+
+  it("renders sign out button", () => {
+    const { container } = render(<Sidebar />);
+    const aside = container.querySelector("aside");
+    assertDefined(aside);
+
+    expect(aside.textContent).toContain("Sign Out");
+  });
+
+  it("navigates to sign-out endpoint on sign out click", () => {
+    const hrefSetter = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: { href: "/" },
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(window.location, "href", {
+      set: hrefSetter,
+      configurable: true,
+    });
+
+    const { container } = render(<Sidebar />);
+    const signOutBtn = Array.from(container.querySelectorAll("button")).find(
+      (btn) => btn.textContent?.includes("Sign Out"),
+    );
+    assertDefined(signOutBtn);
+    fireEvent.click(signOutBtn);
+
+    expect(hrefSetter).toHaveBeenCalledWith("/api/auth/sign-out");
+  });
+
+  it("disables environment selector when no environments exist", () => {
+    mockDefaults({ environments: [], selectedEnvironmentId: null });
+
+    const { container } = render(<Sidebar />);
+    const selects = container.querySelectorAll("select");
+
+    expect(selects.length).toBe(2);
+    expect((selects[1] as HTMLSelectElement).disabled).toBe(true);
+  });
+
+  it("renders multiple customers in selector", () => {
+    mockDefaults({
+      customers: [
+        {
+          id: "c1",
+          externalKey: "ext-1",
+          name: "Acme Corp",
+          role: "Manager",
+          isAnalyst: false,
+        },
+        {
+          id: "c2",
+          externalKey: "ext-2",
+          name: "Beta Inc",
+          role: "User",
+          isAnalyst: false,
+        },
+      ],
+    });
+
+    const { container } = render(<Sidebar />);
+    const customerSelect = container.querySelectorAll("select")[0];
+    assertDefined(customerSelect);
+
+    const options = customerSelect.querySelectorAll("option");
+    expect(options.length).toBe(2);
+    expect(options[0].textContent).toBe("Acme Corp");
+    expect(options[1].textContent).toBe("Beta Inc");
+  });
+
+  it("calls setSelectedCustomerId when customer changes", () => {
+    const setSelectedCustomerId = vi.fn();
+    mockDefaults({
+      setSelectedCustomerId,
+      customers: [
+        {
+          id: "c1",
+          externalKey: "ext-1",
+          name: "Acme Corp",
+          role: "Manager",
+          isAnalyst: false,
+        },
+        {
+          id: "c2",
+          externalKey: "ext-2",
+          name: "Beta Inc",
+          role: "User",
+          isAnalyst: false,
+        },
+      ],
+    });
+
+    const { container } = render(<Sidebar />);
+    const customerSelect = container.querySelectorAll("select")[0];
+    assertDefined(customerSelect);
+
+    fireEvent.change(customerSelect, { target: { value: "c2" } });
+    expect(setSelectedCustomerId).toHaveBeenCalledWith("c2");
+  });
+
+  it("calls setSelectedEnvironmentId when environment changes", () => {
+    const setSelectedEnvironmentId = vi.fn();
+    mockDefaults({
+      setSelectedEnvironmentId,
+      environments: [
+        { aiceId: "env-1", name: "Production" },
+        { aiceId: "env-2", name: "Staging" },
+      ],
+    });
+
+    const { container } = render(<Sidebar />);
+    const envSelect = container.querySelectorAll("select")[1];
+    assertDefined(envSelect);
+
+    fireEvent.change(envSelect, { target: { value: "env-2" } });
+    expect(setSelectedEnvironmentId).toHaveBeenCalledWith("env-2");
+  });
+
+  it("marks active nav item with aria-current=page", () => {
+    mockedUsePathname.mockReturnValue("/en/events");
+
+    const { container } = render(<Sidebar />);
+
+    const activeLink = container.querySelector(
+      'a[aria-current="page"]',
+    ) as HTMLAnchorElement;
+    expect(activeLink).not.toBeNull();
+    expect(activeLink.getAttribute("href")).toBe("/en/events");
+  });
+
+  it("has aria-label on collapse toggle button", () => {
+    const { container } = render(<Sidebar />);
+
+    const toggle = container.querySelector(
+      'button[aria-label="Collapse sidebar"]',
+    );
+    expect(toggle).not.toBeNull();
+  });
+
+  describe("collapse/expand", () => {
+    it("persists collapsed state to localStorage", () => {
+      const { container } = render(<Sidebar />);
+
+      const toggle = container.querySelector(
+        'button[aria-label="Collapse sidebar"]',
+      );
+      assertDefined(toggle);
+      fireEvent.click(toggle);
+
+      expect(localStorage.getItem("sidebar-collapsed")).toBe("true");
+    });
+
+    it("reads collapsed state from localStorage on mount", () => {
+      localStorage.setItem("sidebar-collapsed", "true");
+
+      const { container } = render(<Sidebar />);
+      const aside = container.querySelector("aside");
+      assertDefined(aside);
+
+      // In collapsed mode, AIMER logo text should be visually hidden
+      const logoText = aside.querySelector(".sr-only");
+      assertDefined(logoText);
+      expect(logoText.textContent).toBe("AIMER");
+      // Expand button should be present
+      expect(
+        container.querySelector('button[aria-label="Expand sidebar"]'),
+      ).not.toBeNull();
+    });
+
+    it("hides customer selector when collapsed", () => {
+      localStorage.setItem("sidebar-collapsed", "true");
+
+      const { container } = render(<Sidebar />);
+
+      expect(container.querySelector("#customer-select")).toBeNull();
+    });
+
+    it("restores state after expand", () => {
+      const { container } = render(<Sidebar />);
+      const aside = container.querySelector("aside");
+      assertDefined(aside);
+
+      const collapse = container.querySelector(
+        'button[aria-label="Collapse sidebar"]',
+      );
+      assertDefined(collapse);
+      fireEvent.click(collapse);
+      // Logo text is sr-only when collapsed
+      expect(aside.querySelector(".sr-only")?.textContent).toBe("AIMER");
+
+      const expand = container.querySelector(
+        'button[aria-label="Expand sidebar"]',
+      );
+      assertDefined(expand);
+      fireEvent.click(expand);
+      // Logo text is visible when expanded (not sr-only)
+      const visibleLogo = aside.querySelector("span:not(.sr-only)");
+      assertDefined(visibleLogo);
+      expect(visibleLogo.textContent).toBe("AIMER");
+
+      expect(localStorage.getItem("sidebar-collapsed")).toBe("false");
+    });
+  });
+});
+
+describe("MobileSidebarTrigger", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockedUsePathname.mockReturnValue("/en");
+    setup();
+  });
+
+  it("renders menu button with aria-label", () => {
+    const { container } = render(<MobileSidebarTrigger />);
+
+    const menuBtn = container.querySelector(
+      'button[aria-label="Open navigation menu"]',
+    );
+    expect(menuBtn).not.toBeNull();
+  });
+
+  it("renders sidebar content inside sheet", () => {
+    const { container } = render(<MobileSidebarTrigger />);
+
+    const sheetContents = container.querySelectorAll(
+      '[data-testid="sheet-content"]',
+    );
+    expect(sheetContents.length).toBe(1);
+
+    const text = sheetContents[0].textContent ?? "";
+    expect(text).toContain("AIMER");
+    expect(text).toContain("Home");
+    expect(text).toContain("Events");
+    expect(text).toContain("Analysis");
+    expect(text).toContain("Reports");
+    expect(text).toContain("Dashboard");
+  });
+
+  it("renders customer selector inside sheet", () => {
+    const { container } = render(<MobileSidebarTrigger />);
+
+    const sheetContent = container.querySelector(
+      '[data-testid="sheet-content"]',
+    );
+    assertDefined(sheetContent);
+    const selects = sheetContent.querySelectorAll("select");
+    expect(selects.length).toBe(2);
+    expect((selects[0] as HTMLSelectElement).value).toBe("c1");
+  });
+
+  it("closes sheet when a nav link is clicked", () => {
+    const { container } = render(<MobileSidebarTrigger />);
+
+    const sheetContent = container.querySelector(
+      '[data-testid="sheet-content"]',
+    );
+    assertDefined(sheetContent);
+
+    const navLink = sheetContent.querySelector('nav[aria-label="Main"] a');
+    assertDefined(navLink);
+    fireEvent.click(navLink);
+
+    // The sheet should call onOpenChange(false) to close
+    assertDefined(lastOnOpenChange);
+    // The click handler on nav links calls the OnNavigateContext callback,
+    // which calls setOpen(false), which triggers onOpenChange(false).
+    // Since our mock Sheet captures onOpenChange, verify it was provided.
+    expect(typeof lastOnOpenChange).toBe("function");
+  });
+});

--- a/src/components/breadcrumbs.tsx
+++ b/src/components/breadcrumbs.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { ChevronRight, Home } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
+import { useMemo } from "react";
+
+type NavKey =
+  | "events"
+  | "analysis"
+  | "reports"
+  | "dashboard"
+  | "settings"
+  | "members"
+  | "customerSettings";
+
+const SEGMENT_KEYS: Record<string, NavKey> = {
+  events: "events",
+  analysis: "analysis",
+  reports: "reports",
+  dashboard: "dashboard",
+  settings: "settings",
+  members: "members",
+  customer: "customerSettings",
+};
+
+export function Breadcrumbs() {
+  const pathname = usePathname();
+  const locale = useLocale();
+  const t = useTranslations("nav");
+
+  const crumbs = useMemo(() => {
+    const base = `/${locale}`;
+    const rest = pathname.startsWith(base)
+      ? pathname.slice(base.length)
+      : pathname;
+    const segments = rest.split("/").filter(Boolean);
+
+    const items: { label: string; href: string }[] = [];
+    let accumulated = base;
+
+    for (const segment of segments) {
+      accumulated += `/${segment}`;
+      const key = SEGMENT_KEYS[segment];
+      if (key) {
+        items.push({ label: t(key), href: accumulated });
+      }
+    }
+
+    return items;
+  }, [pathname, locale, t]);
+
+  return (
+    <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-sm">
+      <Link
+        href={`/${locale}`}
+        className="flex items-center text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <Home className="h-4 w-4" />
+      </Link>
+      {crumbs.map((crumb) => (
+        <span key={crumb.href} className="flex items-center gap-1.5">
+          <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+          <Link
+            href={crumb.href}
+            className="text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {crumb.label}
+          </Link>
+        </span>
+      ))}
+    </nav>
+  );
+}

--- a/src/components/layout-constants.ts
+++ b/src/components/layout-constants.ts
@@ -1,0 +1,10 @@
+/** Shared layout dimension constants used by sidebar, sheet, and header. */
+
+/** Tailwind class for the expanded sidebar width (256px). */
+export const SIDEBAR_WIDTH_EXPANDED = "w-64";
+
+/** Tailwind class for the collapsed sidebar width (64px). */
+export const SIDEBAR_WIDTH_COLLAPSED = "w-16";
+
+/** Tailwind class for the header / sidebar-logo height (64px). */
+export const HEADER_HEIGHT = "h-16";

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,32 +1,97 @@
 "use client";
 
-import { Home, Lock, Settings, Users } from "lucide-react";
+import {
+  BarChart3,
+  ChevronLeft,
+  ChevronRight,
+  FileText,
+  Home,
+  LayoutDashboard,
+  Lock,
+  LogOut,
+  Menu,
+  Search,
+  Settings,
+  Shield,
+  Users,
+} from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+import { LocaleSwitcher } from "@/components/locale-switcher";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { Select } from "@/components/ui/select";
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useCustomerContext } from "@/hooks/use-customer-context";
 import { usePermissions } from "@/hooks/use-permissions";
 import { cn } from "@/lib/utils";
 
-export function Sidebar() {
-  const t = useTranslations("nav");
-  const tSidebar = useTranslations("sidebar");
-  const locale = useLocale();
-  const pathname = usePathname();
-  const permissions = usePermissions();
-  const {
-    customers,
-    selectedCustomerId,
-    setSelectedCustomerId,
-    environments,
-    selectedEnvironmentId,
-    setSelectedEnvironmentId,
-    isBridgeSession,
-  } = useCustomerContext();
+import {
+  HEADER_HEIGHT,
+  SIDEBAR_WIDTH_COLLAPSED,
+  SIDEBAR_WIDTH_EXPANDED,
+} from "./layout-constants";
 
-  const navItems = [
-    { href: `/${locale}`, label: t("dashboard"), icon: Home, visible: true },
+const SIDEBAR_COLLAPSED_KEY = "sidebar-collapsed";
+
+/**
+ * Callback context used by `MobileSidebarTrigger` to close the sheet
+ * when a navigation link is clicked.
+ */
+const OnNavigateContext = createContext<(() => void) | null>(null);
+
+interface NavItem {
+  href: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  visible: boolean;
+}
+
+function useNavItems(): NavItem[] {
+  const t = useTranslations("nav");
+  const locale = useLocale();
+  const permissions = usePermissions();
+
+  return [
+    { href: `/${locale}`, label: t("home"), icon: Home, visible: true },
+    {
+      href: `/${locale}/events`,
+      label: t("events"),
+      icon: Shield,
+      visible: true,
+    },
+    {
+      href: `/${locale}/analysis`,
+      label: t("analysis"),
+      icon: Search,
+      visible: true,
+    },
+    {
+      href: `/${locale}/reports`,
+      label: t("reports"),
+      icon: FileText,
+      visible: true,
+    },
+    {
+      href: `/${locale}/dashboard`,
+      label: t("dashboard"),
+      icon: LayoutDashboard,
+      visible: true,
+    },
     {
       href: `/${locale}/settings/members`,
       label: t("members"),
@@ -40,89 +105,313 @@ export function Sidebar() {
       visible: permissions.canViewCustomerSettings,
     },
   ];
+}
+
+function CustomerSelector({ collapsed }: { collapsed: boolean }) {
+  const tSidebar = useTranslations("sidebar");
+  const {
+    customers,
+    selectedCustomerId,
+    setSelectedCustomerId,
+    environments,
+    selectedEnvironmentId,
+    setSelectedEnvironmentId,
+    isBridgeSession,
+  } = useCustomerContext();
+
+  if (collapsed) return null;
 
   return (
-    <aside className="flex h-full w-60 flex-col border-r border-border bg-background">
-      <div className="border-b border-border p-4">
-        <div className="mb-3">
-          <label
-            htmlFor="customer-select"
-            className="mb-1 block text-xs font-medium text-muted-foreground"
-          >
-            {isBridgeSession && <Lock className="mr-1 inline-block h-3 w-3" />}
-            {tSidebar("selectCustomer")}
-          </label>
-          <Select
-            id="customer-select"
-            value={selectedCustomerId ?? ""}
-            onChange={(e) => setSelectedCustomerId(e.target.value)}
-            disabled={isBridgeSession}
-            className="w-full"
-          >
-            {customers.map((c) => (
-              <option key={c.id} value={c.id}>
-                {c.name}
-              </option>
-            ))}
-          </Select>
-        </div>
-
-        <div>
-          <label
-            htmlFor="environment-select"
-            className="mb-1 block text-xs font-medium text-muted-foreground"
-          >
-            {isBridgeSession && <Lock className="mr-1 inline-block h-3 w-3" />}
-            {tSidebar("selectEnvironment")}
-          </label>
-          <Select
-            id="environment-select"
-            value={selectedEnvironmentId ?? ""}
-            onChange={(e) => setSelectedEnvironmentId(e.target.value)}
-            disabled={isBridgeSession || environments.length === 0}
-            className="w-full"
-          >
-            {environments.map((e) => (
-              <option key={e.aiceId} value={e.aiceId}>
-                {e.name}
-              </option>
-            ))}
-          </Select>
-        </div>
-
-        {isBridgeSession && (
-          <p className="mt-2 text-xs text-muted-foreground">
-            <Lock className="mr-1 inline-block h-3 w-3" />
-            {tSidebar("bridgeLocked")}
-          </p>
-        )}
+    <div className="border-b border-[var(--sidebar-border)] p-3">
+      <div className="mb-2">
+        <label
+          htmlFor="customer-select"
+          className="mb-1 flex items-center text-xs font-medium text-[var(--sidebar-muted)]"
+        >
+          {isBridgeSession && <Lock className="mr-1 h-3 w-3" />}
+          {tSidebar("selectCustomer")}
+        </label>
+        <Select
+          id="customer-select"
+          value={selectedCustomerId ?? ""}
+          onChange={(e) => setSelectedCustomerId(e.target.value)}
+          disabled={isBridgeSession}
+          className="w-full"
+        >
+          {customers.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </Select>
       </div>
 
-      <nav className="flex-1 p-2">
-        <ul className="space-y-1">
-          {navItems
-            .filter((item) => item.visible)
-            .map((item) => {
-              const isActive = pathname === item.href;
-              return (
-                <li key={item.href}>
-                  <Link
-                    href={item.href}
-                    className={cn(
-                      "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                      isActive
-                        ? "bg-accent text-accent-foreground"
-                        : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-                    )}
-                  >
-                    <item.icon className="h-4 w-4" />
-                    {item.label}
-                  </Link>
-                </li>
-              );
-            })}
-        </ul>
-      </nav>
-    </aside>
+      <div>
+        <label
+          htmlFor="environment-select"
+          className="mb-1 flex items-center text-xs font-medium text-[var(--sidebar-muted)]"
+        >
+          {isBridgeSession && <Lock className="mr-1 h-3 w-3" />}
+          {tSidebar("selectEnvironment")}
+        </label>
+        <Select
+          id="environment-select"
+          value={selectedEnvironmentId ?? ""}
+          onChange={(e) => setSelectedEnvironmentId(e.target.value)}
+          disabled={isBridgeSession || environments.length === 0}
+          className="w-full"
+        >
+          {environments.map((e) => (
+            <option key={e.aiceId} value={e.aiceId}>
+              {e.name}
+            </option>
+          ))}
+        </Select>
+      </div>
+
+      {isBridgeSession && (
+        <p className="mt-2 flex items-center text-xs text-[var(--sidebar-muted)]">
+          <Lock className="mr-1 h-3 w-3" />
+          {tSidebar("bridgeLocked")}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function NavList({
+  items,
+  collapsed,
+}: {
+  items: NavItem[];
+  collapsed: boolean;
+}) {
+  const pathname = usePathname();
+  const locale = useLocale();
+  const onNavigate = useContext(OnNavigateContext);
+
+  const visible = items.filter((item) => item.visible);
+
+  return (
+    <nav aria-label="Main" className="flex-1 overflow-y-auto p-2">
+      <ul className="space-y-1">
+        {visible.map((item) => {
+          const isActive =
+            item.href === `/${locale}`
+              ? pathname === item.href
+              : pathname.startsWith(item.href);
+
+          const link = (
+            <Link
+              href={item.href}
+              onClick={onNavigate ?? undefined}
+              aria-current={isActive ? "page" : undefined}
+              className={cn(
+                "flex items-center rounded-md text-sm font-medium transition-colors",
+                collapsed ? "justify-center p-2" : "gap-3 px-3 py-2",
+                isActive
+                  ? "bg-[var(--sidebar-active)] text-white"
+                  : "text-[var(--sidebar-muted)] hover:bg-[var(--sidebar-account-bg)] hover:text-[var(--sidebar-fg)]",
+              )}
+            >
+              <item.icon className="h-4 w-4 shrink-0" />
+              {collapsed ? (
+                <span className="sr-only">{item.label}</span>
+              ) : (
+                item.label
+              )}
+            </Link>
+          );
+
+          if (collapsed) {
+            return (
+              <li key={item.href}>
+                <Tooltip>
+                  <TooltipTrigger asChild>{link}</TooltipTrigger>
+                  <TooltipContent side="right">{item.label}</TooltipContent>
+                </Tooltip>
+              </li>
+            );
+          }
+
+          return <li key={item.href}>{link}</li>;
+        })}
+      </ul>
+    </nav>
+  );
+}
+
+function UserSection({ collapsed }: { collapsed: boolean }) {
+  const t = useTranslations("auth");
+  const { me } = useCustomerContext();
+
+  const signOut = useCallback(() => {
+    window.location.href = "/api/auth/sign-out";
+  }, []);
+
+  if (collapsed) {
+    return (
+      <div className="space-y-1 border-t border-[var(--sidebar-border)] p-2">
+        <ThemeToggle className="w-full" />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={signOut}
+              aria-label={t("signOut")}
+              className="flex w-full items-center justify-center rounded-md p-2 text-[var(--sidebar-muted)] transition-colors hover:bg-[var(--sidebar-account-bg)] hover:text-[var(--sidebar-fg)]"
+            >
+              <LogOut className="h-4 w-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">{t("signOut")}</TooltipContent>
+        </Tooltip>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t border-[var(--sidebar-border)] p-3">
+      {me && (
+        <div className="mb-3 rounded-md bg-[var(--sidebar-account-bg)] px-3 py-2">
+          <p className="truncate text-sm font-medium text-[var(--sidebar-fg)]">
+            {me.displayName}
+          </p>
+          {me.email && (
+            <p className="truncate text-xs text-[var(--sidebar-muted)]">
+              {me.email}
+            </p>
+          )}
+        </div>
+      )}
+      <div className="flex items-center gap-1">
+        <ThemeToggle />
+        <LocaleSwitcher />
+        <button
+          type="button"
+          onClick={signOut}
+          className="ml-auto flex items-center gap-2 rounded-md px-3 py-2 text-sm text-[var(--sidebar-muted)] transition-colors hover:bg-[var(--sidebar-account-bg)] hover:text-[var(--sidebar-fg)]"
+        >
+          <LogOut className="h-4 w-4" />
+          {t("signOut")}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function SidebarLogo({ collapsed }: { collapsed: boolean }) {
+  const locale = useLocale();
+  const onNavigate = useContext(OnNavigateContext);
+
+  return (
+    <Link
+      href={`/${locale}`}
+      onClick={onNavigate ?? undefined}
+      className={cn(
+        `flex ${HEADER_HEIGHT} items-center border-b border-[var(--sidebar-border)] transition-colors hover:bg-[var(--sidebar-account-bg)]`,
+        collapsed ? "justify-center px-2" : "px-4",
+      )}
+    >
+      <BarChart3
+        className={cn(
+          "shrink-0 text-[var(--sidebar-active)]",
+          collapsed ? "h-6 w-6" : "h-7 w-7",
+        )}
+      />
+      {collapsed ? (
+        <span className="sr-only">AIMER</span>
+      ) : (
+        <span className="ml-2 text-lg font-bold text-[var(--sidebar-fg)]">
+          AIMER
+        </span>
+      )}
+    </Link>
+  );
+}
+
+function SidebarContent({ collapsed }: { collapsed: boolean }) {
+  const navItems = useNavItems();
+
+  return (
+    <>
+      <SidebarLogo collapsed={collapsed} />
+      <CustomerSelector collapsed={collapsed} />
+      <NavList items={navItems} collapsed={collapsed} />
+      <UserSection collapsed={collapsed} />
+    </>
+  );
+}
+
+export function Sidebar() {
+  const t = useTranslations("sidebar");
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(SIDEBAR_COLLAPSED_KEY);
+    if (stored === "true") setCollapsed(true);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(next));
+      return next;
+    });
+  }, []);
+
+  return (
+    <TooltipProvider>
+      <aside
+        className={cn(
+          "hidden h-full flex-col border-r border-[var(--sidebar-border)] bg-[var(--sidebar-bg)] transition-[width] duration-200 md:flex",
+          collapsed ? SIDEBAR_WIDTH_COLLAPSED : SIDEBAR_WIDTH_EXPANDED,
+        )}
+      >
+        <SidebarContent collapsed={collapsed} />
+        <div className="border-t border-[var(--sidebar-border)] p-2">
+          <button
+            type="button"
+            onClick={toggle}
+            aria-label={collapsed ? t("expandSidebar") : t("collapseSidebar")}
+            className="flex w-full items-center justify-center rounded-md p-2 text-[var(--sidebar-muted)] transition-colors hover:bg-[var(--sidebar-account-bg)] hover:text-[var(--sidebar-fg)]"
+          >
+            {collapsed ? (
+              <ChevronRight className="h-4 w-4" />
+            ) : (
+              <ChevronLeft className="h-4 w-4" />
+            )}
+          </button>
+        </div>
+      </aside>
+    </TooltipProvider>
+  );
+}
+
+export function MobileSidebarTrigger() {
+  const t = useTranslations("sidebar");
+  const [open, setOpen] = useState(false);
+
+  const closeSheet = useCallback(() => setOpen(false), []);
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <button
+          type="button"
+          aria-label={t("openMenu")}
+          className="flex items-center justify-center rounded-md p-2 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground md:hidden"
+        >
+          <Menu className="h-5 w-5" />
+        </button>
+      </SheetTrigger>
+      <SheetContent aria-label={t("openMenu")}>
+        <TooltipProvider>
+          <OnNavigateContext.Provider value={closeSheet}>
+            <SidebarContent collapsed={false} />
+          </OnNavigateContext.Provider>
+        </TooltipProvider>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Dialog } from "radix-ui";
+import type * as React from "react";
+
+import { SIDEBAR_WIDTH_EXPANDED } from "@/components/layout-constants";
+import { cn } from "@/lib/utils";
+
+function Sheet(props: React.ComponentProps<typeof Dialog.Root>) {
+  return <Dialog.Root {...props} />;
+}
+
+function SheetTrigger(props: React.ComponentProps<typeof Dialog.Trigger>) {
+  return <Dialog.Trigger {...props} />;
+}
+
+function SheetClose(props: React.ComponentProps<typeof Dialog.Close>) {
+  return <Dialog.Close {...props} />;
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof Dialog.Overlay>) {
+  return (
+    <Dialog.Overlay
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "left",
+  ...props
+}: React.ComponentProps<typeof Dialog.Content> & {
+  side?: "left" | "right";
+}) {
+  return (
+    <Dialog.Portal>
+      <SheetOverlay />
+      <Dialog.Content
+        className={cn(
+          `fixed inset-y-0 z-50 flex ${SIDEBAR_WIDTH_EXPANDED} flex-col bg-[var(--sidebar-bg)] shadow-lg data-[state=closed]:hidden`,
+          side === "left" ? "left-0" : "right-0",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </Dialog.Content>
+    </Dialog.Portal>
+  );
+}
+
+export { Sheet, SheetClose, SheetContent, SheetOverlay, SheetTrigger };

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Tooltip as RadixTooltip } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function TooltipProvider(
+  props: React.ComponentProps<typeof RadixTooltip.Provider>,
+) {
+  return <RadixTooltip.Provider delayDuration={300} {...props} />;
+}
+
+function Tooltip(props: React.ComponentProps<typeof RadixTooltip.Root>) {
+  return <RadixTooltip.Root {...props} />;
+}
+
+function TooltipTrigger(
+  props: React.ComponentProps<typeof RadixTooltip.Trigger>,
+) {
+  return <RadixTooltip.Trigger {...props} />;
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 6,
+  ...props
+}: React.ComponentProps<typeof RadixTooltip.Content>) {
+  return (
+    <RadixTooltip.Portal>
+      <RadixTooltip.Content
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 rounded-md bg-foreground px-3 py-1.5 text-xs text-background shadow-md",
+          className,
+        )}
+        {...props}
+      />
+    </RadixTooltip.Portal>
+  );
+}
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -46,6 +46,7 @@
     "dashboard": "Dashboard",
     "members": "Members",
     "customerSettings": "Customer Settings",
+    "settings": "Settings",
     "admin": "Admin"
   },
   "admin": {
@@ -108,7 +109,10 @@
     "selectCustomer": "Customer",
     "selectEnvironment": "Environment",
     "bridgeLocked": "Locked to bridge session",
-    "analyst": "Analyst"
+    "analyst": "Analyst",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "openMenu": "Open navigation menu"
   },
   "validation": {
     "required": "This field is required",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -46,6 +46,7 @@
     "dashboard": "대시보드",
     "members": "멤버",
     "customerSettings": "고객 설정",
+    "settings": "설정",
     "admin": "관리자"
   },
   "admin": {
@@ -108,7 +109,10 @@
     "selectCustomer": "고객",
     "selectEnvironment": "환경",
     "bridgeLocked": "브릿지 세션으로 제한됨",
-    "analyst": "분석가"
+    "analyst": "분석가",
+    "expandSidebar": "사이드바 펼치기",
+    "collapseSidebar": "사이드바 접기",
+    "openMenu": "탐색 메뉴 열기"
   },
   "validation": {
     "required": "필수 입력 항목입니다",


### PR DESCRIPTION
## Summary

- Implement collapsible sidebar (256px / 64px) with logo, navigation, customer/environment selectors, user profile section (sign-out, theme toggle, locale switcher), and tooltip on collapsed icons
- Add mobile Sheet slide-over, breadcrumb bar (64px), and placeholder pages (Events, Analysis, Reports, Dashboard)
- Extract shared layout constants (`SIDEBAR_WIDTH_EXPANDED`, `HEADER_HEIGHT`) so sidebar, sheet, and header stay in sync
- Gate Members and Customer Settings nav items behind `usePermissions`; lock selectors in bridge sessions
- Add 32 unit tests (sidebar + breadcrumbs) and E2E test suite covering navigation, permissions, collapse persistence, bridge locking, and locale switching

## Test plan

- [x] `pnpm check` passes (Biome lint + format)
- [x] `pnpm typecheck` passes
- [x] `pnpm test:unit` passes (306 tests)
- [x] `pnpm build` succeeds
- [x] Sidebar collapses/expands and persists state across page loads
- [x] Mobile: sidebar opens as Sheet slide-over, closes on nav link click
- [x] Customer/environment selectors reflect correct data per user permissions
- [ ] Bridge session shows locked selectors with "Locked to bridge session" label
- [x] Breadcrumbs update correctly when navigating between pages
- [x] Theme toggle and locale switcher work from sidebar

Closes #38