### PR TITLE
Add suspicious activity detection

### DIFF
--- a/e2e/admin-audit-logs-ui.spec.ts
+++ b/e2e/admin-audit-logs-ui.spec.ts
@@ -241,9 +241,6 @@ test.describe("Audit logs UI — Admin", () => {
     await adminPage.goto("/en/admin/audit-logs");
     await adminPage.waitForSelector("table tbody tr");
 
-    // Count initial rows
-    const initialCount = await adminPage.locator("table tbody tr").count();
-
     // Filter to admin-only
     await adminPage.locator("select").selectOption("admin");
     await adminPage.getByRole("button", { name: "Apply" }).click();
@@ -254,8 +251,10 @@ test.describe("Audit logs UI — Admin", () => {
     // All visible auth context badges should say "Admin"
     const badges = adminPage.locator("table tbody tr td:nth-child(5)");
     const count = await badges.count();
-    // With filter active, row count may differ
-    expect(count).toBeLessThanOrEqual(initialCount);
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(badges.nth(i)).toHaveText("Admin");
+    }
   });
 
   test("correlation click clears active filters to show full group", async ({

--- a/e2e/admin-detection-alerts-api.spec.ts
+++ b/e2e/admin-detection-alerts-api.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "@playwright/test";
+
+// E2E tests for GET /api/admin/detection/alerts HTTP layer without
+// authentication.  Verifies the endpoint exists, enforces admin auth,
+// rejects invalid methods, and validates query parameters.
+
+const ENDPOINT = "/api/admin/detection/alerts";
+const ORIGIN = "http://localhost:3000";
+
+test.describe("GET /api/admin/detection/alerts", () => {
+  // =========================================================================
+  // Auth enforcement
+  // =========================================================================
+
+  test("returns 401 without auth cookie", async ({ request }) => {
+    const res = await request.get(ENDPOINT);
+    expect(res.status()).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  test("returns 401 with invalid admin auth cookie", async ({ context }) => {
+    await context.addCookies([
+      {
+        name: "at_admin",
+        value: "invalid-jwt-token",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+
+    const res = await context.request.get(ENDPOINT);
+    expect(res.status()).toBe(401);
+  });
+
+  test("returns 401 with general auth cookie (not admin)", async ({
+    context,
+  }) => {
+    await context.addCookies([
+      {
+        name: "at",
+        value: "some-general-jwt-token",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+
+    const res = await context.request.get(ENDPOINT);
+    expect(res.status()).toBe(401);
+  });
+
+  // =========================================================================
+  // Method enforcement
+  // =========================================================================
+
+  test("returns 405 for POST method", async ({ request }) => {
+    const res = await request.post(ENDPOINT, {
+      headers: { origin: ORIGIN },
+      data: {},
+    });
+    expect(res.status()).toBe(405);
+  });
+
+  test("returns 405 for PUT method", async ({ request }) => {
+    const res = await request.put(ENDPOINT, {
+      headers: { origin: ORIGIN },
+      data: {},
+    });
+    expect(res.status()).toBe(405);
+  });
+
+  test("returns 405 for DELETE method", async ({ request }) => {
+    const res = await request.delete(ENDPOINT);
+    expect(res.status()).toBe(405);
+  });
+
+  // =========================================================================
+  // Query parameter validation (unauthenticated — 401 takes precedence,
+  // but ensures endpoint is reachable and doesn't crash)
+  // =========================================================================
+
+  test("does not crash with invalid query params (returns 401)", async ({
+    request,
+  }) => {
+    const res = await request.get(
+      `${ENDPOINT}?cursor=bad&limit=abc&severity=x`,
+    );
+    expect(res.status()).toBe(401);
+  });
+});

--- a/e2e/admin-detection-alerts-auth.spec.ts
+++ b/e2e/admin-detection-alerts-auth.spec.ts
@@ -1,0 +1,286 @@
+import { expect, test } from "./fixtures";
+
+// E2E tests for GET /api/admin/detection/alerts with authenticated
+// sessions. Exercises the full stack: auth, authorization, DB query,
+// and response mapping with real test data.
+
+const ALERTS_ENDPOINT = "/api/admin/detection/alerts";
+const SUMMARY_ENDPOINT = "/api/admin/detection/alerts/summary";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Insert a test alert directly into audit_db and return its id. */
+async function insertTestAlert(
+  overrides: Record<string, unknown> = {},
+): Promise<number> {
+  const auditUrl =
+    process.env.AUDIT_DATABASE_MIGRATION_URL ??
+    process.env.AUDIT_DATABASE_URL ??
+    "";
+  if (!auditUrl) throw new Error("AUDIT_DATABASE_URL is required");
+
+  const { Pool } = await import("pg");
+  const pool = new Pool({ connectionString: auditUrl });
+  try {
+    const defaults = {
+      indicator: "e2e_test_indicator",
+      severity: "warning",
+      actor_id: "e2e-actor-00000000-0000-0000-0000-000000000099",
+      ip_address: "127.0.0.1",
+      summary: JSON.stringify({ test: true }),
+      audit_log_ids: "{}",
+      correlation_id: null,
+      ...overrides,
+    };
+
+    const result = await pool.query(
+      `INSERT INTO suspicious_activity_alerts
+         (indicator, severity, actor_id, ip_address, summary,
+          audit_log_ids, correlation_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING id`,
+      [
+        defaults.indicator,
+        defaults.severity,
+        defaults.actor_id,
+        defaults.ip_address,
+        defaults.summary,
+        defaults.audit_log_ids,
+        defaults.correlation_id,
+      ],
+    );
+    return result.rows[0].id;
+  } finally {
+    await pool.end();
+  }
+}
+
+/** Delete test alerts by actor_id prefix. */
+async function cleanupTestAlerts(): Promise<void> {
+  const auditUrl =
+    process.env.AUDIT_DATABASE_MIGRATION_URL ??
+    process.env.AUDIT_DATABASE_URL ??
+    "";
+  if (!auditUrl) return;
+
+  const { Pool } = await import("pg");
+  const pool = new Pool({ connectionString: auditUrl });
+  try {
+    await pool.query(
+      "DELETE FROM suspicious_activity_alerts WHERE actor_id LIKE 'e2e-actor-%'",
+    );
+  } finally {
+    await pool.end();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Admin authorized access — alerts list
+// ---------------------------------------------------------------------------
+
+test.describe("Detection alerts — Admin authorized", () => {
+  test.beforeAll(async () => {
+    await cleanupTestAlerts();
+
+    await insertTestAlert({
+      indicator: "consecutive_sign_in_denials",
+      severity: "warning",
+    });
+    await insertTestAlert({
+      indicator: "suspended_account_sign_in",
+      severity: "severe",
+    });
+    await insertTestAlert({
+      indicator: "bridge_abuse",
+      severity: "warning",
+    });
+  });
+
+  test.afterAll(async () => {
+    await cleanupTestAlerts();
+  });
+
+  test("Admin can query detection alerts", async ({ adminPage }) => {
+    const res = await adminPage.request.get(ALERTS_ENDPOINT);
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(body.data).toBeDefined();
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data.length).toBeGreaterThanOrEqual(3);
+
+    // Verify camelCase mapping
+    const entry = body.data[0];
+    expect(entry).toHaveProperty("id");
+    expect(entry).toHaveProperty("createdAt");
+    expect(entry).toHaveProperty("indicator");
+    expect(entry).toHaveProperty("severity");
+    expect(entry).toHaveProperty("actorId");
+    expect(entry).toHaveProperty("ipAddress");
+    expect(entry).toHaveProperty("summary");
+    expect(entry).toHaveProperty("auditLogIds");
+  });
+
+  test("Admin can filter by severity", async ({ adminPage }) => {
+    const res = await adminPage.request.get(
+      `${ALERTS_ENDPOINT}?severity=severe`,
+    );
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    for (const entry of body.data) {
+      expect(entry.severity).toBe("severe");
+    }
+  });
+
+  test("Admin can filter by indicator", async ({ adminPage }) => {
+    const res = await adminPage.request.get(
+      `${ALERTS_ENDPOINT}?indicator=bridge_abuse`,
+    );
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    for (const entry of body.data) {
+      expect(entry.indicator).toBe("bridge_abuse");
+    }
+  });
+
+  test("Admin can paginate with limit and cursor", async ({ adminPage }) => {
+    const res1 = await adminPage.request.get(`${ALERTS_ENDPOINT}?limit=1`);
+    expect(res1.status()).toBe(200);
+
+    const body1 = await res1.json();
+    expect(body1.data).toHaveLength(1);
+    expect(body1.nextCursor).not.toBeNull();
+
+    const res2 = await adminPage.request.get(
+      `${ALERTS_ENDPOINT}?limit=1&cursor=${body1.nextCursor}`,
+    );
+    expect(res2.status()).toBe(200);
+
+    const body2 = await res2.json();
+    expect(body2.data).toHaveLength(1);
+    expect(body2.data[0].id).not.toBe(body1.data[0].id);
+  });
+
+  // =========================================================================
+  // Validation errors (authenticated)
+  // =========================================================================
+
+  test("returns 400 for invalid severity value", async ({ adminPage }) => {
+    const res = await adminPage.request.get(
+      `${ALERTS_ENDPOINT}?severity=invalid`,
+    );
+    expect(res.status()).toBe(400);
+  });
+
+  test("returns 400 for limit out of range", async ({ adminPage }) => {
+    const res = await adminPage.request.get(`${ALERTS_ENDPOINT}?limit=999`);
+    expect(res.status()).toBe(400);
+  });
+
+  test("returns 400 for invalid indicator value", async ({ adminPage }) => {
+    const res = await adminPage.request.get(
+      `${ALERTS_ENDPOINT}?indicator=nonexistent`,
+    );
+    expect(res.status()).toBe(400);
+  });
+
+  test("returns 400 for invalid from date", async ({ adminPage }) => {
+    const res = await adminPage.request.get(
+      `${ALERTS_ENDPOINT}?from=not-a-date`,
+    );
+    expect(res.status()).toBe(400);
+  });
+
+  test("returns 400 for invalid to date", async ({ adminPage }) => {
+    const res = await adminPage.request.get(`${ALERTS_ENDPOINT}?to=not-a-date`);
+    expect(res.status()).toBe(400);
+  });
+
+  test("can filter by date range", async ({ adminPage }) => {
+    const now = new Date();
+    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+
+    const res = await adminPage.request.get(
+      `${ALERTS_ENDPOINT}?from=${yesterday.toISOString()}&to=${tomorrow.toISOString()}`,
+    );
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(Array.isArray(body.data)).toBe(true);
+    // All seeded alerts should be within the range
+    expect(body.data.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("returns empty with out-of-range dates", async ({ adminPage }) => {
+    const farPast = new Date("2000-01-01T00:00:00Z");
+    const alsoFarPast = new Date("2000-01-02T00:00:00Z");
+
+    const res = await adminPage.request.get(
+      `${ALERTS_ENDPOINT}?from=${farPast.toISOString()}&to=${alsoFarPast.toISOString()}`,
+    );
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(body.data).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Admin authorized access — summary
+// ---------------------------------------------------------------------------
+
+test.describe("Detection summary — Admin authorized", () => {
+  test.beforeAll(async () => {
+    await cleanupTestAlerts();
+
+    await insertTestAlert({
+      indicator: "consecutive_sign_in_denials",
+      severity: "warning",
+    });
+    await insertTestAlert({
+      indicator: "suspended_account_sign_in",
+      severity: "severe",
+    });
+  });
+
+  test.afterAll(async () => {
+    await cleanupTestAlerts();
+  });
+
+  test("Admin can get summary counts", async ({ adminPage }) => {
+    const res = await adminPage.request.get(SUMMARY_ENDPOINT);
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(typeof body.severe).toBe("number");
+    expect(typeof body.warning).toBe("number");
+    expect(body.byIndicator).toBeDefined();
+    expect(typeof body.byIndicator).toBe("object");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-admin roles denied
+// ---------------------------------------------------------------------------
+
+test.describe("Detection alerts — Non-admin denied", () => {
+  test("Manager (general context) gets 401/403", async ({ managerPage }) => {
+    const res = await managerPage.request.get(ALERTS_ENDPOINT);
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test("User (general context) gets 401/403", async ({ userPage }) => {
+    const res = await userPage.request.get(ALERTS_ENDPOINT);
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test("Manager cannot access summary", async ({ managerPage }) => {
+    const res = await managerPage.request.get(SUMMARY_ENDPOINT);
+    expect([401, 403]).toContain(res.status());
+  });
+});

--- a/e2e/admin-detection-analyze-api.spec.ts
+++ b/e2e/admin-detection-analyze-api.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+
+// E2E tests for POST /api/admin/detection/analyze cron endpoint.
+// Verifies the shared secret protection.
+
+const ENDPOINT = "/api/admin/detection/analyze";
+const ORIGIN = "http://localhost:3000";
+
+test.describe("POST /api/admin/detection/analyze", () => {
+  test("returns 401 without authorization header", async ({ request }) => {
+    const res = await request.post(ENDPOINT, {
+      headers: { origin: ORIGIN },
+    });
+    expect(res.status()).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  test("returns 401 or 503 with wrong secret", async ({ request }) => {
+    const res = await request.post(ENDPOINT, {
+      headers: {
+        origin: ORIGIN,
+        authorization: "Bearer wrong-secret",
+      },
+    });
+    // 401 when DETECTION_CRON_SECRET is set (secret mismatch),
+    // 503 when it is not configured at all.
+    expect([401, 503]).toContain(res.status());
+  });
+
+  test("returns 405 for GET method", async ({ request }) => {
+    const res = await request.get(ENDPOINT);
+    expect(res.status()).toBe(405);
+  });
+});

--- a/e2e/admin-detection-ui.spec.ts
+++ b/e2e/admin-detection-ui.spec.ts
@@ -1,0 +1,240 @@
+import { expect, test } from "./fixtures";
+
+// E2E UI tests for the suspicious activity page.
+// Uses the admin fixture for authenticated browser access.
+
+// ---------------------------------------------------------------------------
+// Helpers — seed / cleanup alerts for tests that require table data
+// ---------------------------------------------------------------------------
+
+async function insertTestAlert(
+  overrides: Record<string, unknown> = {},
+): Promise<number> {
+  const auditUrl =
+    process.env.AUDIT_DATABASE_MIGRATION_URL ??
+    process.env.AUDIT_DATABASE_URL ??
+    "";
+  if (!auditUrl) throw new Error("AUDIT_DATABASE_URL is required");
+
+  const { Pool } = await import("pg");
+  const pool = new Pool({ connectionString: auditUrl });
+  try {
+    const defaults = {
+      indicator: "consecutive_sign_in_denials",
+      severity: "warning",
+      actor_id: "e2e-ui-actor-00000000-0000-0000-0000-000000000099",
+      ip_address: "127.0.0.1",
+      summary: JSON.stringify({ denialCount: 5, windowMinutes: 15 }),
+      audit_log_ids: "{}",
+      correlation_id: null,
+      ...overrides,
+    };
+
+    const result = await pool.query(
+      `INSERT INTO suspicious_activity_alerts
+         (indicator, severity, actor_id, ip_address, summary,
+          audit_log_ids, correlation_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING id`,
+      [
+        defaults.indicator,
+        defaults.severity,
+        defaults.actor_id,
+        defaults.ip_address,
+        defaults.summary,
+        defaults.audit_log_ids,
+        defaults.correlation_id,
+      ],
+    );
+    return result.rows[0].id;
+  } finally {
+    await pool.end();
+  }
+}
+
+async function cleanupTestAlerts(): Promise<void> {
+  const auditUrl =
+    process.env.AUDIT_DATABASE_MIGRATION_URL ??
+    process.env.AUDIT_DATABASE_URL ??
+    "";
+  if (!auditUrl) return;
+
+  const { Pool } = await import("pg");
+  const pool = new Pool({ connectionString: auditUrl });
+  try {
+    await pool.query(
+      "DELETE FROM suspicious_activity_alerts WHERE actor_id LIKE 'e2e-ui-actor-%'",
+    );
+  } finally {
+    await pool.end();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Page rendering
+// ---------------------------------------------------------------------------
+
+test.describe("Suspicious activity page — rendering", () => {
+  test.beforeAll(async () => {
+    await cleanupTestAlerts();
+
+    await insertTestAlert({
+      indicator: "consecutive_sign_in_denials",
+      severity: "warning",
+    });
+    await insertTestAlert({
+      indicator: "suspended_account_sign_in",
+      severity: "severe",
+    });
+  });
+
+  test.afterAll(async () => {
+    await cleanupTestAlerts();
+  });
+
+  test("shows page title and description", async ({ adminPage }) => {
+    await adminPage.goto("/en/admin/suspicious-activity");
+    await expect(
+      adminPage.getByRole("heading", { name: "Suspicious Activity" }),
+    ).toBeVisible();
+  });
+
+  test("renders alert table with data", async ({ adminPage }) => {
+    await adminPage.goto("/en/admin/suspicious-activity");
+
+    const table = adminPage.locator("table");
+    await expect(table).toBeVisible();
+
+    // Should have at least 2 rows
+    const rows = table.locator("tbody tr");
+    await expect(rows.first()).toBeVisible();
+  });
+
+  test("displays severity badges", async ({ adminPage }) => {
+    await adminPage.goto("/en/admin/suspicious-activity");
+
+    await expect(adminPage.getByText("Severe").first()).toBeVisible();
+    await expect(adminPage.getByText("Warning").first()).toBeVisible();
+  });
+
+  test("expands row to show summary details", async ({ adminPage }) => {
+    await adminPage.goto("/en/admin/suspicious-activity");
+
+    // Click first data row
+    const firstRow = adminPage.locator("table tbody tr").first();
+    await firstRow.click();
+
+    // Should show summary section
+    await expect(adminPage.getByText("Summary").first()).toBeVisible();
+  });
+
+  test("renders in Korean locale", async ({ adminPage }) => {
+    await adminPage.goto("/ko/admin/suspicious-activity");
+    await expect(
+      adminPage.getByRole("heading", { name: "의심스러운 활동" }),
+    ).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sidebar navigation
+// ---------------------------------------------------------------------------
+
+test.describe("Suspicious activity — sidebar navigation", () => {
+  test("sidebar contains Suspicious Activity link", async ({ adminPage }) => {
+    await adminPage.goto("/en/admin/suspicious-activity");
+    const sidebar = adminPage.locator("aside");
+    await expect(sidebar.getByText("Suspicious Activity")).toBeVisible();
+  });
+
+  test("Suspicious Activity link is active when on the page", async ({
+    adminPage,
+  }) => {
+    await adminPage.goto("/en/admin/suspicious-activity");
+    const link = adminPage
+      .locator("aside")
+      .getByRole("link", { name: "Suspicious Activity" });
+    await expect(link).toHaveAttribute("aria-current", "page");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filters
+// ---------------------------------------------------------------------------
+
+test.describe("Suspicious activity — filters", () => {
+  test.beforeAll(async () => {
+    await cleanupTestAlerts();
+
+    await insertTestAlert({
+      indicator: "consecutive_sign_in_denials",
+      severity: "warning",
+    });
+    await insertTestAlert({
+      indicator: "suspended_account_sign_in",
+      severity: "severe",
+    });
+  });
+
+  test.afterAll(async () => {
+    await cleanupTestAlerts();
+  });
+
+  test("can filter by severity", async ({ adminPage }) => {
+    await adminPage.goto("/en/admin/suspicious-activity");
+
+    // Select "Severe" severity
+    await adminPage.locator("select").first().selectOption("severe");
+    await adminPage.getByRole("button", { name: "Apply" }).click();
+
+    // Wait for table to update
+    await adminPage.waitForTimeout(500);
+
+    // All visible badges should be "Severe"
+    const table = adminPage.locator("table");
+    if (await table.isVisible()) {
+      const rows = table.locator("tbody tr");
+      const count = await rows.count();
+      // If rows exist, they should all be severe
+      if (count > 0) {
+        // Check that "Warning" badge is not visible in any row
+        const warningBadges = table.locator("tbody").getByText("Warning");
+        expect(await warningBadges.count()).toBe(0);
+      }
+    }
+  });
+
+  test("can reset filters", async ({ adminPage }) => {
+    await adminPage.goto("/en/admin/suspicious-activity");
+
+    // Apply a filter
+    await adminPage.locator("select").first().selectOption("severe");
+    await adminPage.getByRole("button", { name: "Apply" }).click();
+    await adminPage.waitForTimeout(300);
+
+    // Reset
+    await adminPage.getByRole("button", { name: "Reset" }).click();
+    await adminPage.waitForTimeout(300);
+
+    // Should show all results again
+    const select = adminPage.locator("select").first();
+    await expect(select).toHaveValue("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+test.describe("Suspicious activity — empty state", () => {
+  test.beforeAll(async () => {
+    await cleanupTestAlerts();
+  });
+
+  test("shows empty message when no alerts", async ({ adminPage }) => {
+    await adminPage.goto("/en/admin/suspicious-activity");
+    await expect(
+      adminPage.getByText("No suspicious activity alerts found."),
+    ).toBeVisible();
+  });
+});

--- a/migrations/audit/0002_suspicious_activity_alerts.sql
+++ b/migrations/audit/0002_suspicious_activity_alerts.sql
@@ -1,0 +1,26 @@
+-- Suspicious activity alerts detected from audit log analysis.
+-- Immutable records: INSERT/SELECT only for the runtime role,
+-- matching the tamper-resistance model of audit_logs.
+
+CREATE TABLE suspicious_activity_alerts (
+  id             BIGSERIAL   PRIMARY KEY,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  indicator      TEXT        NOT NULL,
+  severity       TEXT        NOT NULL CHECK (severity IN ('severe', 'warning')),
+  actor_id       TEXT,
+  ip_address     TEXT,
+  summary        JSONB       NOT NULL,
+  audit_log_ids  BIGINT[]    NOT NULL DEFAULT '{}',
+  correlation_id UUID
+);
+
+CREATE INDEX idx_alerts_created_at ON suspicious_activity_alerts (created_at);
+CREATE INDEX idx_alerts_indicator  ON suspicious_activity_alerts (indicator);
+CREATE INDEX idx_alerts_severity   ON suspicious_activity_alerts (severity);
+CREATE INDEX idx_alerts_actor_id   ON suspicious_activity_alerts (actor_id)
+  WHERE actor_id IS NOT NULL;
+
+-- Owner: full access (inherits from schema-level ALL grant in 0001)
+-- Runtime: INSERT/SELECT only
+GRANT SELECT, INSERT ON suspicious_activity_alerts TO aimer_audit;
+GRANT USAGE, SELECT ON SEQUENCE suspicious_activity_alerts_id_seq TO aimer_audit;

--- a/src/app/[locale]/(admin)/admin/suspicious-activity/page.tsx
+++ b/src/app/[locale]/(admin)/admin/suspicious-activity/page.tsx
@@ -1,0 +1,16 @@
+import { getTranslations } from "next-intl/server";
+
+import { SuspiciousActivityPage } from "./suspicious-activity-page";
+
+export default async function Page() {
+  const t = await getTranslations("suspiciousActivity");
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6">
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold text-foreground">{t("title")}</h1>
+        <p className="mt-1 text-sm text-muted-foreground">{t("description")}</p>
+      </div>
+      <SuspiciousActivityPage />
+    </div>
+  );
+}

--- a/src/app/[locale]/(admin)/admin/suspicious-activity/suspicious-activity-page.tsx
+++ b/src/app/[locale]/(admin)/admin/suspicious-activity/suspicious-activity-page.tsx
@@ -1,0 +1,419 @@
+"use client";
+
+import { useFormatter, useTranslations } from "next-intl";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+import { ApiError, apiFetch } from "@/lib/api/client";
+import { ALL_INDICATORS } from "@/lib/detection/indicators";
+
+interface Alert {
+  id: string;
+  createdAt: string;
+  indicator: string;
+  severity: string;
+  actorId: string | null;
+  ipAddress: string | null;
+  summary: Record<string, unknown>;
+  auditLogIds: number[];
+  correlationId: string | null;
+}
+
+interface Filters {
+  severity: string;
+  indicator: string;
+  from: string;
+  to: string;
+}
+
+const INITIAL_FILTERS: Filters = {
+  severity: "",
+  indicator: "",
+  from: "",
+  to: "",
+};
+
+const DATE_TIME_FORMAT = {
+  year: "numeric" as const,
+  month: "2-digit" as const,
+  day: "2-digit" as const,
+  hour: "2-digit" as const,
+  minute: "2-digit" as const,
+  second: "2-digit" as const,
+};
+
+const AUTO_REFRESH_MS = 30_000;
+
+function toISOWithOffset(datetimeLocal: string): string {
+  const d = new Date(datetimeLocal);
+  if (Number.isNaN(d.getTime())) return datetimeLocal;
+  const offset = -d.getTimezoneOffset();
+  const sign = offset >= 0 ? "+" : "-";
+  const hh = String(Math.floor(Math.abs(offset) / 60)).padStart(2, "0");
+  const mm = String(Math.abs(offset) % 60).padStart(2, "0");
+  return `${datetimeLocal}:00${sign}${hh}:${mm}`;
+}
+
+function buildQueryString(filters: Filters, cursor: string | null): string {
+  const params = new URLSearchParams();
+  if (filters.severity) params.set("severity", filters.severity);
+  if (filters.indicator) params.set("indicator", filters.indicator);
+  if (filters.from) params.set("from", toISOWithOffset(filters.from));
+  if (filters.to) params.set("to", toISOWithOffset(filters.to));
+  if (cursor) params.set("cursor", cursor);
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+}
+
+export function SuspiciousActivityPage() {
+  const t = useTranslations("suspiciousActivity");
+  const tIndicators = useTranslations("suspiciousActivity.indicators");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
+
+  const [entries, setEntries] = useState<Alert[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [filters, setFilters] = useState<Filters>(INITIAL_FILTERS);
+  const [activeFilters, setActiveFilters] = useState<Filters>(INITIAL_FILTERS);
+  const [expandedRow, setExpandedRow] = useState<string | null>(null);
+  const [summary, setSummary] = useState<{
+    severe: number;
+    warning: number;
+  } | null>(null);
+
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchAlerts = useCallback(
+    async (appliedFilters: Filters, cursor: string | null, append: boolean) => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        const qs = buildQueryString(appliedFilters, cursor);
+        const data = await apiFetch<{
+          data: Alert[];
+          nextCursor: string | null;
+        }>(`/api/admin/detection/alerts${qs}`, {
+          signal: controller.signal,
+        });
+
+        setEntries((prev) => (append ? [...prev, ...data.data] : data.data));
+        setNextCursor(data.nextCursor);
+        setError(null);
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        if (err instanceof ApiError && err.status === 401) {
+          window.location.href = "/api/admin-auth/sign-in";
+          return;
+        }
+        setError(t("errorLoading"));
+      }
+    },
+    [t],
+  );
+
+  const fetchSummary = useCallback(async () => {
+    try {
+      const data = await apiFetch<{ severe: number; warning: number }>(
+        "/api/admin/detection/alerts/summary",
+      );
+      setSummary(data);
+    } catch {
+      // Summary is non-critical; ignore errors
+    }
+  }, []);
+
+  // Initial load + filter changes
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      await Promise.all([
+        fetchAlerts(activeFilters, null, false),
+        fetchSummary(),
+      ]);
+      if (!cancelled) setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeFilters, fetchAlerts, fetchSummary]);
+
+  // Auto-refresh
+  useEffect(() => {
+    const id = setInterval(() => {
+      fetchAlerts(activeFilters, null, false);
+      fetchSummary();
+    }, AUTO_REFRESH_MS);
+    return () => clearInterval(id);
+  }, [activeFilters, fetchAlerts, fetchSummary]);
+
+  const handleApplyFilters = () => {
+    setActiveFilters({ ...filters });
+  };
+
+  const handleResetFilters = () => {
+    setFilters(INITIAL_FILTERS);
+    setActiveFilters(INITIAL_FILTERS);
+  };
+
+  const handleLoadMore = async () => {
+    if (!nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    await fetchAlerts(activeFilters, nextCursor, true);
+    setLoadingMore(false);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Summary stats */}
+      {summary && (summary.severe > 0 || summary.warning > 0) && (
+        <div className="flex items-center gap-4 rounded-lg border border-border bg-muted/30 px-4 py-3">
+          <span className="text-sm text-muted-foreground">{t("last24h")}</span>
+          {summary.severe > 0 && (
+            <Badge variant="destructive">
+              {t("severeCount", { count: summary.severe })}
+            </Badge>
+          )}
+          {summary.warning > 0 && (
+            <Badge variant="warning">
+              {t("warningCount", { count: summary.warning })}
+            </Badge>
+          )}
+        </div>
+      )}
+
+      {/* Filter controls */}
+      <div className="rounded-lg border border-border p-4">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <Select
+            value={filters.severity}
+            onChange={(e) =>
+              setFilters((f) => ({ ...f, severity: e.target.value }))
+            }
+          >
+            <option value="">{t("allSeverities")}</option>
+            <option value="severe">{t("severe")}</option>
+            <option value="warning">{t("warning")}</option>
+          </Select>
+
+          <Select
+            value={filters.indicator}
+            onChange={(e) =>
+              setFilters((f) => ({ ...f, indicator: e.target.value }))
+            }
+          >
+            <option value="">{t("allIndicators")}</option>
+            {ALL_INDICATORS.map((ind) => (
+              <option key={ind} value={ind}>
+                {tIndicators(ind)}
+              </option>
+            ))}
+          </Select>
+
+          <Input
+            type="datetime-local"
+            placeholder={t("filterFrom")}
+            value={filters.from}
+            onChange={(e) =>
+              setFilters((f) => ({ ...f, from: e.target.value }))
+            }
+          />
+
+          <div className="flex items-center gap-2">
+            <Input
+              type="datetime-local"
+              placeholder={t("filterTo")}
+              value={filters.to}
+              onChange={(e) =>
+                setFilters((f) => ({ ...f, to: e.target.value }))
+              }
+            />
+            <Button type="button" size="sm" onClick={handleApplyFilters}>
+              {t("apply")}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleResetFilters}
+            >
+              {t("reset")}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Loading / error */}
+      {loading && (
+        <div className="flex items-center justify-center py-12">
+          <p className="text-sm text-muted-foreground">{tCommon("loading")}</p>
+        </div>
+      )}
+
+      {error && !loading && (
+        <div className="flex items-center justify-center py-12">
+          <p className="text-sm text-destructive">{error}</p>
+        </div>
+      )}
+
+      {/* Table */}
+      {!loading && !error && (
+        <>
+          {entries.length === 0 ? (
+            <div className="flex items-center justify-center py-12">
+              <p className="text-sm text-muted-foreground">{t("noResults")}</p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto rounded-lg border border-border">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border bg-muted/50">
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                      {t("createdAt")}
+                    </th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                      {t("severity")}
+                    </th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                      {t("indicator")}
+                    </th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                      {t("actor")}
+                    </th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                      {t("ipAddress")}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {entries.map((entry) => (
+                    <AlertRow
+                      key={entry.id}
+                      entry={entry}
+                      expanded={expandedRow === entry.id}
+                      onToggle={() =>
+                        setExpandedRow((prev) =>
+                          prev === entry.id ? null : entry.id,
+                        )
+                      }
+                      format={format}
+                      t={t}
+                      tIndicators={tIndicators}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* Load more */}
+          {nextCursor && (
+            <div className="flex justify-center pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={loadingMore}
+                onClick={handleLoadMore}
+              >
+                {loadingMore ? tCommon("loading") : t("loadMore")}
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function AlertRow({
+  entry,
+  expanded,
+  onToggle,
+  format,
+  t,
+  tIndicators,
+}: {
+  entry: Alert;
+  expanded: boolean;
+  onToggle: () => void;
+  format: ReturnType<typeof useFormatter>;
+  t: ReturnType<typeof useTranslations<"suspiciousActivity">>;
+  tIndicators: ReturnType<
+    typeof useTranslations<"suspiciousActivity.indicators">
+  >;
+}) {
+  return (
+    <>
+      <tr
+        className="cursor-pointer border-b border-border last:border-b-0 hover:bg-muted/30"
+        onClick={onToggle}
+      >
+        <td className="px-4 py-3 text-muted-foreground whitespace-nowrap">
+          {format.dateTime(new Date(entry.createdAt), DATE_TIME_FORMAT)}
+        </td>
+        <td className="px-4 py-3">
+          <Badge
+            variant={entry.severity === "severe" ? "destructive" : "warning"}
+          >
+            {t(entry.severity as "severe" | "warning")}
+          </Badge>
+        </td>
+        <td className="px-4 py-3">
+          <Badge variant="secondary">
+            {tIndicators(entry.indicator as Parameters<typeof tIndicators>[0])}
+          </Badge>
+        </td>
+        <td className="px-4 py-3">
+          {entry.actorId ? (
+            <code className="text-xs">{truncateId(entry.actorId)}</code>
+          ) : (
+            "—"
+          )}
+        </td>
+        <td className="px-4 py-3 text-muted-foreground">
+          {entry.ipAddress ?? "—"}
+        </td>
+      </tr>
+      {expanded && (
+        <tr className="border-b border-border last:border-b-0">
+          <td colSpan={5} className="bg-muted/20 px-4 py-3">
+            <div className="space-y-1">
+              <p className="text-xs font-medium text-muted-foreground">
+                {t("summary")}
+              </p>
+              <pre className="overflow-x-auto rounded bg-muted p-3 text-xs text-foreground">
+                {JSON.stringify(entry.summary, null, 2)}
+              </pre>
+              {entry.auditLogIds.length > 0 && (
+                <p className="text-xs text-muted-foreground">
+                  {t("auditLogIds")}:{" "}
+                  <code>{entry.auditLogIds.join(", ")}</code>
+                </p>
+              )}
+              {entry.correlationId && (
+                <p className="text-xs text-muted-foreground">
+                  Correlation ID: <code>{entry.correlationId}</code>
+                </p>
+              )}
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function truncateId(id: string): string {
+  if (id.length <= 12) return id;
+  return `${id.slice(0, 8)}…`;
+}

--- a/src/app/[locale]/(admin)/layout.tsx
+++ b/src/app/[locale]/(admin)/layout.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { BarChart3, FileText, LogOut, Menu, Settings } from "lucide-react";
+import {
+  BarChart3,
+  FileText,
+  LogOut,
+  Menu,
+  Settings,
+  ShieldAlert,
+} from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
@@ -27,6 +34,11 @@ function useAdminNavItems(): AdminNavItem[] {
       href: `/${locale}/admin/audit-logs`,
       label: t("auditLog"),
       icon: FileText,
+    },
+    {
+      href: `/${locale}/admin/suspicious-activity`,
+      label: t("suspiciousActivity"),
+      icon: ShieldAlert,
     },
     {
       href: `/${locale}/admin`,

--- a/src/app/api/admin-auth/__tests__/callback-alerts.unit.test.ts
+++ b/src/app/api/admin-auth/__tests__/callback-alerts.unit.test.ts
@@ -1,0 +1,212 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockEmitSevereAlert = vi.fn();
+
+vi.mock("@/lib/auth/cookies", () => ({
+  getOidcTempCookies: vi.fn(async () => ({
+    state: "test-state",
+    nonce: "test-nonce",
+    codeVerifier: "test-verifier",
+  })),
+  clearOidcTempCookies: vi.fn(),
+  clearAuthCookies: vi.fn(),
+  setAuthCookies: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/oidc-discovery", () => ({
+  getOidcDiscovery: vi.fn(async () => ({
+    token_endpoint: "https://idp.test/token",
+    jwks_uri: "https://idp.test/jwks",
+    issuer: "https://idp.test",
+  })),
+}));
+
+vi.mock("@/lib/auth/oidc", () => ({
+  getIssuerUrl: vi.fn(() => "https://idp.test"),
+  exchangeCodeForTokens: vi.fn(async () => ({
+    id_token: "fake-id-token",
+    access_token: "fake-access-token",
+  })),
+}));
+
+vi.mock("@/lib/auth/oidc-validate", () => ({
+  validateIdToken: vi.fn(async () => ({
+    sub: "user-sub-001",
+    preferred_username: "admin",
+    name: "Admin User",
+    email: "admin@example.com",
+    email_verified: true,
+    acr: "urn:keycloak:acr:mfa",
+    auth_time: Math.floor(Date.now() / 1000),
+  })),
+}));
+
+const mockUpsertAccount = vi.fn();
+
+vi.mock("@/lib/auth/account", () => ({
+  upsertAccount: (...args: unknown[]) => mockUpsertAccount(...args),
+}));
+
+const mockVerifyAdminClaims = vi.fn();
+
+vi.mock("@/lib/auth/admin-verify", () => ({
+  verifyAdminClaims: (...args: unknown[]) => mockVerifyAdminClaims(...args),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  auditLog: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/detection", () => ({
+  emitSevereAlert: (arg: unknown) => mockEmitSevereAlert(arg),
+}));
+
+vi.mock("@/lib/auth/jwt", () => ({
+  signJwt: vi.fn(async () => ({ token: "jwt-token", iat: 1000, exp: 2000 })),
+}));
+
+vi.mock("@/lib/auth/csrf", () => ({
+  generateCsrf: vi.fn(() => "csrf-token"),
+}));
+
+vi.mock("@/lib/auth/same-account", () => ({
+  enforceSameAccount: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  getAuthPool: vi.fn(() => ({})),
+  query: vi.fn(async () => [{ sid: "session-001" }]),
+  // biome-ignore lint/complexity/noBannedTypes: test mock needs generic callable
+  withTransaction: vi.fn(async (_pool: unknown, fn: Function) => fn({})),
+}));
+
+// ---------------------------------------------------------------------------
+
+function makeCallbackRequest(): NextRequest {
+  const url =
+    "http://localhost:3000/api/admin-auth/callback?code=abc&state=test-state";
+  return new NextRequest(url);
+}
+
+async function callGET(req: NextRequest) {
+  const { GET } = await import("../callback/route");
+  return GET(req);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("admin-auth callback — emitSevereAlert integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.OIDC_ADMIN_CLIENT_SECRET = "test-secret";
+  });
+
+  it("emits suspended_account_sign_in for suspended admin account", async () => {
+    mockUpsertAccount.mockResolvedValue({
+      id: "admin-001",
+      status: "suspended",
+      token_version: 1,
+      admin_eligible: true,
+      locale: null,
+    });
+
+    const res = await callGET(makeCallbackRequest());
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("account_inactive");
+
+    expect(mockEmitSevereAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indicator: "suspended_account_sign_in",
+        actorId: "admin-001",
+        summary: expect.objectContaining({ authContext: "admin" }),
+      }),
+    );
+  });
+
+  it("emits admin_auth_denial_pattern for acr_invalid", async () => {
+    mockUpsertAccount.mockResolvedValue({
+      id: "admin-001",
+      status: "active",
+      token_version: 1,
+      admin_eligible: true,
+      locale: null,
+    });
+    mockVerifyAdminClaims.mockReturnValue("acr_invalid");
+
+    const res = await callGET(makeCallbackRequest());
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("acr_invalid");
+
+    expect(mockEmitSevereAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indicator: "admin_auth_denial_pattern",
+        actorId: "admin-001",
+        summary: expect.objectContaining({ reason: "acr_invalid" }),
+      }),
+    );
+  });
+
+  it("emits admin_auth_denial_pattern for auth_time_too_old", async () => {
+    mockUpsertAccount.mockResolvedValue({
+      id: "admin-001",
+      status: "active",
+      token_version: 1,
+      admin_eligible: true,
+      locale: null,
+    });
+    mockVerifyAdminClaims.mockReturnValue("auth_time_too_old");
+
+    const res = await callGET(makeCallbackRequest());
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("auth_time_too_old");
+
+    expect(mockEmitSevereAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indicator: "admin_auth_denial_pattern",
+        actorId: "admin-001",
+        summary: expect.objectContaining({ reason: "auth_time_too_old" }),
+      }),
+    );
+  });
+
+  it("does not emit alert for non-probing denial reasons", async () => {
+    mockUpsertAccount.mockResolvedValue({
+      id: "admin-001",
+      status: "active",
+      token_version: 1,
+      admin_eligible: false,
+      locale: null,
+    });
+    mockVerifyAdminClaims.mockReturnValue("not_admin_eligible");
+
+    const res = await callGET(makeCallbackRequest());
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("not_admin_eligible");
+
+    // Non-probing denials should not trigger an alert
+    expect(mockEmitSevereAlert).not.toHaveBeenCalled();
+  });
+
+  it("does not emit alert for successful admin login", async () => {
+    mockUpsertAccount.mockResolvedValue({
+      id: "admin-001",
+      status: "active",
+      token_version: 1,
+      admin_eligible: true,
+      locale: null,
+    });
+    mockVerifyAdminClaims.mockReturnValue(null);
+
+    const res = await callGET(makeCallbackRequest());
+    expect(res.status).toBe(307);
+
+    expect(mockEmitSevereAlert).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/admin-auth/callback/route.ts
+++ b/src/app/api/admin-auth/callback/route.ts
@@ -16,6 +16,7 @@ import { validateIdToken } from "@/lib/auth/oidc-validate";
 import { extractRequestMeta } from "@/lib/auth/request-meta";
 import { enforceSameAccount } from "@/lib/auth/same-account";
 import { getAuthPool, query, withTransaction } from "@/lib/db/client";
+import { emitSevereAlert } from "@/lib/detection";
 
 function denyRedirect(request: NextRequest, reason: string): NextResponse {
   return NextResponse.redirect(new URL(`/deny?reason=${reason}`, request.url));
@@ -105,20 +106,30 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     // Status check
     if (account.status !== "active") {
+      const denyDetails = {
+        reason:
+          account.status === "suspended"
+            ? "status_suspended"
+            : "status_disabled",
+        status: account.status,
+      };
       void auditLog({
         actorId: account.id,
         authContext: "admin",
         action: "admin.auth.sign_in_denied",
         targetType: "account",
         targetId: account.id,
-        details: {
-          reason:
-            account.status === "suspended"
-              ? "status_suspended"
-              : "status_disabled",
-          status: account.status,
-        },
+        details: denyDetails,
         ipAddress: meta.ipAddress,
+      });
+      void emitSevereAlert({
+        indicator: "suspended_account_sign_in",
+        actorId: account.id,
+        ipAddress: meta.ipAddress,
+        summary: {
+          authContext: "admin",
+          ...denyDetails,
+        },
       });
       return denyRedirect(request, "account_inactive");
     }
@@ -135,6 +146,17 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         details: { reason: denyReason, acr: idClaims.acr },
         ipAddress: meta.ipAddress,
       });
+
+      // acr/auth_time denials indicate admin auth probing
+      if (denyReason === "acr_invalid" || denyReason === "auth_time_too_old") {
+        void emitSevereAlert({
+          indicator: "admin_auth_denial_pattern",
+          actorId: account.id,
+          ipAddress: meta.ipAddress,
+          summary: { reason: denyReason, acr: idClaims.acr },
+        });
+      }
+
       return denyRedirect(request, denyReason);
     }
 

--- a/src/app/api/admin/detection/alerts/route.ts
+++ b/src/app/api/admin/detection/alerts/route.ts
@@ -1,0 +1,144 @@
+import type { NextRequest } from "next/server";
+import { assertAuthorized } from "@/lib/auth/authorization";
+import { HttpError } from "@/lib/auth/errors";
+import { withAuth } from "@/lib/auth/guards";
+import { getAuditPool, getAuthPool } from "@/lib/db/client";
+import { ALL_INDICATORS } from "@/lib/detection/indicators";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+const VALID_SEVERITIES = new Set(["severe", "warning"]);
+const VALID_INDICATORS: Set<string> = new Set(ALL_INDICATORS);
+
+export const GET = withAuth(
+  async (req: NextRequest, auth) => {
+    const authPool = getAuthPool();
+    const client = await authPool.connect();
+    try {
+      await assertAuthorized(
+        client,
+        "admin",
+        auth.accountId,
+        "audit-logs:read",
+      );
+    } catch (err) {
+      if (err instanceof HttpError) {
+        return Response.json(
+          { error: err.message },
+          { status: err.statusCode },
+        );
+      }
+      throw err;
+    } finally {
+      client.release();
+    }
+
+    const params = req.nextUrl.searchParams;
+
+    // Pagination
+    const cursorParam = params.get("cursor");
+    const cursor = cursorParam ? Number(cursorParam) : null;
+    if (cursor !== null && (!Number.isFinite(cursor) || cursor < 0)) {
+      return Response.json({ error: "Invalid cursor" }, { status: 400 });
+    }
+
+    const limitParam = params.get("limit");
+    let limit = DEFAULT_LIMIT;
+    if (limitParam) {
+      limit = Number(limitParam);
+      if (!Number.isFinite(limit) || limit < 1 || limit > MAX_LIMIT) {
+        return Response.json(
+          { error: `limit must be between 1 and ${MAX_LIMIT}` },
+          { status: 400 },
+        );
+      }
+    }
+
+    // Filters
+    const severity = params.get("severity");
+    if (severity && !VALID_SEVERITIES.has(severity)) {
+      return Response.json(
+        { error: "severity must be 'severe' or 'warning'" },
+        { status: 400 },
+      );
+    }
+
+    const indicator = params.get("indicator");
+    if (indicator && !VALID_INDICATORS.has(indicator)) {
+      return Response.json(
+        { error: "Invalid indicator value" },
+        { status: 400 },
+      );
+    }
+    const from = params.get("from");
+    const to = params.get("to");
+    if (from && Number.isNaN(Date.parse(from))) {
+      return Response.json({ error: "Invalid from date" }, { status: 400 });
+    }
+    if (to && Number.isNaN(Date.parse(to))) {
+      return Response.json({ error: "Invalid to date" }, { status: 400 });
+    }
+
+    // Build query
+    const conditions: string[] = [];
+    const values: unknown[] = [];
+    let idx = 1;
+
+    if (cursor !== null) {
+      conditions.push(`id < $${idx++}`);
+      values.push(cursor);
+    }
+    if (severity) {
+      conditions.push(`severity = $${idx++}`);
+      values.push(severity);
+    }
+    if (indicator) {
+      conditions.push(`indicator = $${idx++}`);
+      values.push(indicator);
+    }
+    if (from) {
+      conditions.push(`created_at >= $${idx++}::timestamptz`);
+      values.push(from);
+    }
+    if (to) {
+      conditions.push(`created_at <= $${idx++}::timestamptz`);
+      values.push(to);
+    }
+
+    const where =
+      conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    values.push(limit + 1);
+
+    const sql = `
+      SELECT id, created_at, indicator, severity, actor_id, ip_address,
+             summary, audit_log_ids, correlation_id
+      FROM suspicious_activity_alerts
+      ${where}
+      ORDER BY id DESC
+      LIMIT $${idx}`;
+
+    const auditPool = getAuditPool();
+    const result = await auditPool.query(sql, values);
+
+    const hasMore = result.rows.length > limit;
+    const rows = hasMore ? result.rows.slice(0, limit) : result.rows;
+    const nextCursor = hasMore ? String(rows[rows.length - 1].id) : null;
+
+    return Response.json({
+      data: rows.map((r) => ({
+        id: String(r.id),
+        createdAt: r.created_at,
+        indicator: r.indicator,
+        severity: r.severity,
+        actorId: r.actor_id,
+        ipAddress: r.ip_address,
+        summary: r.summary,
+        auditLogIds: r.audit_log_ids,
+        correlationId: r.correlation_id,
+      })),
+      nextCursor,
+    });
+  },
+  { ctx: "admin" },
+);

--- a/src/app/api/admin/detection/alerts/summary/route.ts
+++ b/src/app/api/admin/detection/alerts/summary/route.ts
@@ -1,0 +1,67 @@
+import type { NextRequest } from "next/server";
+import { assertAuthorized } from "@/lib/auth/authorization";
+import { HttpError } from "@/lib/auth/errors";
+import { withAuth } from "@/lib/auth/guards";
+import { getAuditPool, getAuthPool } from "@/lib/db/client";
+
+export const GET = withAuth(
+  async (_req: NextRequest, auth) => {
+    const authPool = getAuthPool();
+    const client = await authPool.connect();
+    try {
+      await assertAuthorized(
+        client,
+        "admin",
+        auth.accountId,
+        "audit-logs:read",
+      );
+    } catch (err) {
+      if (err instanceof HttpError) {
+        return Response.json(
+          { error: err.message },
+          { status: err.statusCode },
+        );
+      }
+      throw err;
+    } finally {
+      client.release();
+    }
+
+    const auditPool = getAuditPool();
+
+    const severityResult = await auditPool.query<{
+      severity: string;
+      count: string;
+    }>(
+      `SELECT severity, COUNT(*)::text AS count
+       FROM suspicious_activity_alerts
+       WHERE created_at > NOW() - INTERVAL '24 hours'
+       GROUP BY severity`,
+    );
+
+    const indicatorResult = await auditPool.query<{
+      indicator: string;
+      count: string;
+    }>(
+      `SELECT indicator, COUNT(*)::text AS count
+       FROM suspicious_activity_alerts
+       WHERE created_at > NOW() - INTERVAL '24 hours'
+       GROUP BY indicator`,
+    );
+
+    let severe = 0;
+    let warning = 0;
+    for (const row of severityResult.rows) {
+      if (row.severity === "severe") severe = Number(row.count);
+      if (row.severity === "warning") warning = Number(row.count);
+    }
+
+    const byIndicator: Record<string, number> = {};
+    for (const row of indicatorResult.rows) {
+      byIndicator[row.indicator] = Number(row.count);
+    }
+
+    return Response.json({ severe, warning, byIndicator });
+  },
+  { ctx: "admin" },
+);

--- a/src/app/api/admin/detection/analyze/route.ts
+++ b/src/app/api/admin/detection/analyze/route.ts
@@ -1,0 +1,38 @@
+import type { NextRequest } from "next/server";
+import { getAuditPool } from "@/lib/db/client";
+import { runAllAnalyzers } from "@/lib/detection/analyzers";
+
+/**
+ * POST /api/admin/detection/analyze
+ *
+ * Cron-triggered endpoint that runs all periodic detection analyzers.
+ * Protected by a shared secret (DETECTION_CRON_SECRET), not admin auth,
+ * since this is a machine-to-machine call.
+ */
+export async function POST(req: NextRequest): Promise<Response> {
+  const auth = req.headers.get("authorization");
+  if (!auth?.startsWith("Bearer ")) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const secret = process.env.DETECTION_CRON_SECRET;
+  if (!secret) {
+    return Response.json(
+      { error: "Detection cron not configured" },
+      { status: 503 },
+    );
+  }
+
+  if (auth !== `Bearer ${secret}`) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const pool = getAuditPool();
+    const alertsCreated = await runAllAnalyzers(pool);
+    return Response.json({ alertsCreated });
+  } catch (err) {
+    console.error("[detection] Analysis run failed:", err);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/auth/__tests__/callback-alerts.unit.test.ts
+++ b/src/app/api/auth/__tests__/callback-alerts.unit.test.ts
@@ -1,0 +1,171 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockEmitSevereAlert = vi.fn();
+
+vi.mock("@/lib/auth/cookies", () => ({
+  getOidcTempCookies: vi.fn(async () => ({
+    state: "test-state",
+    nonce: "test-nonce",
+    codeVerifier: "test-verifier",
+  })),
+  clearOidcTempCookies: vi.fn(),
+  clearInvitationTokenCookie: vi.fn(),
+  clearConnectionIdCookie: vi.fn(),
+  clearAuthCookies: vi.fn(),
+  setAuthCookies: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/oidc-discovery", () => ({
+  getOidcDiscovery: vi.fn(async () => ({
+    token_endpoint: "https://idp.test/token",
+    jwks_uri: "https://idp.test/jwks",
+    issuer: "https://idp.test",
+  })),
+}));
+
+vi.mock("@/lib/auth/oidc", () => ({
+  getIssuerUrl: vi.fn(() => "https://idp.test"),
+  exchangeCodeForTokens: vi.fn(async () => ({
+    id_token: "fake-id-token",
+    access_token: "fake-access-token",
+  })),
+}));
+
+vi.mock("@/lib/auth/oidc-validate", () => ({
+  validateIdToken: vi.fn(async () => ({
+    sub: "user-sub-001",
+    preferred_username: "testuser",
+    name: "Test User",
+    email: "test@example.com",
+    email_verified: true,
+  })),
+}));
+
+const mockUpsertAccount = vi.fn();
+
+vi.mock("@/lib/auth/account", () => ({
+  upsertAccount: (...args: unknown[]) => mockUpsertAccount(...args),
+  countAccessibleCustomers: vi.fn(async () => 1),
+}));
+
+vi.mock("@/lib/auth/invitations", () => ({
+  acceptInvitation: vi.fn(async () => ({ deny: null })),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  auditLog: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/detection", () => ({
+  emitSevereAlert: (arg: unknown) => mockEmitSevereAlert(arg),
+}));
+
+vi.mock("@/lib/auth/jwt", () => ({
+  signJwt: vi.fn(async () => ({ token: "jwt-token", iat: 1000, exp: 2000 })),
+}));
+
+vi.mock("@/lib/auth/csrf", () => ({
+  generateCsrf: vi.fn(() => "csrf-token"),
+}));
+
+vi.mock("@/lib/auth/same-account", () => ({
+  enforceSameAccount: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/auth/bridge", () => ({
+  processBridgeCallback: vi.fn(async () => ({ deny: null })),
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  getAuthPool: vi.fn(() => ({})),
+  query: vi.fn(async () => [{ sid: "session-001" }]),
+  // biome-ignore lint/complexity/noBannedTypes: test mock needs generic callable
+  withTransaction: vi.fn(async (_pool: unknown, fn: Function) => fn({})),
+}));
+
+// ---------------------------------------------------------------------------
+
+function makeCallbackRequest(): NextRequest {
+  const url =
+    "http://localhost:3000/api/auth/callback?code=abc&state=test-state";
+  return new NextRequest(url);
+}
+
+async function callGET(req: NextRequest) {
+  const { GET } = await import("../callback/route");
+  return GET(req);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("callback route — emitSevereAlert integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.OIDC_GENERAL_CLIENT_SECRET = "test-secret";
+  });
+
+  it("emits suspended_account_sign_in alert for suspended account", async () => {
+    mockUpsertAccount.mockResolvedValue({
+      id: "account-001",
+      status: "suspended",
+      token_version: 1,
+      admin_eligible: false,
+      locale: null,
+    });
+
+    const res = await callGET(makeCallbackRequest());
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("account_inactive");
+
+    expect(mockEmitSevereAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indicator: "suspended_account_sign_in",
+        actorId: "account-001",
+        summary: expect.objectContaining({ authContext: "general" }),
+      }),
+    );
+  });
+
+  it("emits suspended_account_sign_in alert for disabled account", async () => {
+    mockUpsertAccount.mockResolvedValue({
+      id: "account-001",
+      status: "disabled",
+      token_version: 1,
+      admin_eligible: false,
+      locale: null,
+    });
+
+    const res = await callGET(makeCallbackRequest());
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("account_inactive");
+
+    expect(mockEmitSevereAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indicator: "suspended_account_sign_in",
+        actorId: "account-001",
+      }),
+    );
+  });
+
+  it("does not emit alert for active account", async () => {
+    mockUpsertAccount.mockResolvedValue({
+      id: "account-001",
+      status: "active",
+      token_version: 1,
+      admin_eligible: false,
+      locale: null,
+    });
+
+    const res = await callGET(makeCallbackRequest());
+    expect(res.status).toBe(307);
+    // No alert emitted for normal sign-in
+    expect(mockEmitSevereAlert).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/auth/__tests__/callback-bridge.unit.test.ts
+++ b/src/app/api/auth/__tests__/callback-bridge.unit.test.ts
@@ -69,6 +69,11 @@ vi.mock("@/lib/audit", () => ({
   auditLog: vi.fn(async () => {}),
 }));
 
+const mockEmitSevereAlert = vi.fn();
+vi.mock("@/lib/detection", () => ({
+  emitSevereAlert: (arg: unknown) => mockEmitSevereAlert(arg),
+}));
+
 vi.mock("@/lib/auth/jwt", () => ({
   signJwt: vi.fn(async () => ({
     token: "jwt-token",
@@ -183,6 +188,8 @@ describe("callback route — bridge flow (#33)", () => {
     expect(res.status).toBe(307);
     expect(res.headers.get("location")).toContain("bridge_expired");
     expect(clearAuthCookies).toHaveBeenCalledWith("general");
+    // Non-scope denial: no scope probing alert
+    expect(mockEmitSevereAlert).not.toHaveBeenCalled();
   });
 
   it("redirects to deny page on bridge_customer_mismatch", async () => {
@@ -194,6 +201,13 @@ describe("callback route — bridge flow (#33)", () => {
     expect(res.status).toBe(307);
     expect(res.headers.get("location")).toContain("bridge_customer_mismatch");
     expect(clearAuthCookies).toHaveBeenCalledWith("general");
+    // Scope probing alert emitted for customer_mismatch
+    expect(mockEmitSevereAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indicator: "bridge_scope_probing",
+        actorId: "account-001",
+      }),
+    );
   });
 
   it("redirects to deny page on bridge_no_access", async () => {
@@ -204,6 +218,9 @@ describe("callback route — bridge flow (#33)", () => {
     const res = await callGET(makeCallbackRequest());
     expect(res.status).toBe(307);
     expect(res.headers.get("location")).toContain("bridge_no_access");
+    expect(mockEmitSevereAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ indicator: "bridge_scope_probing" }),
+    );
   });
 
   it("redirects to deny page on bridge_customer_inactive", async () => {
@@ -214,6 +231,9 @@ describe("callback route — bridge flow (#33)", () => {
     const res = await callGET(makeCallbackRequest());
     expect(res.status).toBe(307);
     expect(res.headers.get("location")).toContain("bridge_customer_inactive");
+    expect(mockEmitSevereAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ indicator: "bridge_scope_probing" }),
+    );
   });
 
   it("redirects to deny page on bridge_environment_inactive", async () => {
@@ -225,6 +245,9 @@ describe("callback route — bridge flow (#33)", () => {
     expect(res.status).toBe(307);
     expect(res.headers.get("location")).toContain(
       "bridge_environment_inactive",
+    );
+    expect(mockEmitSevereAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ indicator: "bridge_scope_probing" }),
     );
   });
 

--- a/src/app/api/auth/__tests__/callback-invitation.unit.test.ts
+++ b/src/app/api/auth/__tests__/callback-invitation.unit.test.ts
@@ -70,6 +70,10 @@ vi.mock("@/lib/audit", () => ({
   auditLog: vi.fn(async () => {}),
 }));
 
+vi.mock("@/lib/detection", () => ({
+  emitSevereAlert: vi.fn(async () => {}),
+}));
+
 vi.mock("@/lib/auth/jwt", () => ({
   signJwt: vi.fn(async () => ({
     token: "jwt-token",

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -20,6 +20,7 @@ import { validateIdToken } from "@/lib/auth/oidc-validate";
 import { extractRequestMeta } from "@/lib/auth/request-meta";
 import { enforceSameAccount } from "@/lib/auth/same-account";
 import { getAuthPool, query, withTransaction } from "@/lib/db/client";
+import { emitSevereAlert } from "@/lib/detection";
 
 function denyRedirect(request: NextRequest, reason: string): NextResponse {
   return NextResponse.redirect(new URL(`/deny?reason=${reason}`, request.url));
@@ -109,20 +110,30 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     // Status check
     if (account.status !== "active") {
+      const denyDetails = {
+        reason:
+          account.status === "suspended"
+            ? "status_suspended"
+            : "status_disabled",
+        status: account.status,
+      };
       void auditLog({
         actorId: account.id,
         authContext: "general",
         action: "general.auth.sign_in_denied",
         targetType: "account",
         targetId: account.id,
-        details: {
-          reason:
-            account.status === "suspended"
-              ? "status_suspended"
-              : "status_disabled",
-          status: account.status,
-        },
+        details: denyDetails,
         ipAddress: meta.ipAddress,
+      });
+      void emitSevereAlert({
+        indicator: "suspended_account_sign_in",
+        actorId: account.id,
+        ipAddress: meta.ipAddress,
+        summary: {
+          authContext: "general",
+          ...denyDetails,
+        },
       });
       return denyRedirect(request, "account_inactive");
     }
@@ -192,6 +203,27 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
           ipAddress: meta.ipAddress,
           aiceId: bridgeResult.bridgeAiceId ?? undefined,
         });
+
+        // Scope-related denials indicate probing attempts
+        const scopeReasons = new Set([
+          "bridge_customer_mismatch",
+          "bridge_customer_inactive",
+          "bridge_environment_inactive",
+          "bridge_no_access",
+        ]);
+        if (scopeReasons.has(bridgeResult.deny)) {
+          void emitSevereAlert({
+            indicator: "bridge_scope_probing",
+            actorId: account.id,
+            ipAddress: meta.ipAddress,
+            summary: {
+              reason: bridgeResult.deny,
+              connectionId,
+              aiceId: bridgeResult.bridgeAiceId,
+            },
+          });
+        }
+
         return denyRedirect(request, bridgeResult.deny);
       }
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -56,6 +56,7 @@
     "analysts": "Analysts",
     "trustRegistry": "Trust Registry",
     "auditLog": "Audit Log",
+    "suspiciousActivity": "Suspicious Activity",
     "settings": "Settings"
   },
   "events": {
@@ -145,6 +146,40 @@
     "general": "General",
     "admin": "Admin",
     "errorLoading": "Failed to load audit logs. Please try again."
+  },
+  "suspiciousActivity": {
+    "title": "Suspicious Activity",
+    "description": "Detected suspicious patterns in system activity.",
+    "createdAt": "Detected At",
+    "severity": "Severity",
+    "indicator": "Indicator",
+    "actor": "Actor",
+    "ipAddress": "IP Address",
+    "summary": "Summary",
+    "auditLogIds": "Related Audit Logs",
+    "severe": "Severe",
+    "warning": "Warning",
+    "allSeverities": "All severities",
+    "allIndicators": "All indicators",
+    "filterFrom": "From",
+    "filterTo": "To",
+    "apply": "Apply",
+    "reset": "Reset",
+    "noResults": "No suspicious activity alerts found.",
+    "loadMore": "Load More",
+    "errorLoading": "Failed to load alerts. Please try again.",
+    "last24h": "Last 24 hours",
+    "severeCount": "{count} severe",
+    "warningCount": "{count} warning",
+    "indicators": {
+      "consecutive_sign_in_denials": "Consecutive Sign-in Denials",
+      "admin_auth_denial_pattern": "Admin Auth Denial Pattern",
+      "session_ip_mismatch": "Session IP/UA Mismatch",
+      "concurrent_multi_ip_sessions": "Concurrent Multi-IP Sessions",
+      "bridge_abuse": "Bridge Abuse",
+      "bridge_scope_probing": "Bridge Scope Probing",
+      "suspended_account_sign_in": "Suspended Account Sign-in"
+    }
   },
   "validation": {
     "required": "This field is required",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -56,6 +56,7 @@
     "analysts": "분석가",
     "trustRegistry": "신뢰 레지스트리",
     "auditLog": "감사 로그",
+    "suspiciousActivity": "의심스러운 활동",
     "settings": "설정"
   },
   "events": {
@@ -145,6 +146,40 @@
     "general": "일반",
     "admin": "관리자",
     "errorLoading": "감사 로그를 불러오지 못했습니다. 다시 시도해 주세요."
+  },
+  "suspiciousActivity": {
+    "title": "의심스러운 활동",
+    "description": "시스템 활동에서 감지된 의심스러운 패턴입니다.",
+    "createdAt": "감지 시간",
+    "severity": "심각도",
+    "indicator": "지표",
+    "actor": "행위자",
+    "ipAddress": "IP 주소",
+    "summary": "요약",
+    "auditLogIds": "관련 감사 로그",
+    "severe": "심각",
+    "warning": "경고",
+    "allSeverities": "전체 심각도",
+    "allIndicators": "전체 지표",
+    "filterFrom": "시작일",
+    "filterTo": "종료일",
+    "apply": "적용",
+    "reset": "초기화",
+    "noResults": "의심스러운 활동 알림이 없습니다.",
+    "loadMore": "더 보기",
+    "errorLoading": "알림을 불러오지 못했습니다. 다시 시도해 주세요.",
+    "last24h": "최근 24시간",
+    "severeCount": "심각 {count}건",
+    "warningCount": "경고 {count}건",
+    "indicators": {
+      "consecutive_sign_in_denials": "연속 로그인 거부",
+      "admin_auth_denial_pattern": "관리자 인증 거부 패턴",
+      "session_ip_mismatch": "세션 IP/UA 불일치",
+      "concurrent_multi_ip_sessions": "동시 다중 IP 세션",
+      "bridge_abuse": "브릿지 남용",
+      "bridge_scope_probing": "브릿지 범위 탐색",
+      "suspended_account_sign_in": "정지 계정 로그인 시도"
+    }
   },
   "validation": {
     "required": "필수 입력 항목입니다",

--- a/src/lib/audit/actions.ts
+++ b/src/lib/audit/actions.ts
@@ -26,7 +26,6 @@ export type AuditAction =
   | "bridge.connection_request"
   | "bridge.connection_granted"
   | "bridge.connection_denied"
-  | "bridge.write_attempt_blocked"
   // Invitation
   | "invitation.created"
   | "invitation.accepted"

--- a/src/lib/auth/__tests__/withauth-audit.unit.test.ts
+++ b/src/lib/auth/__tests__/withauth-audit.unit.test.ts
@@ -24,11 +24,13 @@ vi.mock("../jwt", () => ({
 }));
 
 const mockValidateSession = vi.fn();
+const mockUpdateSessionMeta = vi.fn();
 vi.mock("../session-validator", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../session-validator")>();
   return {
     ...actual,
     validateSession: (...args: unknown[]) => mockValidateSession(...args),
+    updateSessionMeta: (...args: unknown[]) => mockUpdateSessionMeta(...args),
   };
 });
 
@@ -211,6 +213,8 @@ describe("withAuth session audit events", () => {
     mockValidateSession.mockResolvedValue({
       createdAt: 1700000000,
       lastActiveAt: 1700000000,
+      ipAddress: "10.0.0.1",
+      userAgent: "unknown",
       bridgeAiceId: null,
       bridgeCustomerIds: null,
     });
@@ -221,6 +225,121 @@ describe("withAuth session audit events", () => {
 
     expect(res.status).toBe(200);
     expect(handler).toHaveBeenCalledOnce();
+    expect(mockAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("emits session.ip_mismatch and updates session meta when IP changes", async () => {
+    mockGetAuthCookie.mockResolvedValue("valid-token");
+    mockVerifyJwtFull.mockResolvedValue(CLAIMS);
+    mockValidateSession.mockResolvedValue({
+      createdAt: 1700000000,
+      lastActiveAt: 1700000000,
+      ipAddress: "192.168.1.1", // different from x-forwarded-for: 10.0.0.1
+      userAgent: "unknown",
+      bridgeAiceId: null,
+      bridgeCustomerIds: null,
+    });
+
+    const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }));
+    const guarded = withAuth(handler);
+    const res = await guarded(makeRequest());
+
+    expect(res.status).toBe(200);
+    expect(handler).toHaveBeenCalledOnce();
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "session.ip_mismatch",
+        actorId: "account-1",
+        targetType: "session",
+        targetId: "sid-1",
+        details: { previous: "192.168.1.1", current: "10.0.0.1" },
+      }),
+    );
+    expect(mockUpdateSessionMeta).toHaveBeenCalledWith(
+      expect.anything(),
+      "sid-1",
+      "10.0.0.1",
+      undefined,
+    );
+  });
+
+  it("emits session.ua_mismatch and updates session meta when UA changes", async () => {
+    mockGetAuthCookie.mockResolvedValue("valid-token");
+    mockVerifyJwtFull.mockResolvedValue(CLAIMS);
+    mockValidateSession.mockResolvedValue({
+      createdAt: 1700000000,
+      lastActiveAt: 1700000000,
+      ipAddress: "10.0.0.1", // same IP
+      userAgent: "Mozilla/5.0 Chrome/100", // different UA
+      bridgeAiceId: null,
+      bridgeCustomerIds: null,
+    });
+
+    const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }));
+    const guarded = withAuth(handler);
+    const res = await guarded(makeRequest());
+
+    expect(res.status).toBe(200);
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "session.ua_mismatch",
+        details: { previous: "Mozilla/5.0 Chrome/100", current: "unknown" },
+      }),
+    );
+    expect(mockUpdateSessionMeta).toHaveBeenCalledWith(
+      expect.anything(),
+      "sid-1",
+      undefined,
+      "unknown",
+    );
+  });
+
+  it("emits both mismatch events and updates both when IP and UA differ", async () => {
+    mockGetAuthCookie.mockResolvedValue("valid-token");
+    mockVerifyJwtFull.mockResolvedValue(CLAIMS);
+    mockValidateSession.mockResolvedValue({
+      createdAt: 1700000000,
+      lastActiveAt: 1700000000,
+      ipAddress: "192.168.1.1",
+      userAgent: "Mozilla/5.0 Chrome/100",
+      bridgeAiceId: null,
+      bridgeCustomerIds: null,
+    });
+
+    const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }));
+    const guarded = withAuth(handler);
+    await guarded(makeRequest());
+
+    const actions = mockAuditLog.mock.calls.map(
+      (call: unknown[]) => (call[0] as { action: string }).action,
+    );
+    expect(actions).toContain("session.ip_mismatch");
+    expect(actions).toContain("session.ua_mismatch");
+    expect(mockAuditLog).toHaveBeenCalledTimes(2);
+    expect(mockUpdateSessionMeta).toHaveBeenCalledWith(
+      expect.anything(),
+      "sid-1",
+      "10.0.0.1",
+      "unknown",
+    );
+  });
+
+  it("does not emit mismatch when IP and UA match", async () => {
+    mockGetAuthCookie.mockResolvedValue("valid-token");
+    mockVerifyJwtFull.mockResolvedValue(CLAIMS);
+    mockValidateSession.mockResolvedValue({
+      createdAt: 1700000000,
+      lastActiveAt: 1700000000,
+      ipAddress: "10.0.0.1",
+      userAgent: "unknown",
+      bridgeAiceId: null,
+      bridgeCustomerIds: null,
+    });
+
+    const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }));
+    const guarded = withAuth(handler);
+    await guarded(makeRequest());
+
     expect(mockAuditLog).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/auth/guards.ts
+++ b/src/lib/auth/guards.ts
@@ -13,6 +13,7 @@ import { getSessionPolicy } from "./session-policy";
 import {
   SessionExpiredError,
   SessionRevokedError,
+  updateSessionMeta,
   validateSession,
 } from "./session-validator";
 
@@ -78,6 +79,52 @@ export function withAuth(
         );
         bridgeAiceId = session.bridgeAiceId;
         bridgeCustomerIds = session.bridgeCustomerIds;
+
+        // IP/UA mismatch detection — emit once, then update session baseline
+        // so subsequent requests with the same new IP/UA don't re-trigger.
+        const ipChanged =
+          meta.ipAddress && meta.ipAddress !== session.ipAddress;
+        const uaChanged =
+          meta.userAgent && meta.userAgent !== session.userAgent;
+
+        if (ipChanged) {
+          void auditLog({
+            actorId: claims.sub,
+            authContext: ctx,
+            action: "session.ip_mismatch",
+            targetType: "session",
+            targetId: claims.sid,
+            details: {
+              previous: session.ipAddress,
+              current: meta.ipAddress,
+            },
+            ipAddress: meta.ipAddress,
+            sid: claims.sid,
+          });
+        }
+        if (uaChanged) {
+          void auditLog({
+            actorId: claims.sub,
+            authContext: ctx,
+            action: "session.ua_mismatch",
+            targetType: "session",
+            targetId: claims.sid,
+            details: {
+              previous: session.userAgent,
+              current: meta.userAgent,
+            },
+            ipAddress: meta.ipAddress,
+            sid: claims.sid,
+          });
+        }
+        if (ipChanged || uaChanged) {
+          void updateSessionMeta(
+            getAuthPool(),
+            claims.sid,
+            ipChanged ? meta.ipAddress : undefined,
+            uaChanged ? meta.userAgent : undefined,
+          );
+        }
       } catch (err) {
         if (err instanceof SessionExpiredError) {
           const action =

--- a/src/lib/auth/session-validator.ts
+++ b/src/lib/auth/session-validator.ts
@@ -8,6 +8,8 @@ import { query } from "../db/client";
 export interface ValidatedSession {
   createdAt: number;
   lastActiveAt: number;
+  ipAddress: string;
+  userAgent: string;
   bridgeAiceId: string | null;
   bridgeCustomerIds: string[] | null;
 }
@@ -40,11 +42,14 @@ export async function validateSession(
     revoked: boolean;
     created_at: Date;
     last_active_at: Date;
+    ip_address: string;
+    user_agent: string;
     bridge_aice_id: string | null;
     bridge_customer_ids: string[] | null;
   }>(
     pool,
-    `SELECT revoked, created_at, last_active_at, bridge_aice_id, bridge_customer_ids
+    `SELECT revoked, created_at, last_active_at, ip_address, user_agent,
+            bridge_aice_id, bridge_customer_ids
      FROM sessions WHERE sid = $1`,
     [sid],
   );
@@ -83,7 +88,41 @@ export async function validateSession(
   return {
     createdAt,
     lastActiveAt,
+    ipAddress: row.ip_address,
+    userAgent: row.user_agent,
     bridgeAiceId: row.bridge_aice_id,
     bridgeCustomerIds: row.bridge_customer_ids,
   };
+}
+
+// ---------------------------------------------------------------------------
+// updateSessionMeta — update IP/UA baseline after mismatch detection
+// ---------------------------------------------------------------------------
+
+export async function updateSessionMeta(
+  pool: Pool,
+  sid: string,
+  ipAddress?: string,
+  userAgent?: string,
+): Promise<void> {
+  const sets: string[] = [];
+  const values: unknown[] = [];
+  let idx = 1;
+
+  if (ipAddress !== undefined) {
+    sets.push(`ip_address = $${idx++}`);
+    values.push(ipAddress);
+  }
+  if (userAgent !== undefined) {
+    sets.push(`user_agent = $${idx++}`);
+    values.push(userAgent);
+  }
+  if (sets.length === 0) return;
+
+  values.push(sid);
+  await query(
+    pool,
+    `UPDATE sessions SET ${sets.join(", ")} WHERE sid = $${idx}`,
+    values,
+  );
 }

--- a/src/lib/db/__tests__/schema.db.test.ts
+++ b/src/lib/db/__tests__/schema.db.test.ts
@@ -462,11 +462,11 @@ describe.skipIf(!hasPostgres)("Schema verification (audit_db)", () => {
     await closeAdminPool();
   });
 
-  it("applies both audit migrations cleanly", async () => {
+  it("applies all audit migrations cleanly", async () => {
     const { rows } = await pool.query(
       "SELECT version FROM _migrations ORDER BY version",
     );
-    expect(rows).toHaveLength(2);
+    expect(rows).toHaveLength(3);
   });
 
   it("audit_logs.auth_context rejects invalid values", async () => {
@@ -487,6 +487,9 @@ describe.skipIf(!hasPostgres)("Schema verification (audit_db)", () => {
       // which grants to aimer_audit_owner and aimer_audit. Since we ran
       // migrations as superuser, re-grant explicitly.
       await pool.query("GRANT SELECT, INSERT ON audit_logs TO aimer_audit");
+      await pool.query(
+        "GRANT SELECT, INSERT ON suspicious_activity_alerts TO aimer_audit",
+      );
       await pool.query(
         "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO aimer_audit",
       );

--- a/src/lib/detection/__tests__/analyzers.unit.test.ts
+++ b/src/lib/detection/__tests__/analyzers.unit.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock insertAlert before importing analyzers
+const mockInsertAlert = vi.fn();
+vi.mock("..", () => ({
+  insertAlert: (...args: unknown[]) => mockInsertAlert(...args),
+}));
+
+vi.mock("server-only", () => ({}));
+
+const { analyzeConsecutiveDenials } = await import(
+  "../analyzers/consecutive-denials"
+);
+const { analyzeSessionIpMismatch } = await import(
+  "../analyzers/session-ip-mismatch"
+);
+const { analyzeConcurrentMultiIp } = await import(
+  "../analyzers/concurrent-multi-ip"
+);
+const { analyzeBridgeAbuse } = await import("../analyzers/bridge-abuse");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockPool(queryResults: Record<string, unknown>) {
+  const callIndex = { value: 0 };
+  const results = Object.values(queryResults);
+  return {
+    query: vi.fn().mockImplementation(() => {
+      const idx = callIndex.value++;
+      return results[idx] ?? { rows: [] };
+    }),
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+  } as any;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("analyzeConsecutiveDenials", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates alert when threshold is met (by actor)", async () => {
+    const pool = mockPool({
+      byActor: {
+        rows: [
+          {
+            actor_id: "actor-1",
+            ip_address: "10.0.0.1",
+            denial_count: 5,
+            log_ids: ["1", "2", "3", "4", "5"],
+          },
+        ],
+      },
+      dedupActor: { rows: [] }, // no duplicate
+      byIp: { rows: [] },
+    });
+
+    const count = await analyzeConsecutiveDenials(pool);
+    expect(count).toBe(1);
+    expect(mockInsertAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indicator: "consecutive_sign_in_denials",
+        actorId: "actor-1",
+        ipAddress: "10.0.0.1",
+        summary: expect.objectContaining({
+          denialCount: 5,
+          groupedBy: "actor_id",
+        }),
+        auditLogIds: [1, 2, 3, 4, 5],
+      }),
+    );
+  });
+
+  it("skips when duplicate exists within cooldown", async () => {
+    const pool = mockPool({
+      byActor: {
+        rows: [
+          {
+            actor_id: "actor-1",
+            ip_address: "10.0.0.1",
+            denial_count: 5,
+            log_ids: ["1", "2", "3", "4", "5"],
+          },
+        ],
+      },
+      dedupActor: { rows: [{ "?column?": 1 }] }, // duplicate exists
+      byIp: { rows: [] },
+    });
+
+    const count = await analyzeConsecutiveDenials(pool);
+    expect(count).toBe(0);
+    expect(mockInsertAlert).not.toHaveBeenCalled();
+  });
+
+  it("returns 0 when no denials exceed threshold", async () => {
+    const pool = mockPool({
+      byActor: { rows: [] },
+      byIp: { rows: [] },
+    });
+
+    const count = await analyzeConsecutiveDenials(pool);
+    expect(count).toBe(0);
+    expect(mockInsertAlert).not.toHaveBeenCalled();
+  });
+
+  it("creates alert by IP when threshold is met", async () => {
+    const pool = mockPool({
+      byActor: { rows: [] },
+      byIp: {
+        rows: [
+          {
+            ip_address: "10.0.0.99",
+            denial_count: 7,
+            log_ids: ["10", "11", "12", "13", "14", "15", "16"],
+          },
+        ],
+      },
+      dedupIp: { rows: [] },
+    });
+
+    const count = await analyzeConsecutiveDenials(pool);
+    expect(count).toBe(1);
+    expect(mockInsertAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ipAddress: "10.0.0.99",
+        summary: expect.objectContaining({ groupedBy: "ip_address" }),
+      }),
+    );
+  });
+});
+
+describe("analyzeSessionIpMismatch", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates alert when mismatch threshold is met", async () => {
+    const pool = mockPool({
+      detect: {
+        rows: [
+          {
+            actor_id: "actor-2",
+            sid: "sid-2",
+            ip_address: "10.0.0.2",
+            mismatch_count: 3,
+            log_ids: ["20", "21", "22"],
+          },
+        ],
+      },
+      dedup: { rows: [] },
+    });
+
+    const count = await analyzeSessionIpMismatch(pool);
+    expect(count).toBe(1);
+    expect(mockInsertAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indicator: "session_ip_mismatch",
+        actorId: "actor-2",
+        summary: expect.objectContaining({ sid: "sid-2", mismatchCount: 3 }),
+      }),
+    );
+  });
+
+  it("returns 0 when no mismatches exceed threshold", async () => {
+    const pool = mockPool({ detect: { rows: [] } });
+    const count = await analyzeSessionIpMismatch(pool);
+    expect(count).toBe(0);
+  });
+
+  it("skips duplicate within cooldown", async () => {
+    const pool = mockPool({
+      detect: {
+        rows: [
+          {
+            actor_id: "actor-2",
+            sid: "sid-2",
+            ip_address: "10.0.0.2",
+            mismatch_count: 3,
+            log_ids: ["20", "21", "22"],
+          },
+        ],
+      },
+      dedup: { rows: [{ "?column?": 1 }] },
+    });
+
+    const count = await analyzeSessionIpMismatch(pool);
+    expect(count).toBe(0);
+    expect(mockInsertAlert).not.toHaveBeenCalled();
+  });
+});
+
+describe("analyzeConcurrentMultiIp", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates alert for multi-IP sign-ins", async () => {
+    const pool = mockPool({
+      detect: {
+        rows: [
+          {
+            actor_id: "actor-3",
+            ip_count: 3,
+            ips: ["10.0.0.1", "10.0.0.2", "10.0.0.3"],
+            log_ids: ["30", "31", "32"],
+          },
+        ],
+      },
+      dedup: { rows: [] },
+    });
+
+    const count = await analyzeConcurrentMultiIp(pool);
+    expect(count).toBe(1);
+    expect(mockInsertAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indicator: "concurrent_multi_ip_sessions",
+        actorId: "actor-3",
+        summary: expect.objectContaining({
+          ipCount: 3,
+          ips: ["10.0.0.1", "10.0.0.2", "10.0.0.3"],
+        }),
+      }),
+    );
+  });
+
+  it("returns 0 when no concurrent sessions", async () => {
+    const pool = mockPool({ detect: { rows: [] } });
+    const count = await analyzeConcurrentMultiIp(pool);
+    expect(count).toBe(0);
+    expect(mockInsertAlert).not.toHaveBeenCalled();
+  });
+
+  it("skips duplicate within cooldown", async () => {
+    const pool = mockPool({
+      detect: {
+        rows: [
+          {
+            actor_id: "actor-3",
+            ip_count: 2,
+            ips: ["10.0.0.1", "10.0.0.2"],
+            log_ids: ["30", "31"],
+          },
+        ],
+      },
+      dedup: { rows: [{ "?column?": 1 }] },
+    });
+
+    const count = await analyzeConcurrentMultiIp(pool);
+    expect(count).toBe(0);
+    expect(mockInsertAlert).not.toHaveBeenCalled();
+  });
+});
+
+describe("analyzeBridgeAbuse", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates alert for frequent bridge requests", async () => {
+    const pool = mockPool({
+      detect: {
+        rows: [
+          {
+            aice_id: "aice.example.com",
+            request_count: 15,
+            log_ids: ["40", "41", "42"],
+          },
+        ],
+      },
+      dedup: { rows: [] },
+    });
+
+    const count = await analyzeBridgeAbuse(pool);
+    expect(count).toBe(1);
+    expect(mockInsertAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indicator: "bridge_abuse",
+        summary: expect.objectContaining({
+          aiceId: "aice.example.com",
+          requestCount: 15,
+        }),
+      }),
+    );
+  });
+
+  it("returns 0 when no bridge abuse detected", async () => {
+    const pool = mockPool({ detect: { rows: [] } });
+    const count = await analyzeBridgeAbuse(pool);
+    expect(count).toBe(0);
+    expect(mockInsertAlert).not.toHaveBeenCalled();
+  });
+
+  it("skips duplicate within cooldown", async () => {
+    const pool = mockPool({
+      detect: {
+        rows: [
+          {
+            aice_id: "aice.example.com",
+            request_count: 15,
+            log_ids: ["40", "41", "42"],
+          },
+        ],
+      },
+      dedup: { rows: [{ "?column?": 1 }] },
+    });
+
+    const count = await analyzeBridgeAbuse(pool);
+    expect(count).toBe(0);
+    expect(mockInsertAlert).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/detection/__tests__/deduplicate.unit.test.ts
+++ b/src/lib/detection/__tests__/deduplicate.unit.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_COOLDOWN_MINUTES,
+  isDuplicate,
+} from "../analyzers/deduplicate";
+
+function mockPool(rows: Record<string, unknown>[] = []) {
+  return {
+    query: vi.fn().mockResolvedValue({ rows }),
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+  } as any;
+}
+
+describe("DEFAULT_COOLDOWN_MINUTES", () => {
+  it("is 60", () => {
+    expect(DEFAULT_COOLDOWN_MINUTES).toBe(60);
+  });
+});
+
+describe("isDuplicate", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns false when no matching rows exist", async () => {
+    const pool = mockPool([]);
+    const result = await isDuplicate(pool, "bridge_abuse", 60, {
+      actorId: "actor-1",
+    });
+    expect(result).toBe(false);
+  });
+
+  it("returns true when matching rows exist", async () => {
+    const pool = mockPool([{ "?column?": 1 }]);
+    const result = await isDuplicate(pool, "bridge_abuse", 60, {
+      actorId: "actor-1",
+    });
+    expect(result).toBe(true);
+  });
+
+  it("builds query with actorId condition", async () => {
+    const pool = mockPool();
+    await isDuplicate(pool, "consecutive_sign_in_denials", 60, {
+      actorId: "actor-1",
+    });
+
+    const [sql, params] = pool.query.mock.calls[0];
+    expect(sql).toContain("indicator = $1");
+    expect(sql).toContain("$2::int * INTERVAL '1 minute'");
+    expect(sql).toContain("actor_id = $3");
+    expect(params).toEqual(["consecutive_sign_in_denials", 60, "actor-1"]);
+  });
+
+  it("builds query with ipAddress condition", async () => {
+    const pool = mockPool();
+    await isDuplicate(pool, "consecutive_sign_in_denials", 60, {
+      ipAddress: "10.0.0.1",
+    });
+
+    const [sql, params] = pool.query.mock.calls[0];
+    expect(sql).toContain("ip_address = $3");
+    expect(params).toEqual(["consecutive_sign_in_denials", 60, "10.0.0.1"]);
+  });
+
+  it("builds query with jsonPath condition", async () => {
+    const pool = mockPool();
+    await isDuplicate(pool, "bridge_abuse", 60, {
+      jsonPath: ["aiceId", "aice.example.com"],
+    });
+
+    const [sql, params] = pool.query.mock.calls[0];
+    expect(sql).toContain("summary->>$3 = $4");
+    expect(params).toEqual(["bridge_abuse", 60, "aiceId", "aice.example.com"]);
+  });
+
+  it("combines actorId and ipAddress conditions", async () => {
+    const pool = mockPool();
+    await isDuplicate(pool, "session_ip_mismatch", 60, {
+      actorId: "actor-1",
+      ipAddress: "10.0.0.1",
+    });
+
+    const [sql, params] = pool.query.mock.calls[0];
+    expect(sql).toContain("actor_id = $3");
+    expect(sql).toContain("ip_address = $4");
+    expect(params).toEqual(["session_ip_mismatch", 60, "actor-1", "10.0.0.1"]);
+  });
+
+  it("passes cooldown as a parameterized value", async () => {
+    const pool = mockPool();
+    await isDuplicate(pool, "bridge_abuse", 30, { actorId: "actor-1" });
+
+    const [sql, params] = pool.query.mock.calls[0];
+    expect(sql).toContain("$2::int * INTERVAL '1 minute'");
+    expect(params[1]).toBe(30);
+  });
+});

--- a/src/lib/detection/__tests__/detection.unit.test.ts
+++ b/src/lib/detection/__tests__/detection.unit.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock dependencies before importing
+const mockQuery = vi.fn().mockResolvedValue({ rows: [] });
+vi.mock("../../db/client", () => ({
+  getAuditPool: () => ({ query: mockQuery }),
+}));
+
+const mockGetCorrelationId = vi.fn().mockReturnValue(undefined);
+vi.mock("../../audit/correlation", () => ({
+  getCorrelationId: () => mockGetCorrelationId(),
+}));
+
+vi.mock("server-only", () => ({}));
+
+const { insertAlert, emitSevereAlert } = await import("../index");
+
+describe("insertAlert", () => {
+  afterEach(() => {
+    mockQuery.mockClear();
+    mockGetCorrelationId.mockReturnValue(undefined);
+  });
+
+  it("inserts a row with all fields", async () => {
+    await insertAlert({
+      indicator: "consecutive_sign_in_denials",
+      actorId: "user-1",
+      ipAddress: "10.0.0.1",
+      summary: { count: 5 },
+      auditLogIds: [1, 2, 3],
+      correlationId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    });
+
+    expect(mockQuery).toHaveBeenCalledOnce();
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("INSERT INTO suspicious_activity_alerts");
+    expect(params[0]).toBe("consecutive_sign_in_denials"); // indicator
+    expect(params[1]).toBe("warning"); // severity (auto from severityOf)
+    expect(params[2]).toBe("user-1"); // actor_id
+    expect(params[3]).toBe("10.0.0.1"); // ip_address
+    expect(params[4]).toBe('{"count":5}'); // summary
+    expect(params[5]).toEqual([1, 2, 3]); // audit_log_ids
+    expect(params[6]).toBe("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+  });
+
+  it("fills nulls for optional fields", async () => {
+    await insertAlert({
+      indicator: "bridge_abuse",
+      summary: { aiceId: "test" },
+    });
+
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params[2]).toBeNull(); // actor_id
+    expect(params[3]).toBeNull(); // ip_address
+    expect(params[5]).toEqual([]); // audit_log_ids
+    expect(params[6]).toBeNull(); // correlation_id
+  });
+
+  it("falls back to AsyncLocalStorage correlation ID when not explicit", async () => {
+    mockGetCorrelationId.mockReturnValue("from-async-local-storage");
+
+    await insertAlert({
+      indicator: "bridge_abuse",
+      summary: { aiceId: "test" },
+    });
+
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params[6]).toBe("from-async-local-storage");
+  });
+
+  it("prefers explicit correlationId over AsyncLocalStorage", async () => {
+    mockGetCorrelationId.mockReturnValue("from-async-local-storage");
+
+    await insertAlert({
+      indicator: "bridge_abuse",
+      summary: { aiceId: "test" },
+      correlationId: "explicit-id",
+    });
+
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params[6]).toBe("explicit-id");
+  });
+
+  it("auto-assigns severity from indicator type", async () => {
+    // severe indicator
+    await insertAlert({
+      indicator: "suspended_account_sign_in",
+      summary: { reason: "status_suspended" },
+    });
+
+    const [, severeParams] = mockQuery.mock.calls[0];
+    expect(severeParams[1]).toBe("severe");
+
+    mockQuery.mockClear();
+
+    // warning indicator
+    await insertAlert({
+      indicator: "bridge_abuse",
+      summary: { aiceId: "test" },
+    });
+
+    const [, warningParams] = mockQuery.mock.calls[0];
+    expect(warningParams[1]).toBe("warning");
+  });
+
+  it("allows explicit severity override", async () => {
+    await insertAlert({
+      indicator: "bridge_abuse",
+      severity: "severe",
+      summary: { aiceId: "test" },
+    });
+
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params[1]).toBe("severe");
+  });
+
+  it("swallows errors without throwing", async () => {
+    mockQuery.mockRejectedValueOnce(new Error("connection refused"));
+
+    await expect(
+      insertAlert({
+        indicator: "bridge_abuse",
+        summary: { aiceId: "test" },
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("emitSevereAlert", () => {
+  afterEach(() => {
+    mockQuery.mockClear();
+  });
+
+  it("always inserts with severity=severe", async () => {
+    await emitSevereAlert({
+      indicator: "bridge_abuse", // normally "warning"
+      summary: { aiceId: "test" },
+    });
+
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params[1]).toBe("severe");
+  });
+
+  it("passes all params through to insertAlert", async () => {
+    await emitSevereAlert({
+      indicator: "suspended_account_sign_in",
+      actorId: "actor-1",
+      ipAddress: "1.2.3.4",
+      summary: { reason: "status_suspended", authContext: "admin" },
+      auditLogIds: [42],
+      correlationId: "11111111-2222-3333-4444-555555555555",
+    });
+
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params[0]).toBe("suspended_account_sign_in");
+    expect(params[2]).toBe("actor-1");
+    expect(params[3]).toBe("1.2.3.4");
+    expect(params[5]).toEqual([42]);
+    expect(params[6]).toBe("11111111-2222-3333-4444-555555555555");
+  });
+});

--- a/src/lib/detection/__tests__/run-all-analyzers.unit.test.ts
+++ b/src/lib/detection/__tests__/run-all-analyzers.unit.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock all 5 analyzers
+const mockConsecutiveDenials = vi.fn().mockResolvedValue(0);
+const mockSessionIpMismatch = vi.fn().mockResolvedValue(0);
+const mockConcurrentMultiIp = vi.fn().mockResolvedValue(0);
+const mockBridgeAbuse = vi.fn().mockResolvedValue(0);
+
+vi.mock("../analyzers/consecutive-denials", () => ({
+  analyzeConsecutiveDenials: (...args: unknown[]) =>
+    mockConsecutiveDenials(...args),
+}));
+vi.mock("../analyzers/session-ip-mismatch", () => ({
+  analyzeSessionIpMismatch: (...args: unknown[]) =>
+    mockSessionIpMismatch(...args),
+}));
+vi.mock("../analyzers/concurrent-multi-ip", () => ({
+  analyzeConcurrentMultiIp: (...args: unknown[]) =>
+    mockConcurrentMultiIp(...args),
+}));
+vi.mock("../analyzers/bridge-abuse", () => ({
+  analyzeBridgeAbuse: (...args: unknown[]) => mockBridgeAbuse(...args),
+}));
+
+vi.mock("server-only", () => ({}));
+
+const { runAllAnalyzers } = await import("../analyzers/index");
+
+// biome-ignore lint/suspicious/noExplicitAny: test mock
+const fakePool = {} as any;
+
+describe("runAllAnalyzers", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+    mockConsecutiveDenials.mockResolvedValue(0);
+    mockSessionIpMismatch.mockResolvedValue(0);
+    mockConcurrentMultiIp.mockResolvedValue(0);
+    mockBridgeAbuse.mockResolvedValue(0);
+  });
+
+  it("calls all 4 analyzers", async () => {
+    await runAllAnalyzers(fakePool);
+
+    expect(mockConsecutiveDenials).toHaveBeenCalledWith(fakePool);
+    expect(mockSessionIpMismatch).toHaveBeenCalledWith(fakePool);
+    expect(mockConcurrentMultiIp).toHaveBeenCalledWith(fakePool);
+    expect(mockBridgeAbuse).toHaveBeenCalledWith(fakePool);
+  });
+
+  it("returns the sum of all analyzer counts", async () => {
+    mockConsecutiveDenials.mockResolvedValue(2);
+    mockSessionIpMismatch.mockResolvedValue(1);
+    mockConcurrentMultiIp.mockResolvedValue(0);
+    mockBridgeAbuse.mockResolvedValue(3);
+
+    const total = await runAllAnalyzers(fakePool);
+    expect(total).toBe(6);
+  });
+
+  it("continues running remaining analyzers when one fails", async () => {
+    mockConsecutiveDenials.mockRejectedValue(new Error("DB error"));
+    mockSessionIpMismatch.mockResolvedValue(1);
+    mockBridgeAbuse.mockResolvedValue(2);
+
+    const total = await runAllAnalyzers(fakePool);
+
+    // Failed analyzer contributes 0, others succeed
+    expect(total).toBe(3);
+    // All analyzers still called
+    expect(mockConcurrentMultiIp).toHaveBeenCalled();
+    expect(mockBridgeAbuse).toHaveBeenCalled();
+  });
+
+  it("returns 0 when all analyzers return 0", async () => {
+    const total = await runAllAnalyzers(fakePool);
+    expect(total).toBe(0);
+  });
+});

--- a/src/lib/detection/analyzers/bridge-abuse.ts
+++ b/src/lib/detection/analyzers/bridge-abuse.ts
@@ -1,0 +1,53 @@
+import type { Pool } from "pg";
+import { insertAlert } from "..";
+import { DEFAULT_COOLDOWN_MINUTES, isDuplicate } from "./deduplicate";
+
+const WINDOW_MINUTES = 15;
+const THRESHOLD = 10;
+
+/**
+ * Detect AICE environments with abnormally frequent bridge connection
+ * requests within a window.
+ */
+export async function analyzeBridgeAbuse(pool: Pool): Promise<number> {
+  let count = 0;
+
+  const rows = await pool.query<{
+    aice_id: string;
+    request_count: number;
+    log_ids: string[];
+  }>(
+    `SELECT aice_id,
+            COUNT(*)::int AS request_count,
+            array_agg(id ORDER BY id) AS log_ids
+     FROM audit_logs
+     WHERE action = 'bridge.connection_request'
+       AND aice_id IS NOT NULL
+       AND timestamp > NOW() - INTERVAL '${WINDOW_MINUTES} minutes'
+     GROUP BY aice_id
+     HAVING COUNT(*) >= $1`,
+    [THRESHOLD],
+  );
+
+  for (const row of rows.rows) {
+    if (
+      await isDuplicate(pool, "bridge_abuse", DEFAULT_COOLDOWN_MINUTES, {
+        jsonPath: ["aiceId", row.aice_id],
+      })
+    )
+      continue;
+
+    await insertAlert({
+      indicator: "bridge_abuse",
+      summary: {
+        aiceId: row.aice_id,
+        requestCount: row.request_count,
+        windowMinutes: WINDOW_MINUTES,
+      },
+      auditLogIds: row.log_ids.map(Number),
+    });
+    count++;
+  }
+
+  return count;
+}

--- a/src/lib/detection/analyzers/concurrent-multi-ip.ts
+++ b/src/lib/detection/analyzers/concurrent-multi-ip.ts
@@ -1,0 +1,59 @@
+import type { Pool } from "pg";
+import { insertAlert } from "..";
+import { DEFAULT_COOLDOWN_MINUTES, isDuplicate } from "./deduplicate";
+
+const WINDOW_MINUTES = 30;
+
+/**
+ * Detect accounts that signed in from multiple IPs within a window.
+ * Uses recent sign_in_success events from audit_logs.
+ */
+export async function analyzeConcurrentMultiIp(pool: Pool): Promise<number> {
+  let count = 0;
+
+  const rows = await pool.query<{
+    actor_id: string;
+    ip_count: number;
+    ips: string[];
+    log_ids: string[];
+  }>(
+    `SELECT actor_id,
+            COUNT(DISTINCT ip_address)::int AS ip_count,
+            array_agg(DISTINCT ip_address) AS ips,
+            array_agg(id ORDER BY id) AS log_ids
+     FROM audit_logs
+     WHERE action IN ('general.auth.sign_in_success', 'admin.auth.sign_in_success')
+       AND ip_address IS NOT NULL
+       AND timestamp > NOW() - INTERVAL '${WINDOW_MINUTES} minutes'
+     GROUP BY actor_id
+     HAVING COUNT(DISTINCT ip_address) >= 2`,
+  );
+
+  for (const row of rows.rows) {
+    if (
+      await isDuplicate(
+        pool,
+        "concurrent_multi_ip_sessions",
+        DEFAULT_COOLDOWN_MINUTES,
+        {
+          actorId: row.actor_id,
+        },
+      )
+    )
+      continue;
+
+    await insertAlert({
+      indicator: "concurrent_multi_ip_sessions",
+      actorId: row.actor_id,
+      summary: {
+        ipCount: row.ip_count,
+        ips: row.ips,
+        windowMinutes: WINDOW_MINUTES,
+      },
+      auditLogIds: row.log_ids.map(Number),
+    });
+    count++;
+  }
+
+  return count;
+}

--- a/src/lib/detection/analyzers/consecutive-denials.ts
+++ b/src/lib/detection/analyzers/consecutive-denials.ts
@@ -1,0 +1,86 @@
+import type { Pool } from "pg";
+import { insertAlert } from "..";
+import { DEFAULT_COOLDOWN_MINUTES, isDuplicate } from "./deduplicate";
+
+const WINDOW_MINUTES = 15;
+const THRESHOLD = 5;
+
+const GROUPS = [
+  {
+    groupBy: "actor_id" as const,
+    sql: `SELECT actor_id, MIN(ip_address) AS ip_address,
+            COUNT(*)::int AS denial_count,
+            array_agg(id ORDER BY id) AS log_ids
+     FROM audit_logs
+     WHERE action IN ('general.auth.sign_in_denied', 'admin.auth.sign_in_denied')
+       AND timestamp > NOW() - INTERVAL '${WINDOW_MINUTES} minutes'
+     GROUP BY actor_id
+     HAVING COUNT(*) >= $1`,
+    dedupKey: (row: { actor_id: string }) => ({ actorId: row.actor_id }),
+    alertFields: (row: { actor_id: string; ip_address: string | null }) => ({
+      actorId: row.actor_id,
+      ipAddress: row.ip_address ?? undefined,
+    }),
+  },
+  {
+    groupBy: "ip_address" as const,
+    sql: `SELECT ip_address,
+            COUNT(*)::int AS denial_count,
+            array_agg(id ORDER BY id) AS log_ids
+     FROM audit_logs
+     WHERE action IN ('general.auth.sign_in_denied', 'admin.auth.sign_in_denied')
+       AND ip_address IS NOT NULL
+       AND timestamp > NOW() - INTERVAL '${WINDOW_MINUTES} minutes'
+     GROUP BY ip_address
+     HAVING COUNT(*) >= $1`,
+    dedupKey: (row: { ip_address: string }) => ({ ipAddress: row.ip_address }),
+    alertFields: (row: { ip_address: string }) => ({
+      ipAddress: row.ip_address,
+    }),
+  },
+] as const;
+
+/**
+ * Detect accounts or IPs with repeated sign-in denials within a window.
+ * Covers both general and admin auth contexts.
+ */
+export async function analyzeConsecutiveDenials(pool: Pool): Promise<number> {
+  let count = 0;
+
+  for (const group of GROUPS) {
+    const result = await pool.query<{
+      actor_id: string;
+      ip_address: string | null;
+      denial_count: number;
+      log_ids: string[];
+    }>(group.sql, [THRESHOLD]);
+
+    for (const row of result.rows) {
+      if (
+        await isDuplicate(
+          pool,
+          "consecutive_sign_in_denials",
+          DEFAULT_COOLDOWN_MINUTES,
+          // biome-ignore lint/suspicious/noExplicitAny: row shape varies by group
+          group.dedupKey(row as any),
+        )
+      )
+        continue;
+
+      await insertAlert({
+        indicator: "consecutive_sign_in_denials",
+        // biome-ignore lint/suspicious/noExplicitAny: row shape varies by group
+        ...group.alertFields(row as any),
+        summary: {
+          denialCount: row.denial_count,
+          windowMinutes: WINDOW_MINUTES,
+          groupedBy: group.groupBy,
+        },
+        auditLogIds: row.log_ids.map(Number),
+      });
+      count++;
+    }
+  }
+
+  return count;
+}

--- a/src/lib/detection/analyzers/deduplicate.ts
+++ b/src/lib/detection/analyzers/deduplicate.ts
@@ -1,0 +1,45 @@
+import type { Pool } from "pg";
+
+/** Default cooldown window for alert deduplication. */
+export const DEFAULT_COOLDOWN_MINUTES = 60;
+
+/**
+ * Check whether an alert with the given indicator already exists within
+ * the cooldown window. Returns true if a duplicate exists.
+ */
+export async function isDuplicate(
+  pool: Pool,
+  indicator: string,
+  cooldownMinutes: number,
+  match: { actorId?: string; ipAddress?: string; jsonPath?: [string, string] },
+): Promise<boolean> {
+  const conditions = [
+    "indicator = $1",
+    "created_at > NOW() - $2::int * INTERVAL '1 minute'",
+  ];
+  const values: unknown[] = [indicator, cooldownMinutes];
+  let idx = 3;
+
+  if (match.actorId) {
+    conditions.push(`actor_id = $${idx++}`);
+    values.push(match.actorId);
+  }
+  if (match.ipAddress) {
+    conditions.push(`ip_address = $${idx++}`);
+    values.push(match.ipAddress);
+  }
+  if (match.jsonPath) {
+    const keyIdx = idx++;
+    const valIdx = idx++;
+    conditions.push(`summary->>$${keyIdx} = $${valIdx}`);
+    values.push(match.jsonPath[0], match.jsonPath[1]);
+  }
+
+  const result = await pool.query(
+    `SELECT 1 FROM suspicious_activity_alerts
+     WHERE ${conditions.join(" AND ")}
+     LIMIT 1`,
+    values,
+  );
+  return result.rows.length > 0;
+}

--- a/src/lib/detection/analyzers/index.ts
+++ b/src/lib/detection/analyzers/index.ts
@@ -1,0 +1,29 @@
+import type { Pool } from "pg";
+import { analyzeBridgeAbuse } from "./bridge-abuse";
+import { analyzeConcurrentMultiIp } from "./concurrent-multi-ip";
+import { analyzeConsecutiveDenials } from "./consecutive-denials";
+import { analyzeSessionIpMismatch } from "./session-ip-mismatch";
+
+/**
+ * Run all periodic detection analyzers. Returns total alerts created.
+ */
+export async function runAllAnalyzers(pool: Pool): Promise<number> {
+  let total = 0;
+
+  const analyzers = [
+    analyzeConsecutiveDenials,
+    analyzeSessionIpMismatch,
+    analyzeConcurrentMultiIp,
+    analyzeBridgeAbuse,
+  ];
+
+  for (const analyze of analyzers) {
+    try {
+      total += await analyze(pool);
+    } catch (err) {
+      console.error(`[detection] Analyzer failed:`, err);
+    }
+  }
+
+  return total;
+}

--- a/src/lib/detection/analyzers/session-ip-mismatch.ts
+++ b/src/lib/detection/analyzers/session-ip-mismatch.ts
@@ -1,0 +1,56 @@
+import type { Pool } from "pg";
+import { insertAlert } from "..";
+import { DEFAULT_COOLDOWN_MINUTES, isDuplicate } from "./deduplicate";
+
+const WINDOW_MINUTES = 30;
+const THRESHOLD = 2;
+
+/**
+ * Detect sessions with IP or User-Agent changes mid-session.
+ * Relies on session.ip_mismatch and session.ua_mismatch audit events.
+ */
+export async function analyzeSessionIpMismatch(pool: Pool): Promise<number> {
+  let count = 0;
+
+  const rows = await pool.query<{
+    actor_id: string;
+    sid: string;
+    ip_address: string | null;
+    mismatch_count: number;
+    log_ids: string[];
+  }>(
+    `SELECT actor_id, sid, MIN(ip_address) AS ip_address,
+            COUNT(*)::int AS mismatch_count,
+            array_agg(id ORDER BY id) AS log_ids
+     FROM audit_logs
+     WHERE action IN ('session.ip_mismatch', 'session.ua_mismatch')
+       AND timestamp > NOW() - INTERVAL '${WINDOW_MINUTES} minutes'
+     GROUP BY actor_id, sid
+     HAVING COUNT(*) >= $1`,
+    [THRESHOLD],
+  );
+
+  for (const row of rows.rows) {
+    if (
+      await isDuplicate(pool, "session_ip_mismatch", DEFAULT_COOLDOWN_MINUTES, {
+        actorId: row.actor_id,
+      })
+    )
+      continue;
+
+    await insertAlert({
+      indicator: "session_ip_mismatch",
+      actorId: row.actor_id,
+      ipAddress: row.ip_address ?? undefined,
+      summary: {
+        sid: row.sid,
+        mismatchCount: row.mismatch_count,
+        windowMinutes: WINDOW_MINUTES,
+      },
+      auditLogIds: row.log_ids.map(Number),
+    });
+    count++;
+  }
+
+  return count;
+}

--- a/src/lib/detection/index.ts
+++ b/src/lib/detection/index.ts
@@ -1,0 +1,59 @@
+import "server-only";
+
+import { getCorrelationId } from "../audit/correlation";
+import { getAuditPool } from "../db/client";
+import type { AlertSeverity, SuspiciousIndicator } from "./indicators";
+import { severityOf } from "./indicators";
+
+export type { AlertSeverity, SuspiciousIndicator } from "./indicators";
+
+export interface AlertParams {
+  indicator: SuspiciousIndicator;
+  severity?: AlertSeverity;
+  actorId?: string;
+  ipAddress?: string;
+  summary: Record<string, unknown>;
+  auditLogIds?: number[];
+  correlationId?: string;
+}
+
+/**
+ * Insert a suspicious activity alert.
+ *
+ * Fire-and-forget: errors are logged to stderr but never thrown,
+ * so detection failures cannot break the request pipeline.
+ */
+export async function insertAlert(params: AlertParams): Promise<void> {
+  const severity = params.severity ?? severityOf(params.indicator);
+
+  try {
+    const pool = getAuditPool();
+    await pool.query(
+      `INSERT INTO suspicious_activity_alerts
+         (indicator, severity, actor_id, ip_address, summary,
+          audit_log_ids, correlation_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7::uuid)`,
+      [
+        params.indicator,
+        severity,
+        params.actorId ?? null,
+        params.ipAddress ?? null,
+        JSON.stringify(params.summary),
+        params.auditLogIds ?? [],
+        params.correlationId ?? getCorrelationId() ?? null,
+      ],
+    );
+  } catch (err) {
+    console.error("[detection] Failed to insert alert:", err);
+  }
+}
+
+/**
+ * Emit a severe alert synchronously at the call site.
+ * Convenience wrapper that forces severity to "severe".
+ */
+export async function emitSevereAlert(
+  params: Omit<AlertParams, "severity">,
+): Promise<void> {
+  return insertAlert({ ...params, severity: "severe" });
+}

--- a/src/lib/detection/indicators.ts
+++ b/src/lib/detection/indicators.ts
@@ -1,0 +1,35 @@
+/**
+ * Suspicious activity detection indicators per Discussion #10 §6.
+ */
+export type SuspiciousIndicator =
+  | "consecutive_sign_in_denials"
+  | "admin_auth_denial_pattern"
+  | "session_ip_mismatch"
+  | "concurrent_multi_ip_sessions"
+  | "bridge_abuse"
+  | "bridge_scope_probing"
+  | "suspended_account_sign_in";
+
+export type AlertSeverity = "severe" | "warning";
+
+/** All detection indicators, ordered for UI display. */
+export const ALL_INDICATORS: readonly SuspiciousIndicator[] = [
+  "consecutive_sign_in_denials",
+  "admin_auth_denial_pattern",
+  "session_ip_mismatch",
+  "concurrent_multi_ip_sessions",
+  "bridge_abuse",
+  "bridge_scope_probing",
+  "suspended_account_sign_in",
+] as const;
+
+/** Indicators that trigger immediate event-driven alerts. */
+export const SEVERE_INDICATORS = new Set<SuspiciousIndicator>([
+  "suspended_account_sign_in",
+  "admin_auth_denial_pattern",
+  "bridge_scope_probing",
+]);
+
+export function severityOf(indicator: SuspiciousIndicator): AlertSeverity {
+  return SEVERE_INDICATORS.has(indicator) ? "severe" : "warning";
+}


### PR DESCRIPTION
## Summary

- Implements two-path suspicious activity detection per Discussion #10 §6
- **Event-driven (severe)**: immediate alerts for suspended account sign-in, admin auth denial patterns (`acr_invalid`, `auth_time_too_old`), and bridge scope probing
- **Periodic analyzers**: consecutive sign-in denials, session IP/UA mismatch, concurrent multi-IP sessions, bridge abuse
- Session mismatch emits once per change by updating session IP/UA baseline after detection
- Alerts auto-inherit correlation IDs from AsyncLocalStorage
- Adds admin dashboard page with severity/indicator/date filters, auto-refresh, summary stats panel, cursor pagination, expandable row details, and i18n (EN/KO)
- New `suspicious_activity_alerts` table in `audit_db` (INSERT/SELECT only for runtime role)
- Three API endpoints: alerts list, summary counts, cron-triggered analysis

## Detection indicators

| Indicator | Path | Severity |
|-----------|------|----------|
| `suspended_account_sign_in` | Event-driven | Severe |
| `admin_auth_denial_pattern` | Event-driven | Severe |
| `bridge_scope_probing` | Event-driven | Severe |
| `consecutive_sign_in_denials` | Periodic | Warning |
| `session_ip_mismatch` | Periodic | Warning |
| `concurrent_multi_ip_sessions` | Periodic | Warning |
| `bridge_abuse` | Periodic | Warning |

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (425 tests)
- [x] `pnpm biome check` passes
- [x] CI: Check, Unit Test, DB Test, E2E, Image Build all pass
- [x] `suspicious-activity/page.tsx` exists and renders `SuspiciousActivityPage`
- [x] Admin sidebar has `ShieldAlert` nav item linking to `/admin/suspicious-activity`
- [x] `ko.json` has full `suspiciousActivity` namespace with Korean translations

Closes #117