### PR TITLE
Add guard-level audit and missing producers

### DIFF
--- a/src/app/api/admin/audit-logs/__tests__/route.unit.test.ts
+++ b/src/app/api/admin/audit-logs/__tests__/route.unit.test.ts
@@ -25,6 +25,7 @@ const mockWithAuth = vi.fn(
       meta: { ipAddress: "127.0.0.1", userAgent: "test" },
       bridgeAiceId: null,
       bridgeCustomerIds: null,
+      audit: {},
     }),
 );
 

--- a/src/app/api/admin/audit-retention/__tests__/route.unit.test.ts
+++ b/src/app/api/admin/audit-retention/__tests__/route.unit.test.ts
@@ -1,0 +1,139 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockPurge = vi.fn();
+const mockAuditMeta: Record<string, unknown> = {};
+
+vi.mock("@/lib/audit/retention", () => ({
+  purgeExpiredAuditLogs: (...args: unknown[]) => mockPurge(...args),
+}));
+
+vi.mock("@/lib/auth/guards", () => ({
+  // biome-ignore lint/complexity/noBannedTypes: test mock needs generic callable
+  withAuth: (handler: Function, _opts?: unknown) => (req: NextRequest) =>
+    handler(req, {
+      accountId: "acct-1",
+      sessionId: "sess-1",
+      authContext: "admin",
+      tokenVersion: 1,
+      iat: 1000,
+      meta: { ipAddress: "127.0.0.1", userAgent: "test" },
+      bridgeAiceId: null,
+      bridgeCustomerIds: null,
+      audit: mockAuditMeta,
+    }),
+  verifyOrigin: () => null,
+  verifyCsrf: () => null,
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  getMigrationAuditPool: vi.fn(() => ({})),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/admin/audit-retention", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const k of Object.keys(mockAuditMeta)) {
+      delete mockAuditMeta[k];
+    }
+    mockPurge.mockResolvedValue(10);
+  });
+
+  async function callPOST(body: unknown) {
+    const { POST } = await import("../route");
+    const req = new NextRequest(
+      "http://localhost:3000/api/admin/audit-retention",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify(body),
+      },
+    );
+    return POST(req);
+  }
+
+  it("purges with default retention and returns deleted count", async () => {
+    const res = await callPOST({});
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.deleted).toBe(10);
+    expect(mockPurge).toHaveBeenCalledWith(expect.anything(), undefined);
+  });
+
+  it("accepts custom retentionDays", async () => {
+    mockPurge.mockResolvedValue(5);
+
+    const res = await callPOST({ retentionDays: 90 });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.deleted).toBe(5);
+    expect(mockPurge).toHaveBeenCalledWith(expect.anything(), 90);
+  });
+
+  it("sets audit metadata for guard-level emission", async () => {
+    await callPOST({ retentionDays: 30 });
+
+    expect(mockAuditMeta.details).toEqual({
+      retentionDays: 30,
+      deleted: 10,
+    });
+  });
+
+  it("sets default retentionDays=365 in audit metadata when omitted", async () => {
+    await callPOST({});
+
+    expect(mockAuditMeta.details).toEqual({
+      retentionDays: 365,
+      deleted: 10,
+    });
+  });
+
+  it("returns 400 for non-integer retentionDays", async () => {
+    const res = await callPOST({ retentionDays: 1.5 });
+    expect(res.status).toBe(400);
+    expect(mockPurge).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for retentionDays < 1", async () => {
+    const res = await callPOST({ retentionDays: 0 });
+    expect(res.status).toBe(400);
+    expect(mockPurge).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for non-number retentionDays", async () => {
+    const res = await callPOST({ retentionDays: "abc" });
+    expect(res.status).toBe(400);
+    expect(mockPurge).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const { POST } = await import("../route");
+    const req = new NextRequest(
+      "http://localhost:3000/api/admin/audit-retention",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: "not-json",
+      },
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(mockPurge).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/admin/audit-retention/route.ts
+++ b/src/app/api/admin/audit-retention/route.ts
@@ -1,0 +1,52 @@
+import type { NextRequest } from "next/server";
+import { purgeExpiredAuditLogs } from "@/lib/audit/retention";
+import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
+import { getMigrationAuditPool } from "@/lib/db/client";
+
+export const POST = withAuth(
+  async (req: NextRequest, auth) => {
+    const originErr = verifyOrigin(req);
+    if (originErr) return originErr;
+
+    const csrfErr = verifyCsrf(req, {
+      ctx: "admin",
+      sid: auth.sessionId,
+      iat: auth.iat,
+    });
+    if (csrfErr) return csrfErr;
+
+    let retentionDays: number | undefined;
+    try {
+      const body = await req.json();
+      if (
+        typeof body === "object" &&
+        body !== null &&
+        "retentionDays" in body
+      ) {
+        const val = body.retentionDays;
+        if (typeof val !== "number" || !Number.isInteger(val) || val < 1) {
+          return Response.json(
+            { error: "retentionDays must be a positive integer" },
+            { status: 400 },
+          );
+        }
+        retentionDays = val;
+      }
+    } catch {
+      return Response.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const deleted = await purgeExpiredAuditLogs(
+      getMigrationAuditPool(),
+      retentionDays,
+    );
+
+    auth.audit.details = { retentionDays: retentionDays ?? 365, deleted };
+
+    return Response.json({ deleted });
+  },
+  {
+    ctx: "admin",
+    audit: { action: "system.settings_updated", targetType: "audit-retention" },
+  },
+);

--- a/src/app/api/admin/customers/[customerId]/route.ts
+++ b/src/app/api/admin/customers/[customerId]/route.ts
@@ -1,5 +1,4 @@
 import type { NextRequest } from "next/server";
-import { auditLog } from "@/lib/audit";
 import { deleteCustomer } from "@/lib/auth/delete-customer";
 import { HttpError } from "@/lib/auth/errors";
 import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
@@ -26,7 +25,12 @@ export const DELETE = withAuth(
     }
 
     try {
-      await deleteCustomer(getAuthPool(), getMigrationAuditPool(), customerId);
+      await deleteCustomer(getAuthPool(), getMigrationAuditPool(), customerId, {
+        actorId: auth.accountId,
+        authContext: "admin",
+        ipAddress: auth.meta.ipAddress,
+        sid: auth.sessionId,
+      });
     } catch (err) {
       if (err instanceof HttpError) {
         return Response.json(
@@ -37,17 +41,12 @@ export const DELETE = withAuth(
       throw err;
     }
 
-    void auditLog({
-      actorId: auth.accountId,
-      authContext: "admin",
-      action: "customer.deleted",
-      targetType: "customer",
-      targetId: customerId,
-      ipAddress: auth.meta.ipAddress,
-      sid: auth.sessionId,
-    });
+    auth.audit.targetId = customerId;
 
     return new Response(null, { status: 204 });
   },
-  { ctx: "admin" },
+  {
+    ctx: "admin",
+    audit: { action: "customer.deleted", targetType: "customer" },
+  },
 );

--- a/src/app/api/admin/customers/route.ts
+++ b/src/app/api/admin/customers/route.ts
@@ -1,5 +1,4 @@
 import type { NextRequest } from "next/server";
-import { auditLog } from "@/lib/audit";
 import { createCustomer } from "@/lib/auth/customers";
 import { HttpError } from "@/lib/auth/errors";
 import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
@@ -87,18 +86,22 @@ export const POST = withAuth(
 
       // Provision customer database after auth_db transaction commits
       const pool = getAuthPool();
-      const databaseStatus = await provisionCustomerDb(pool, result.id);
-
-      void auditLog({
-        actorId: auth.accountId,
-        authContext: "admin",
-        action: "customer.created",
-        targetType: "customer",
-        targetId: result.id,
-        details: { name, externalKey, managerAccountId, databaseStatus },
-        ipAddress: auth.meta.ipAddress,
-        sid: auth.sessionId,
+      const databaseStatus = await provisionCustomerDb(pool, result.id, {
+        actorContext: {
+          actorId: auth.accountId,
+          authContext: "admin",
+          ipAddress: auth.meta.ipAddress,
+          sid: auth.sessionId,
+        },
       });
+
+      auth.audit.targetId = result.id;
+      auth.audit.details = {
+        name,
+        externalKey,
+        managerAccountId,
+        databaseStatus,
+      };
 
       return Response.json(
         {
@@ -120,5 +123,8 @@ export const POST = withAuth(
       throw err;
     }
   },
-  { ctx: "admin" },
+  {
+    ctx: "admin",
+    audit: { action: "customer.created", targetType: "customer" },
+  },
 );

--- a/src/app/api/admin/kek/rotate/route.ts
+++ b/src/app/api/admin/kek/rotate/route.ts
@@ -1,5 +1,4 @@
 import type { NextRequest } from "next/server";
-import { auditLog } from "@/lib/audit";
 import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
 import { rotateAllKeks } from "@/lib/auth/kek-rotation";
 import { getAuthPool } from "@/lib/db/client";
@@ -18,23 +17,18 @@ export const POST = withAuth(
 
     const result = await rotateAllKeks(getAuthPool());
 
-    void auditLog({
-      actorId: auth.accountId,
-      authContext: "admin",
-      action: "openbao.kek_rotated",
-      targetType: "system",
-      details: {
-        customersRotated: result.customersRotated,
-        customersErrored: result.customersErrored,
-        customerDeksRewrapped: result.customerDeksRewrapped,
-        eventDeksRewrapped: result.eventDeksRewrapped,
-        stagingDeksRewrapped: result.stagingDeksRewrapped,
-      },
-      ipAddress: auth.meta.ipAddress,
-      sid: auth.sessionId,
-    });
+    auth.audit.details = {
+      customersRotated: result.customersRotated,
+      customersErrored: result.customersErrored,
+      customerDeksRewrapped: result.customerDeksRewrapped,
+      eventDeksRewrapped: result.eventDeksRewrapped,
+      stagingDeksRewrapped: result.stagingDeksRewrapped,
+    };
 
     return Response.json(result);
   },
-  { ctx: "admin" },
+  {
+    ctx: "admin",
+    audit: { action: "openbao.kek_rotated", targetType: "system" },
+  },
 );

--- a/src/app/api/admin/session-policy/route.ts
+++ b/src/app/api/admin/session-policy/route.ts
@@ -1,5 +1,4 @@
 import type { NextRequest } from "next/server";
-import { auditLog } from "@/lib/audit";
 import { HttpError } from "@/lib/auth/errors";
 import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
 import {
@@ -56,16 +55,8 @@ export const PUT = withAuth(
 
       clearSessionPolicyCache();
 
-      void auditLog({
-        actorId: auth.accountId,
-        authContext: "admin",
-        action: "system.settings_updated",
-        targetType: "system-settings",
-        targetId: "session_policy",
-        details: { policy },
-        ipAddress: auth.meta.ipAddress,
-        sid: auth.sessionId,
-      });
+      auth.audit.targetId = "session_policy";
+      auth.audit.details = { policy };
 
       return Response.json({ policy });
     } catch (err: unknown) {
@@ -78,5 +69,8 @@ export const PUT = withAuth(
       throw err;
     }
   },
-  { ctx: "admin" },
+  {
+    ctx: "admin",
+    audit: { action: "system.settings_updated", targetType: "system-settings" },
+  },
 );

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -155,7 +155,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         void auditLog({
           actorId: account.id,
           authContext: "general",
-          action: "invitation.failed",
+          action:
+            result.deny === "invitation_expired"
+              ? "invitation.expired"
+              : "invitation.failed",
           targetType: "invitation",
           details: { reason: result.deny },
           ipAddress: meta.ipAddress,

--- a/src/app/api/events/__tests__/ingest.unit.test.ts
+++ b/src/app/api/events/__tests__/ingest.unit.test.ts
@@ -20,6 +20,7 @@ const mockWithAuth = vi.fn(
       meta: { ipAddress: "127.0.0.1", userAgent: "test" },
       bridgeAiceId: null,
       bridgeCustomerIds: null,
+      audit: {},
     }),
 );
 
@@ -171,6 +172,7 @@ describe("POST /api/events/ingest", () => {
           meta: { ipAddress: "127.0.0.1", userAgent: "test" },
           bridgeAiceId: "aice-1",
           bridgeCustomerIds: [CUSTOMER_ID],
+          audit: {},
         }),
     );
 
@@ -205,6 +207,44 @@ describe("POST /api/events/ingest", () => {
         },
       }),
     );
+  });
+
+  it("emits bridge.write_attempt_blocked when authorize returns bridge_write_blocked", async () => {
+    mockAuthorize.mockResolvedValue({
+      authorized: false,
+      reason: "bridge_write_blocked",
+    });
+
+    const file = new File([new Uint8Array([1, 2, 3])], "events.bin");
+    const req = makeIngestRequest({
+      events_data: file,
+      customer_id: CUSTOMER_ID,
+      aice_id: "aice-1",
+      schema_version: "1.0",
+      event_count: "5",
+    });
+
+    const res = await callPOST(req);
+    expect(res.status).toBe(403);
+
+    // Should emit both bridge.write_attempt_blocked AND upload_denied
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "bridge.write_attempt_blocked",
+        details: expect.objectContaining({
+          operation: "ingest",
+        }),
+      }),
+    );
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "detection_events.upload_denied",
+        details: expect.objectContaining({
+          reason: "bridge_write_blocked",
+        }),
+      }),
+    );
+    expect(mockAuditLog).toHaveBeenCalledTimes(2);
   });
 
   it("returns 400 when events_data is missing", async () => {

--- a/src/app/api/events/__tests__/staged-approve.unit.test.ts
+++ b/src/app/api/events/__tests__/staged-approve.unit.test.ts
@@ -47,6 +47,7 @@ vi.mock("@/lib/auth/guards", () => ({
         "b0000000-0000-0000-0000-000000000001",
         "b0000000-0000-0000-0000-000000000002",
       ],
+      audit: {},
     }),
   verifyOrigin: () => null,
   verifyCsrf: () => null,
@@ -276,6 +277,37 @@ describe("PATCH /api/events/staged/[payloadId]/customers/[customerId]", () => {
         }),
       }),
     );
+  });
+
+  it("emits bridge.write_attempt_blocked when authorize returns bridge_write_blocked", async () => {
+    mockAuthorize.mockResolvedValue({
+      authorized: false,
+      reason: "bridge_write_blocked",
+    });
+
+    const res = await callPATCH(PAYLOAD_ID, CUSTOMER_ID, {
+      action: "approve",
+    });
+    expect(res.status).toBe(403);
+
+    // Should emit both bridge.write_attempt_blocked AND transfer_denied
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "bridge.write_attempt_blocked",
+        details: expect.objectContaining({
+          operation: "approve",
+        }),
+      }),
+    );
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "detection_events.transfer_denied",
+        details: expect.objectContaining({
+          reason: "bridge_write_blocked",
+        }),
+      }),
+    );
+    expect(mockAuditLog).toHaveBeenCalledTimes(2);
   });
 
   it("returns 403 for customer not in bridgeCustomerIds", async () => {

--- a/src/app/api/events/__tests__/staged-detail.unit.test.ts
+++ b/src/app/api/events/__tests__/staged-detail.unit.test.ts
@@ -26,6 +26,7 @@ vi.mock("@/lib/auth/guards", () => ({
       meta: { ipAddress: "127.0.0.1", userAgent: "test" },
       bridgeAiceId: null,
       bridgeCustomerIds: null,
+      audit: {},
     }),
 }));
 

--- a/src/app/api/events/__tests__/staged-list.unit.test.ts
+++ b/src/app/api/events/__tests__/staged-list.unit.test.ts
@@ -24,6 +24,7 @@ vi.mock("@/lib/auth/guards", () => ({
       meta: { ipAddress: "127.0.0.1", userAgent: "test" },
       bridgeAiceId: null,
       bridgeCustomerIds: null,
+      audit: {},
     }),
 }));
 

--- a/src/app/api/events/ingest/route.ts
+++ b/src/app/api/events/ingest/route.ts
@@ -112,6 +112,17 @@ export const POST = withAuth(async (req: NextRequest, auth) => {
   };
 
   if (!authResult.authorized) {
+    if (authResult.reason === "bridge_write_blocked") {
+      void auditLog({
+        ...auditBase,
+        action: "bridge.write_attempt_blocked",
+        details: {
+          customerId: customerIdField,
+          aiceId: aiceIdField,
+          operation: "ingest",
+        },
+      });
+    }
     void auditLog({
       ...auditBase,
       action: "detection_events.upload_denied",
@@ -119,7 +130,7 @@ export const POST = withAuth(async (req: NextRequest, auth) => {
       details: {
         customerId: customerIdField,
         aiceId: aiceIdField,
-        reason: "authorization_failed",
+        reason: authResult.reason ?? "authorization_failed",
       },
     });
     return Response.json({ error: "Forbidden" }, { status: 403 });

--- a/src/app/api/events/staged/[payloadId]/customers/[customerId]/route.ts
+++ b/src/app/api/events/staged/[payloadId]/customers/[customerId]/route.ts
@@ -122,10 +122,20 @@ export const PATCH = withAuth(async (req: NextRequest, auth) => {
   };
 
   if (!authResult.authorized) {
+    if (authResult.reason === "bridge_write_blocked") {
+      void auditLog({
+        ...auditBase,
+        action: "bridge.write_attempt_blocked" satisfies AuditAction,
+        details: { customerId, aiceId: staged.aice_id, operation: "approve" },
+      });
+    }
     void auditLog({
       ...auditBase,
       action: "detection_events.transfer_denied" satisfies AuditAction,
-      details: { customerId, reason: "authorization_failed" },
+      details: {
+        customerId,
+        reason: authResult.reason ?? "authorization_failed",
+      },
     });
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }

--- a/src/app/api/invitations/[id]/route.ts
+++ b/src/app/api/invitations/[id]/route.ts
@@ -1,5 +1,4 @@
 import type { NextRequest } from "next/server";
-import { auditLog } from "@/lib/audit";
 import { HttpError } from "@/lib/auth/errors";
 import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
 import { revokeInvitation } from "@/lib/auth/invitation-management";
@@ -8,41 +7,39 @@ import { getAuthPool } from "@/lib/db/client";
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-export const DELETE = withAuth(async (req: NextRequest, auth) => {
-  const originErr = verifyOrigin(req);
-  if (originErr) return originErr;
+export const DELETE = withAuth(
+  async (req: NextRequest, auth) => {
+    const originErr = verifyOrigin(req);
+    if (originErr) return originErr;
 
-  const csrfErr = verifyCsrf(req, {
-    ctx: "general",
-    sid: auth.sessionId,
-    iat: auth.iat,
-  });
-  if (csrfErr) return csrfErr;
-
-  // Extract invitation ID from the URL path
-  const id = req.nextUrl.pathname.split("/").pop();
-  if (!id || !UUID_RE.test(id)) {
-    return Response.json({ error: "Invalid invitation ID" }, { status: 400 });
-  }
-
-  try {
-    await revokeInvitation(getAuthPool(), auth.accountId, id);
-
-    void auditLog({
-      actorId: auth.accountId,
-      authContext: "general",
-      action: "invitation.revoked",
-      targetType: "invitation",
-      targetId: id,
-      ipAddress: auth.meta.ipAddress,
+    const csrfErr = verifyCsrf(req, {
+      ctx: "general",
       sid: auth.sessionId,
+      iat: auth.iat,
     });
+    if (csrfErr) return csrfErr;
 
-    return new Response(null, { status: 204 });
-  } catch (err: unknown) {
-    if (err instanceof HttpError) {
-      return Response.json({ error: err.message }, { status: err.statusCode });
+    // Extract invitation ID from the URL path
+    const id = req.nextUrl.pathname.split("/").pop();
+    if (!id || !UUID_RE.test(id)) {
+      return Response.json({ error: "Invalid invitation ID" }, { status: 400 });
     }
-    throw err;
-  }
-});
+
+    try {
+      await revokeInvitation(getAuthPool(), auth.accountId, id);
+
+      auth.audit.targetId = id;
+
+      return new Response(null, { status: 204 });
+    } catch (err: unknown) {
+      if (err instanceof HttpError) {
+        return Response.json(
+          { error: err.message },
+          { status: err.statusCode },
+        );
+      }
+      throw err;
+    }
+  },
+  { audit: { action: "invitation.revoked", targetType: "invitation" } },
+);

--- a/src/app/api/invitations/route.ts
+++ b/src/app/api/invitations/route.ts
@@ -1,5 +1,4 @@
 import type { NextRequest } from "next/server";
-import { auditLog } from "@/lib/audit";
 import { HttpError } from "@/lib/auth/errors";
 import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
 import { listPendingInvitations } from "@/lib/auth/invitation-management";
@@ -42,91 +41,91 @@ export const GET = withAuth(async (req: NextRequest, auth) => {
 // POST /api/invitations
 // ---------------------------------------------------------------------------
 
-export const POST = withAuth(async (req: NextRequest, auth) => {
-  const originErr = verifyOrigin(req);
-  if (originErr) return originErr;
+export const POST = withAuth(
+  async (req: NextRequest, auth) => {
+    const originErr = verifyOrigin(req);
+    if (originErr) return originErr;
 
-  const csrfErr = verifyCsrf(req, {
-    ctx: "general",
-    sid: auth.sessionId,
-    iat: auth.iat,
-  });
-  if (csrfErr) return csrfErr;
-
-  // Parse and validate request body
-  let raw: unknown;
-  try {
-    raw = await req.json();
-  } catch {
-    return Response.json({ error: "Invalid JSON" }, { status: 400 });
-  }
-
-  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
-    return Response.json(
-      { error: "Request body must be a JSON object" },
-      { status: 400 },
-    );
-  }
-
-  const { customerId, email, role } = raw as Record<string, unknown>;
-  if (
-    typeof customerId !== "string" ||
-    typeof email !== "string" ||
-    typeof role !== "string"
-  ) {
-    return Response.json(
-      { error: "customerId, email, and role are required strings" },
-      { status: 400 },
-    );
-  }
-
-  if (!UUID_RE.test(customerId)) {
-    return Response.json(
-      { error: "Invalid customerId format" },
-      { status: 400 },
-    );
-  }
-
-  try {
-    const result = await withTransaction(getAuthPool(), (client) =>
-      createInvitation(client, {
-        accountId: auth.accountId,
-        customerId,
-        email,
-        roleName: role,
-      }),
-    );
-
-    void auditLog({
-      actorId: auth.accountId,
-      authContext: "general",
-      action: "invitation.created",
-      targetType: "invitation",
-      targetId: result.id,
-      details: { customerId, email, role },
-      ipAddress: auth.meta.ipAddress,
+    const csrfErr = verifyCsrf(req, {
+      ctx: "general",
       sid: auth.sessionId,
-      customerId,
+      iat: auth.iat,
     });
+    if (csrfErr) return csrfErr;
 
-    // Fire-and-forget: email failure must not affect the API response.
-    sendInvitationEmail({
-      to: email,
-      token: result.token,
-      customerName: result.customerName,
-      roleName: role,
-      expiresAt: result.expiresAt,
-      baseUrl: req.nextUrl.origin,
-    }).catch((err) => console.error("[email] Failed to send invitation:", err));
-
-    return Response.json(
-      { id: result.id, expiresAt: result.expiresAt.toISOString() },
-      { status: 201 },
-    );
-  } catch (err: unknown) {
-    if (err instanceof HttpError) {
-      return Response.json({ error: err.message }, { status: err.statusCode });
+    // Parse and validate request body
+    let raw: unknown;
+    try {
+      raw = await req.json();
+    } catch {
+      return Response.json({ error: "Invalid JSON" }, { status: 400 });
     }
-    throw err;
-  }
-});
+
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+      return Response.json(
+        { error: "Request body must be a JSON object" },
+        { status: 400 },
+      );
+    }
+
+    const { customerId, email, role } = raw as Record<string, unknown>;
+    if (
+      typeof customerId !== "string" ||
+      typeof email !== "string" ||
+      typeof role !== "string"
+    ) {
+      return Response.json(
+        { error: "customerId, email, and role are required strings" },
+        { status: 400 },
+      );
+    }
+
+    if (!UUID_RE.test(customerId)) {
+      return Response.json(
+        { error: "Invalid customerId format" },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const result = await withTransaction(getAuthPool(), (client) =>
+        createInvitation(client, {
+          accountId: auth.accountId,
+          customerId,
+          email,
+          roleName: role,
+        }),
+      );
+
+      auth.audit.targetId = result.id;
+      auth.audit.details = { customerId, email, role };
+      auth.audit.customerId = customerId;
+
+      // Fire-and-forget: email failure must not affect the API response.
+      sendInvitationEmail({
+        to: email,
+        token: result.token,
+        customerName: result.customerName,
+        roleName: role,
+        expiresAt: result.expiresAt,
+        baseUrl: req.nextUrl.origin,
+      }).catch((err) =>
+        console.error("[email] Failed to send invitation:", err),
+      );
+
+      return Response.json(
+        { id: result.id, expiresAt: result.expiresAt.toISOString() },
+        { status: 201 },
+      );
+    } catch (err: unknown) {
+      if (err instanceof HttpError) {
+        return Response.json(
+          { error: err.message },
+          { status: err.statusCode },
+        );
+      }
+      throw err;
+    }
+  },
+  { audit: { action: "invitation.created", targetType: "invitation" } },
+);

--- a/src/app/api/members/[accountId]/route.ts
+++ b/src/app/api/members/[accountId]/route.ts
@@ -1,5 +1,4 @@
 import type { NextRequest } from "next/server";
-import { auditLog } from "@/lib/audit";
 import { HttpError } from "@/lib/auth/errors";
 import { verifyCsrf, verifyOrigin, withAuth } from "@/lib/auth/guards";
 import { changeRole, removeMember } from "@/lib/auth/members";
@@ -12,149 +11,145 @@ const UUID_RE =
 // DELETE /api/members/:accountId?customer_id=...
 // ---------------------------------------------------------------------------
 
-export const DELETE = withAuth(async (req: NextRequest, auth) => {
-  const originErr = verifyOrigin(req);
-  if (originErr) return originErr;
+export const DELETE = withAuth(
+  async (req: NextRequest, auth) => {
+    const originErr = verifyOrigin(req);
+    if (originErr) return originErr;
 
-  const csrfErr = verifyCsrf(req, {
-    ctx: "general",
-    sid: auth.sessionId,
-    iat: auth.iat,
-  });
-  if (csrfErr) return csrfErr;
-
-  const targetAccountId = req.nextUrl.pathname.split("/").pop();
-  if (!targetAccountId || !UUID_RE.test(targetAccountId)) {
-    return Response.json(
-      { error: "Invalid accountId format" },
-      { status: 400 },
-    );
-  }
-
-  const customerId = req.nextUrl.searchParams.get("customer_id");
-  if (!customerId || !UUID_RE.test(customerId)) {
-    return Response.json(
-      { error: "customer_id query parameter is required" },
-      { status: 400 },
-    );
-  }
-
-  try {
-    await withTransaction(getAuthPool(), (client) =>
-      removeMember(client, {
-        accountId: auth.accountId,
-        targetAccountId,
-        customerId,
-      }),
-    );
-
-    void auditLog({
-      actorId: auth.accountId,
-      authContext: "general",
-      action: "membership.removed",
-      targetType: "membership",
-      targetId: targetAccountId,
-      details: { customerId },
-      ipAddress: auth.meta.ipAddress,
+    const csrfErr = verifyCsrf(req, {
+      ctx: "general",
       sid: auth.sessionId,
-      customerId,
+      iat: auth.iat,
     });
+    if (csrfErr) return csrfErr;
 
-    return new Response(null, { status: 204 });
-  } catch (err: unknown) {
-    if (err instanceof HttpError) {
-      return Response.json({ error: err.message }, { status: err.statusCode });
+    const targetAccountId = req.nextUrl.pathname.split("/").pop();
+    if (!targetAccountId || !UUID_RE.test(targetAccountId)) {
+      return Response.json(
+        { error: "Invalid accountId format" },
+        { status: 400 },
+      );
     }
-    throw err;
-  }
-});
+
+    const customerId = req.nextUrl.searchParams.get("customer_id");
+    if (!customerId || !UUID_RE.test(customerId)) {
+      return Response.json(
+        { error: "customer_id query parameter is required" },
+        { status: 400 },
+      );
+    }
+
+    try {
+      await withTransaction(getAuthPool(), (client) =>
+        removeMember(client, {
+          accountId: auth.accountId,
+          targetAccountId,
+          customerId,
+        }),
+      );
+
+      auth.audit.targetId = targetAccountId;
+      auth.audit.details = { customerId };
+      auth.audit.customerId = customerId;
+
+      return new Response(null, { status: 204 });
+    } catch (err: unknown) {
+      if (err instanceof HttpError) {
+        return Response.json(
+          { error: err.message },
+          { status: err.statusCode },
+        );
+      }
+      throw err;
+    }
+  },
+  { audit: { action: "membership.removed", targetType: "membership" } },
+);
 
 // ---------------------------------------------------------------------------
 // PATCH /api/members/:accountId
 // ---------------------------------------------------------------------------
 
-export const PATCH = withAuth(async (req: NextRequest, auth) => {
-  const originErr = verifyOrigin(req);
-  if (originErr) return originErr;
+export const PATCH = withAuth(
+  async (req: NextRequest, auth) => {
+    const originErr = verifyOrigin(req);
+    if (originErr) return originErr;
 
-  const csrfErr = verifyCsrf(req, {
-    ctx: "general",
-    sid: auth.sessionId,
-    iat: auth.iat,
-  });
-  if (csrfErr) return csrfErr;
-
-  const targetAccountId = req.nextUrl.pathname.split("/").pop();
-  if (!targetAccountId || !UUID_RE.test(targetAccountId)) {
-    return Response.json(
-      { error: "Invalid accountId format" },
-      { status: 400 },
-    );
-  }
-
-  // Parse body
-  let raw: unknown;
-  try {
-    raw = await req.json();
-  } catch {
-    return Response.json({ error: "Invalid JSON" }, { status: 400 });
-  }
-
-  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
-    return Response.json(
-      { error: "Request body must be a JSON object" },
-      { status: 400 },
-    );
-  }
-
-  const { customerId, roleId } = raw as Record<string, unknown>;
-  if (
-    typeof customerId !== "string" ||
-    typeof roleId !== "number" ||
-    !Number.isInteger(roleId) ||
-    roleId < -2147483648 ||
-    roleId > 2147483647
-  ) {
-    return Response.json(
-      { error: "customerId (string) and roleId (integer) are required" },
-      { status: 400 },
-    );
-  }
-
-  if (!UUID_RE.test(customerId)) {
-    return Response.json(
-      { error: "Invalid customerId format" },
-      { status: 400 },
-    );
-  }
-
-  try {
-    await withTransaction(getAuthPool(), (client) =>
-      changeRole(client, {
-        accountId: auth.accountId,
-        targetAccountId,
-        customerId,
-        roleId,
-      }),
-    );
-
-    void auditLog({
-      actorId: auth.accountId,
-      authContext: "general",
-      action: "membership.role_changed",
-      targetType: "membership",
-      targetId: targetAccountId,
-      details: { customerId, roleId },
-      ipAddress: auth.meta.ipAddress,
+    const csrfErr = verifyCsrf(req, {
+      ctx: "general",
       sid: auth.sessionId,
-      customerId,
+      iat: auth.iat,
     });
+    if (csrfErr) return csrfErr;
 
-    return new Response(null, { status: 204 });
-  } catch (err: unknown) {
-    if (err instanceof HttpError) {
-      return Response.json({ error: err.message }, { status: err.statusCode });
+    const targetAccountId = req.nextUrl.pathname.split("/").pop();
+    if (!targetAccountId || !UUID_RE.test(targetAccountId)) {
+      return Response.json(
+        { error: "Invalid accountId format" },
+        { status: 400 },
+      );
     }
-    throw err;
-  }
-});
+
+    // Parse body
+    let raw: unknown;
+    try {
+      raw = await req.json();
+    } catch {
+      return Response.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+      return Response.json(
+        { error: "Request body must be a JSON object" },
+        { status: 400 },
+      );
+    }
+
+    const { customerId, roleId } = raw as Record<string, unknown>;
+    if (
+      typeof customerId !== "string" ||
+      typeof roleId !== "number" ||
+      !Number.isInteger(roleId) ||
+      roleId < -2147483648 ||
+      roleId > 2147483647
+    ) {
+      return Response.json(
+        { error: "customerId (string) and roleId (integer) are required" },
+        { status: 400 },
+      );
+    }
+
+    if (!UUID_RE.test(customerId)) {
+      return Response.json(
+        { error: "Invalid customerId format" },
+        { status: 400 },
+      );
+    }
+
+    try {
+      await withTransaction(getAuthPool(), (client) =>
+        changeRole(client, {
+          accountId: auth.accountId,
+          targetAccountId,
+          customerId,
+          roleId,
+        }),
+      );
+
+      auth.audit.targetId = targetAccountId;
+      auth.audit.details = { customerId, roleId };
+      auth.audit.customerId = customerId;
+
+      return new Response(null, { status: 204 });
+    } catch (err: unknown) {
+      if (err instanceof HttpError) {
+        return Response.json(
+          { error: err.message },
+          { status: err.statusCode },
+        );
+      }
+      throw err;
+    }
+  },
+  { audit: { action: "membership.role_changed", targetType: "membership" } },
+);

--- a/src/lib/audit/__tests__/retention.unit.test.ts
+++ b/src/lib/audit/__tests__/retention.unit.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { purgeExpiredAuditLogs } = await import("../retention");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("purgeExpiredAuditLogs", () => {
+  it("deletes anonymized rows older than retention window", async () => {
+    const mockQuery = vi.fn().mockResolvedValue({ rowCount: 42 });
+    const pool = { query: mockQuery } as never;
+
+    const result = await purgeExpiredAuditLogs(pool, 90);
+
+    expect(result).toBe(42);
+    expect(mockQuery).toHaveBeenCalledOnce();
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("ip_address IS NULL"),
+      [90],
+    );
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("make_interval(days => $1)"),
+      [90],
+    );
+  });
+
+  it("defaults to 365 days when retentionDays is omitted", async () => {
+    const mockQuery = vi.fn().mockResolvedValue({ rowCount: 0 });
+    const pool = { query: mockQuery } as never;
+
+    await purgeExpiredAuditLogs(pool);
+
+    expect(mockQuery).toHaveBeenCalledWith(expect.any(String), [365]);
+  });
+
+  it("returns 0 when rowCount is null", async () => {
+    const mockQuery = vi.fn().mockResolvedValue({ rowCount: null });
+    const pool = { query: mockQuery } as never;
+
+    const result = await purgeExpiredAuditLogs(pool);
+
+    expect(result).toBe(0);
+  });
+});

--- a/src/lib/audit/__tests__/taxonomy-completeness.test.ts
+++ b/src/lib/audit/__tests__/taxonomy-completeness.test.ts
@@ -1,0 +1,239 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { AuditAction } from "../actions";
+
+// ---------------------------------------------------------------------------
+// Extract all AuditAction string values from the source file
+// ---------------------------------------------------------------------------
+
+const ACTIONS_FILE = join(__dirname, "..", "actions.ts");
+
+function extractAuditActions(): string[] {
+  const source = readFileSync(ACTIONS_FILE, "utf-8");
+  const matches = source.match(/"([a-z][a-z0-9_.]+)"/g);
+  if (!matches) throw new Error("No AuditAction strings found in actions.ts");
+  return matches.map((m) => m.slice(1, -1));
+}
+
+// ---------------------------------------------------------------------------
+// Producer map — actions that have a verified emitter in production code.
+// Guard-level audit (via withAuth `audit` option) counts as a producer.
+// ---------------------------------------------------------------------------
+
+const PRODUCED: Record<string, string> = {
+  // General auth
+  "general.auth.sign_in_success": "src/app/api/auth/callback/route.ts",
+  "general.auth.sign_in_denied": "src/app/api/auth/callback/route.ts",
+  "general.auth.sign_out": "src/app/api/auth/sign-out/route.ts",
+  "general.auth.sign_out_all": "src/app/api/auth/sign-out-all/route.ts",
+  // Admin auth
+  "admin.auth.sign_in_success": "src/app/api/admin-auth/callback/route.ts",
+  "admin.auth.sign_in_denied": "src/app/api/admin-auth/callback/route.ts",
+  "admin.auth.sign_out": "src/app/api/admin-auth/sign-out/route.ts",
+  "admin.auth.sign_out_all": "src/app/api/admin-auth/sign-out-all/route.ts",
+  // Session
+  "session.ip_mismatch": "src/lib/auth/guards.ts",
+  "session.ua_mismatch": "src/lib/auth/guards.ts",
+  "session.idle_timeout": "src/lib/auth/guards.ts",
+  "session.absolute_timeout": "src/lib/auth/guards.ts",
+  "session.revoked": "src/lib/auth/guards.ts",
+  "session.cross_context_mismatch": "src/lib/auth/same-account.ts",
+  // Bridge
+  "bridge.connection_request": "src/app/api/auth/bridge/route.ts",
+  "bridge.connection_granted": "src/app/api/auth/callback/route.ts",
+  "bridge.connection_denied": "src/app/api/auth/callback/route.ts",
+  "bridge.write_attempt_blocked": "src/app/api/events/ingest/route.ts",
+  // Invitation (guard-level: created, revoked; handler-level: accepted, failed, expired)
+  "invitation.created": "src/app/api/invitations/route.ts",
+  "invitation.accepted": "src/app/api/auth/callback/route.ts",
+  "invitation.failed": "src/app/api/auth/callback/route.ts",
+  "invitation.expired": "src/app/api/auth/callback/route.ts",
+  "invitation.revoked": "src/app/api/invitations/[id]/route.ts",
+  // Membership (guard-level: role_changed, removed)
+  "membership.role_changed": "src/app/api/members/[accountId]/route.ts",
+  "membership.removed": "src/app/api/members/[accountId]/route.ts",
+  // Customer (guard-level: created, deleted)
+  "customer.created": "src/app/api/admin/customers/route.ts",
+  "customer.deleted": "src/app/api/admin/customers/[customerId]/route.ts",
+  // Detection event ingestion
+  "detection_events.transfer_approved":
+    "src/app/api/events/staged/[payloadId]/customers/[customerId]/route.ts",
+  "detection_events.transfer_failed":
+    "src/app/api/events/staged/[payloadId]/customers/[customerId]/route.ts",
+  "detection_events.transfer_denied":
+    "src/app/api/events/staged/[payloadId]/customers/[customerId]/route.ts",
+  "detection_events.transfer_rejected":
+    "src/app/api/events/staged/[payloadId]/customers/[customerId]/route.ts",
+  "detection_events.transfer_not_found":
+    "src/app/api/events/staged/[payloadId]/customers/[customerId]/route.ts",
+  "detection_events.upload_completed": "src/app/api/events/ingest/route.ts",
+  "detection_events.upload_failed": "src/app/api/events/ingest/route.ts",
+  "detection_events.upload_denied": "src/app/api/events/ingest/route.ts",
+  // Customer DB
+  "customer_db.provisioned": "src/lib/db/provision-customer.ts",
+  "customer_db.provision_failed": "src/lib/db/provision-customer.ts",
+  "customer_db.dropped": "src/lib/auth/delete-customer.ts",
+  // OpenBao Transit (guard-level: kek_rotated)
+  "openbao.kek_rotated": "src/app/api/admin/kek/rotate/route.ts",
+  "openbao.dek_destroyed": "src/lib/auth/delete-customer.ts",
+  // System (guard-level: settings_updated)
+  "system.settings_updated": "src/app/api/admin/session-policy/route.ts",
+  // Audit (internal) — emitted via raw SQL in anonymize.ts
+  "audit.anonymize": "src/lib/audit/anonymize.ts",
+} satisfies Partial<Record<AuditAction, string>>;
+
+// ---------------------------------------------------------------------------
+// Actions defined in the taxonomy but not yet produced.
+// These belong to features not yet built (account management, environment
+// management, trust registry, role management, analyst assignments).
+// When a feature is built, move its actions from here to PRODUCED.
+// ---------------------------------------------------------------------------
+
+const NOT_YET_PRODUCED: Set<AuditAction> = new Set([
+  // Account management — no admin routes yet
+  "account.created",
+  "account.updated",
+  "account.suspended",
+  "account.restored",
+  "account.disabled",
+  "account.admin_eligible_changed",
+  "account.analyst_eligible_changed",
+  // Membership — implicit creation (via invitation acceptance), last_manager guard
+  "membership.created",
+  "membership.last_manager_blocked",
+  // Analyst assignment — no routes yet
+  "analyst.assignment.created",
+  "analyst.assignment.removed",
+  // Customer lifecycle — update/suspend/disable routes not yet built
+  "customer.updated",
+  "customer.suspended",
+  "customer.disabled",
+  // AICE environment management — no routes yet
+  "environment.created",
+  "environment.updated",
+  "environment.disabled",
+  "environment.customer_linked",
+  "environment.customer_unlinked",
+  // Trust registry — no routes yet
+  "trust_registry.key_registered",
+  "trust_registry.key_disabled",
+  "trust_registry.key_removed",
+  // Role management — no routes yet
+  "role.created",
+  "role.updated",
+  "role.deleted",
+  "role.permission_changed",
+  // Customer DB — retry path not yet wired to provisionCustomerDb
+  "customer_db.provision_retried",
+  // Detection events — transfer_completed not yet wired
+  "detection_events.transfer_completed",
+  // System — policy_changed not yet distinct from settings_updated
+  "system.policy_changed",
+]);
+
+// ---------------------------------------------------------------------------
+// Discussion #10 §4 required category prefixes
+// ---------------------------------------------------------------------------
+
+const REQUIRED_CATEGORIES = [
+  "general.auth",
+  "admin.auth",
+  "session",
+  "bridge",
+  "invitation",
+  "account",
+  "membership",
+  "analyst.assignment",
+  "customer",
+  "environment",
+  "trust_registry",
+  "role",
+  "detection_events",
+  "customer_db",
+  "openbao",
+  "system",
+  "audit",
+];
+
+/** Categories whose routes are built and must have at least one producer. */
+const PRODUCED_CATEGORIES = [
+  "general.auth",
+  "admin.auth",
+  "session",
+  "bridge",
+  "invitation",
+  "membership",
+  "customer",
+  "detection_events",
+  "customer_db",
+  "openbao",
+  "system",
+  "audit",
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("audit event taxonomy completeness (Discussion #10 §4)", () => {
+  const allActions = extractAuditActions();
+
+  it("every AuditAction is either PRODUCED or explicitly NOT_YET_PRODUCED", () => {
+    const unaccounted = allActions.filter(
+      (action) =>
+        !(action in PRODUCED) && !NOT_YET_PRODUCED.has(action as AuditAction),
+    );
+    expect(
+      unaccounted,
+      `Actions not accounted for: ${unaccounted.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("PRODUCED + NOT_YET_PRODUCED has no entries missing from AuditAction", () => {
+    const actionSet = new Set(allActions);
+    const staleProduced = Object.keys(PRODUCED).filter(
+      (key) => !actionSet.has(key),
+    );
+    const staleNotYet = [...NOT_YET_PRODUCED].filter(
+      (key) => !actionSet.has(key),
+    );
+    const stale = [...staleProduced, ...staleNotYet];
+    expect(
+      stale,
+      `Stale entries not in AuditAction type: ${stale.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("no action appears in both PRODUCED and NOT_YET_PRODUCED", () => {
+    const overlap = Object.keys(PRODUCED).filter((key) =>
+      NOT_YET_PRODUCED.has(key as AuditAction),
+    );
+    expect(overlap, `Actions in both maps: ${overlap.join(", ")}`).toEqual([]);
+  });
+
+  it("every required category has at least one action defined", () => {
+    for (const category of REQUIRED_CATEGORIES) {
+      const matching = allActions.filter(
+        (action) => action.startsWith(`${category}.`) || action === category,
+      );
+      expect(
+        matching.length,
+        `Category "${category}" has no actions defined`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it("every produced category has at least one produced action", () => {
+    for (const category of PRODUCED_CATEGORIES) {
+      const matching = Object.keys(PRODUCED).filter(
+        (action) => action.startsWith(`${category}.`) || action === category,
+      );
+      expect(
+        matching.length,
+        `Category "${category}" has no produced actions — ` +
+          "add a producer or move from NOT_YET_PRODUCED",
+      ).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/lib/audit/actions.ts
+++ b/src/lib/audit/actions.ts
@@ -26,6 +26,7 @@ export type AuditAction =
   | "bridge.connection_request"
   | "bridge.connection_granted"
   | "bridge.connection_denied"
+  | "bridge.write_attempt_blocked"
   // Invitation
   | "invitation.created"
   | "invitation.accepted"

--- a/src/lib/audit/index.ts
+++ b/src/lib/audit/index.ts
@@ -7,6 +7,14 @@ import { getCorrelationId } from "./correlation";
 export type { AuditAction } from "./actions";
 export { getCorrelationId, withCorrelationId } from "./correlation";
 
+/** Actor context for audit event emission from service functions. */
+export interface ActorContext {
+  actorId: string;
+  authContext: "general" | "admin";
+  ipAddress?: string;
+  sid?: string;
+}
+
 /**
  * Actor ID for pre-authentication requests where the caller's identity
  * cannot be determined (e.g. invalid context token on bridge entry).

--- a/src/lib/audit/retention.ts
+++ b/src/lib/audit/retention.ts
@@ -1,0 +1,29 @@
+import "server-only";
+
+import type { Pool } from "pg";
+
+const DEFAULT_RETENTION_DAYS = 365;
+
+/**
+ * Purge anonymized audit log entries older than the retention window.
+ *
+ * Only deletes rows where `ip_address IS NULL` — the anonymization
+ * step nullifies IP addresses, so this predicate targets rows that
+ * have already been through PII redaction (i.e., the customer has
+ * been hard-deleted and the data is no longer forensically useful
+ * beyond the retention period).
+ *
+ * Returns the number of rows deleted.
+ */
+export async function purgeExpiredAuditLogs(
+  pool: Pool,
+  retentionDays = DEFAULT_RETENTION_DAYS,
+): Promise<number> {
+  const result = await pool.query(
+    `DELETE FROM audit_logs
+     WHERE ip_address IS NULL
+       AND created_at < NOW() - make_interval(days => $1)`,
+    [retentionDays],
+  );
+  return result.rowCount ?? 0;
+}

--- a/src/lib/auth/__tests__/authorization.db.test.ts
+++ b/src/lib/auth/__tests__/authorization.db.test.ts
@@ -608,6 +608,7 @@ describe.skipIf(!hasPostgres)("authorize() (DB integration)", () => {
         }),
       );
       expect(result.authorized).toBe(false);
+      expect(result.reason).toBe("bridge_write_blocked");
     });
 
     it("allows read in bridge session", async () => {
@@ -621,7 +622,7 @@ describe.skipIf(!hasPostgres)("authorize() (DB integration)", () => {
       expect(result.authorized).toBe(true);
     });
 
-    it("allows ingest in bridge session", async () => {
+    it("rejects ingest in bridge session", async () => {
       const result = await withClient((c) =>
         authorize(c, "general", userAccountId, "workspace:read", {
           customerId: activeCustomerId,
@@ -629,7 +630,8 @@ describe.skipIf(!hasPostgres)("authorize() (DB integration)", () => {
           bridgeScope: mkBridgeScope(),
         }),
       );
-      expect(result.authorized).toBe(true);
+      expect(result.authorized).toBe(false);
+      expect(result.reason).toBe("bridge_write_blocked");
     });
 
     it("allows process in bridge session", async () => {

--- a/src/lib/auth/__tests__/delete-customer.db.test.ts
+++ b/src/lib/auth/__tests__/delete-customer.db.test.ts
@@ -145,7 +145,7 @@ describe.skipIf(!hasPostgres)("deleteCustomer (DB integration)", () => {
 
     // Delete
     const { deleteCustomer } = await import("../delete-customer");
-    await deleteCustomer(authPool, auditPool, customerId, {
+    await deleteCustomer(authPool, auditPool, customerId, undefined, {
       adminUrl: authDbUrl,
       skipTransit: true,
       skipAuditAnonymize: true,
@@ -204,7 +204,7 @@ describe.skipIf(!hasPostgres)("deleteCustomer (DB integration)", () => {
     );
 
     const { deleteCustomer } = await import("../delete-customer");
-    await deleteCustomer(authPool, auditPool, customerId, {
+    await deleteCustomer(authPool, auditPool, customerId, undefined, {
       adminUrl: authDbUrl,
       skipTransit: true,
       skipAuditAnonymize: true,
@@ -255,7 +255,7 @@ describe.skipIf(!hasPostgres)("deleteCustomer (DB integration)", () => {
 
     // Delete only customer A
     const { deleteCustomer } = await import("../delete-customer");
-    await deleteCustomer(authPool, auditPool, customerA, {
+    await deleteCustomer(authPool, auditPool, customerA, undefined, {
       adminUrl: authDbUrl,
       skipTransit: true,
       skipAuditAnonymize: true,
@@ -276,7 +276,7 @@ describe.skipIf(!hasPostgres)("deleteCustomer (DB integration)", () => {
     expect(secB.rows.length).toBe(1);
 
     // Clean up
-    await deleteCustomer(authPool, auditPool, customerB, {
+    await deleteCustomer(authPool, auditPool, customerB, undefined, {
       adminUrl: authDbUrl,
       skipTransit: true,
       skipAuditAnonymize: true,
@@ -313,7 +313,7 @@ describe.skipIf(!hasPostgres)("deleteCustomer (DB integration)", () => {
 
     // Delete customer A — now only customer B (approved/terminal) remains
     const { deleteCustomer } = await import("../delete-customer");
-    await deleteCustomer(authPool, auditPool, customerA, {
+    await deleteCustomer(authPool, auditPool, customerA, undefined, {
       adminUrl: authDbUrl,
       skipTransit: true,
       skipAuditAnonymize: true,
@@ -327,7 +327,7 @@ describe.skipIf(!hasPostgres)("deleteCustomer (DB integration)", () => {
     expect(payloadAfter.rows.length).toBe(0);
 
     // Clean up customer B
-    await deleteCustomer(authPool, auditPool, customerB, {
+    await deleteCustomer(authPool, auditPool, customerB, undefined, {
       adminUrl: authDbUrl,
       skipTransit: true,
       skipAuditAnonymize: true,
@@ -353,7 +353,7 @@ describe.skipIf(!hasPostgres)("deleteCustomer (DB integration)", () => {
     expect(before.rows.length).toBe(1);
 
     const { deleteCustomer } = await import("../delete-customer");
-    await deleteCustomer(authPool, auditPool, customerId, {
+    await deleteCustomer(authPool, auditPool, customerId, undefined, {
       adminUrl: authDbUrl,
       skipTransit: true,
       skipAuditAnonymize: true,
@@ -391,7 +391,7 @@ describe.skipIf(!hasPostgres)("deleteCustomer (DB integration)", () => {
     expect(before.rows[0].ip_address).toBe("192.168.1.1");
 
     const { deleteCustomer } = await import("../delete-customer");
-    await deleteCustomer(authPool, auditPool, customerId, {
+    await deleteCustomer(authPool, auditPool, customerId, undefined, {
       adminUrl: authDbUrl,
       skipTransit: true,
     });
@@ -430,6 +430,7 @@ describe.skipIf(!hasPostgres)("deleteCustomer (DB integration)", () => {
         authPool,
         auditPool,
         "00000000-0000-0000-0000-000000000000",
+        undefined,
         { adminUrl: authDbUrl, skipTransit: true, skipAuditAnonymize: true },
       );
       expect.fail("should have thrown");
@@ -466,7 +467,7 @@ describe.skipIf(!hasPostgres)("deleteCustomer (DB integration)", () => {
     expect(invBefore.rows.length).toBe(1);
 
     const { deleteCustomer } = await import("../delete-customer");
-    await deleteCustomer(authPool, auditPool, customerId, {
+    await deleteCustomer(authPool, auditPool, customerId, undefined, {
       adminUrl: authDbUrl,
       skipTransit: true,
       skipAuditAnonymize: true,

--- a/src/lib/auth/__tests__/delete-customer.unit.test.ts
+++ b/src/lib/auth/__tests__/delete-customer.unit.test.ts
@@ -1,0 +1,182 @@
+import { Pool } from "pg";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mockAuditLog = vi.fn();
+vi.mock("../../audit", () => ({
+  auditLog: (...args: unknown[]) => mockAuditLog(...args),
+}));
+
+const mockDeleteTransitKey = vi.fn().mockResolvedValue(undefined);
+vi.mock("../../crypto/transit", () => ({
+  getTransitConfig: () => ({ addr: "http://mock:8200", token: "mock" }),
+  deleteTransitKey: (...args: unknown[]) => mockDeleteTransitKey(...args),
+}));
+
+vi.mock("../../audit/anonymize", () => ({
+  anonymizeCustomerAuditLogs: vi.fn().mockResolvedValue(undefined),
+}));
+
+const { deleteCustomer } = await import("../delete-customer");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CUSTOMER_ID = "a0000000-0000-0000-0000-000000000001";
+
+const ACTOR_CONTEXT = {
+  actorId: "admin-1",
+  authContext: "admin" as const,
+  ipAddress: "10.0.0.1",
+  sid: "sid-1",
+};
+
+function makeAuthPool() {
+  const client = {
+    query: vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes("DELETE FROM customers")) {
+        return { rows: [{ id: CUSTOMER_ID }] };
+      }
+      return { rows: [] };
+    }),
+    release: vi.fn(),
+  };
+  return {
+    connect: vi.fn().mockResolvedValue(client),
+    query: vi.fn().mockResolvedValue({ rows: [] }),
+    end: vi.fn(),
+  };
+}
+
+/** Mock Pool.prototype so `new Pool()` inside deleteCustomer works. */
+function mockPoolPrototype(opts?: { dbExists?: boolean }) {
+  const dbExists = opts?.dbExists ?? true;
+  vi.spyOn(Pool.prototype, "query").mockImplementation(async (sql) => {
+    // pg_database existence check
+    if (typeof sql === "string" && sql.includes("pg_database")) {
+      return {
+        rows: dbExists ? [{ "?column?": 1 }] : [],
+        command: "",
+        rowCount: dbExists ? 1 : 0,
+        oid: 0,
+        fields: [],
+      } as never;
+    }
+    return {
+      rows: [],
+      command: "",
+      rowCount: 0,
+      oid: 0,
+      fields: [],
+    } as never;
+  });
+  vi.spyOn(Pool.prototype, "end").mockResolvedValue(undefined);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("deleteCustomer audit emissions", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it("emits customer_db.dropped when database exists", async () => {
+    const authPool = makeAuthPool();
+    mockPoolPrototype({ dbExists: true });
+
+    await deleteCustomer(
+      authPool as never,
+      {} as never,
+      CUSTOMER_ID,
+      ACTOR_CONTEXT,
+      {
+        adminUrl: "postgresql://localhost/test",
+        skipTransit: true,
+        skipAuditAnonymize: true,
+      },
+    );
+
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: "admin-1",
+        authContext: "admin",
+        action: "customer_db.dropped",
+        targetType: "customer_db",
+        targetId: CUSTOMER_ID,
+        customerId: CUSTOMER_ID,
+      }),
+    );
+  });
+
+  it("does not emit customer_db.dropped when database does not exist", async () => {
+    const authPool = makeAuthPool();
+    mockPoolPrototype({ dbExists: false });
+
+    await deleteCustomer(
+      authPool as never,
+      {} as never,
+      CUSTOMER_ID,
+      ACTOR_CONTEXT,
+      {
+        adminUrl: "postgresql://localhost/test",
+        skipTransit: true,
+        skipAuditAnonymize: true,
+      },
+    );
+
+    expect(mockAuditLog).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: "customer_db.dropped" }),
+    );
+  });
+
+  it("emits openbao.dek_destroyed after deleting Transit key", async () => {
+    const authPool = makeAuthPool();
+    mockPoolPrototype({ dbExists: true });
+
+    await deleteCustomer(
+      authPool as never,
+      {} as never,
+      CUSTOMER_ID,
+      ACTOR_CONTEXT,
+      {
+        adminUrl: "postgresql://localhost/test",
+        skipAuditAnonymize: true,
+      },
+    );
+
+    expect(mockDeleteTransitKey).toHaveBeenCalledOnce();
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: "admin-1",
+        authContext: "admin",
+        action: "openbao.dek_destroyed",
+        targetType: "transit_key",
+        customerId: CUSTOMER_ID,
+      }),
+    );
+  });
+
+  it("does not emit audit events when actorContext is omitted", async () => {
+    const authPool = makeAuthPool();
+    mockPoolPrototype({ dbExists: true });
+
+    await deleteCustomer(
+      authPool as never,
+      {} as never,
+      CUSTOMER_ID,
+      undefined,
+      {
+        adminUrl: "postgresql://localhost/test",
+        skipTransit: true,
+        skipAuditAnonymize: true,
+      },
+    );
+
+    expect(mockAuditLog).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/auth/__tests__/withauth-audit.unit.test.ts
+++ b/src/lib/auth/__tests__/withauth-audit.unit.test.ts
@@ -343,3 +343,113 @@ describe("withAuth session audit events", () => {
     expect(mockAuditLog).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Guard-level structural audit
+// ---------------------------------------------------------------------------
+
+function setupValidSession() {
+  mockGetAuthCookie.mockResolvedValue("valid-token");
+  mockVerifyJwtFull.mockResolvedValue(CLAIMS);
+  mockValidateSession.mockResolvedValue({
+    createdAt: 1700000000,
+    lastActiveAt: 1700000000,
+    ipAddress: "10.0.0.1",
+    userAgent: "unknown",
+    bridgeAiceId: null,
+    bridgeCustomerIds: null,
+  });
+}
+
+describe("withAuth guard-level audit emission", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits audit event on 2xx when audit option is set", async () => {
+    setupValidSession();
+
+    const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }));
+    const guarded = withAuth(handler, {
+      audit: { action: "customer.created", targetType: "customer" },
+    });
+    await guarded(makeRequest());
+
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: "account-1",
+        authContext: "general",
+        action: "customer.created",
+        targetType: "customer",
+        sid: "sid-1",
+        ipAddress: "10.0.0.1",
+      }),
+    );
+  });
+
+  it("does not emit audit event on 4xx response", async () => {
+    setupValidSession();
+
+    const handler = vi
+      .fn()
+      .mockResolvedValue(Response.json({ error: "bad" }, { status: 400 }));
+    const guarded = withAuth(handler, {
+      audit: { action: "customer.created", targetType: "customer" },
+    });
+    await guarded(makeRequest());
+
+    expect(mockAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("does not emit audit event when no audit option is set", async () => {
+    setupValidSession();
+
+    const handler = vi.fn().mockResolvedValue(Response.json({ ok: true }));
+    const guarded = withAuth(handler);
+    await guarded(makeRequest());
+
+    expect(mockAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("propagates handler-set audit metadata", async () => {
+    setupValidSession();
+
+    const handler = vi.fn(async (_req, auth) => {
+      auth.audit.targetId = "cust-42";
+      auth.audit.details = { name: "Acme" };
+      auth.audit.customerId = "cust-42";
+      auth.audit.aiceId = "env-1";
+      return Response.json({ ok: true }, { status: 201 });
+    });
+    const guarded = withAuth(handler, {
+      ctx: "admin",
+      audit: { action: "customer.created", targetType: "customer" },
+    });
+    await guarded(makeRequest());
+
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: "account-1",
+        authContext: "admin",
+        action: "customer.created",
+        targetType: "customer",
+        targetId: "cust-42",
+        details: { name: "Acme" },
+        customerId: "cust-42",
+        aiceId: "env-1",
+      }),
+    );
+  });
+
+  it("does not emit when handler throws (no response)", async () => {
+    setupValidSession();
+
+    const handler = vi.fn().mockRejectedValue(new Error("boom"));
+    const guarded = withAuth(handler, {
+      audit: { action: "customer.created", targetType: "customer" },
+    });
+
+    await expect(guarded(makeRequest())).rejects.toThrow("boom");
+    expect(mockAuditLog).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/auth/authorization.ts
+++ b/src/lib/auth/authorization.ts
@@ -19,6 +19,8 @@ export interface AuthorizeOptions {
 
 export interface AuthorizeResult {
   authorized: boolean;
+  /** Denial reason when `authorized` is false. */
+  reason?: "bridge_write_blocked" | "bridge_not_allowed";
   permissions?: Set<string>;
 }
 
@@ -63,10 +65,10 @@ export async function authorize(
   // 2. Bridge scope restriction
   if (bridgeScope) {
     if (!allowInBridge) {
-      return { authorized: false };
+      return { authorized: false, reason: "bridge_not_allowed" };
     }
-    if (operationKind === "write") {
-      return { authorized: false };
+    if (operationKind === "write" || operationKind === "ingest") {
+      return { authorized: false, reason: "bridge_write_blocked" };
     }
     if (customerId && !bridgeScope.customerIds.includes(customerId)) {
       return { authorized: false };

--- a/src/lib/auth/delete-customer.ts
+++ b/src/lib/auth/delete-customer.ts
@@ -1,6 +1,8 @@
 import "server-only";
 
 import { Pool } from "pg";
+import type { ActorContext } from "../audit";
+import { auditLog } from "../audit";
 import { deleteTransitKey, getTransitConfig } from "../crypto/transit";
 import {
   customerDbName,
@@ -36,6 +38,7 @@ export async function deleteCustomer(
   authPool: Pool,
   auditOwnerPool: Pool,
   customerId: string,
+  actorContext?: ActorContext,
   deps?: DeleteDeps,
 ): Promise<void> {
   // -----------------------------------------------------------------------
@@ -85,6 +88,10 @@ export async function deleteCustomer(
 
   // -----------------------------------------------------------------------
   // Phase 2: Infrastructure cleanup (best-effort, post-commit)
+  //
+  // Order matters: anonymize audit logs BEFORE destroying the DEK so
+  // that PII is cleaned while the data is still readable. After
+  // crypto-shredding, backup artifacts become unreadable.
   // -----------------------------------------------------------------------
 
   // Step 4: DROP DATABASE
@@ -92,34 +99,42 @@ export async function deleteCustomer(
   const adminUrl = deps?.adminUrl ?? getAdminUrl();
   const adminPool = new Pool({ connectionString: adminUrl });
   try {
-    // Terminate active connections before dropping
-    await adminPool.query(
-      `SELECT pg_terminate_backend(pid)
-       FROM pg_stat_activity
-       WHERE datname = '${dbName}' AND pid <> pg_backend_pid()`,
+    // Check if the database actually exists before dropping
+    const dbExists = await adminPool.query(
+      "SELECT 1 FROM pg_database WHERE datname = $1",
+      [dbName],
     );
-    await adminPool.query(`DROP DATABASE IF EXISTS ${dbName}`);
+    if (dbExists.rows.length > 0) {
+      // Terminate active connections before dropping
+      await adminPool.query(
+        `SELECT pg_terminate_backend(pid)
+         FROM pg_stat_activity
+         WHERE datname = '${dbName}' AND pid <> pg_backend_pid()`,
+      );
+      await adminPool.query(`DROP DATABASE ${dbName}`);
+      if (actorContext) {
+        void auditLog({
+          actorId: actorContext.actorId,
+          authContext: actorContext.authContext,
+          action: "customer_db.dropped",
+          targetType: "customer_db",
+          targetId: customerId,
+          details: { dbName },
+          ipAddress: actorContext.ipAddress,
+          sid: actorContext.sid,
+          customerId,
+        });
+      }
+    }
   } catch (err) {
     console.error(`Failed to drop database ${dbName}:`, (err as Error).message);
   } finally {
     await adminPool.end();
   }
 
-  // Step 5: Destroy Transit key (crypto-shredding)
-  if (!deps?.skipTransit) {
-    try {
-      const transitConfig = getTransitConfig();
-      const keyName = customerTransitKeyName(customerId);
-      await deleteTransitKey(transitConfig, keyName);
-    } catch (err) {
-      console.error(
-        `Failed to delete Transit key for customer ${customerId}:`,
-        (err as Error).message,
-      );
-    }
-  }
-
-  // Step 6: Anonymize audit log entries (self-audited)
+  // Step 5: Anonymize audit log entries (self-audited)
+  // Must run before DEK destruction so backup artifacts are cleaned
+  // while the data is still accessible.
   if (!deps?.skipAuditAnonymize) {
     try {
       const { anonymizeCustomerAuditLogs } = await import("../audit/anonymize");
@@ -127,6 +142,34 @@ export async function deleteCustomer(
     } catch (err) {
       console.error(
         `Failed to anonymize audit logs for customer ${customerId}:`,
+        (err as Error).message,
+      );
+    }
+  }
+
+  // Step 6: Destroy Transit key (crypto-shredding)
+  // After this, any backup artifacts referencing the DEK are unreadable.
+  if (!deps?.skipTransit) {
+    try {
+      const transitConfig = getTransitConfig();
+      const keyName = customerTransitKeyName(customerId);
+      await deleteTransitKey(transitConfig, keyName);
+      if (actorContext) {
+        void auditLog({
+          actorId: actorContext.actorId,
+          authContext: actorContext.authContext,
+          action: "openbao.dek_destroyed",
+          targetType: "transit_key",
+          targetId: keyName,
+          details: { customerId },
+          ipAddress: actorContext.ipAddress,
+          sid: actorContext.sid,
+          customerId,
+        });
+      }
+    } catch (err) {
+      console.error(
+        `Failed to delete Transit key for customer ${customerId}:`,
         (err as Error).message,
       );
     }

--- a/src/lib/auth/guards.ts
+++ b/src/lib/auth/guards.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server";
 import { auditLog } from "../audit";
+import type { AuditAction } from "../audit/actions";
 import { withCorrelationId } from "../audit/correlation";
 import { getAuthPool } from "../db/client";
 import type { AuthContext } from "./cookies";
@@ -21,6 +22,20 @@ import {
 // Types
 // ---------------------------------------------------------------------------
 
+/** Declarative audit config for guard-level emission. */
+export interface AuditOption {
+  action: AuditAction;
+  targetType: string;
+}
+
+/** Mutable metadata that handlers populate for guard-level audit. */
+export interface AuditMeta {
+  targetId?: string;
+  details?: Record<string, unknown>;
+  customerId?: string;
+  aiceId?: string;
+}
+
 export interface AuthenticatedRequest {
   accountId: string;
   sessionId: string;
@@ -30,6 +45,8 @@ export interface AuthenticatedRequest {
   meta: RequestMeta;
   bridgeAiceId: string | null;
   bridgeCustomerIds: string[] | null;
+  /** Mutable audit metadata — set fields before returning a 2xx response. */
+  audit: AuditMeta;
 }
 
 export interface LogoutAuthRequest {
@@ -45,9 +62,10 @@ export interface LogoutAuthRequest {
 
 export function withAuth(
   handler: (req: NextRequest, auth: AuthenticatedRequest) => Promise<Response>,
-  options?: { ctx?: AuthContext },
+  options?: { ctx?: AuthContext; audit?: AuditOption },
 ): (req: NextRequest) => Promise<Response> {
   const ctx = options?.ctx ?? "general";
+  const auditOption = options?.audit;
 
   return async (req: NextRequest) => {
     const token = await getAuthCookie(ctx);
@@ -171,7 +189,8 @@ export function withAuth(
         });
       }
 
-      return handler(req, {
+      const auditMeta: AuditMeta = {};
+      const response = await handler(req, {
         accountId: claims.sub,
         sessionId: claims.sid,
         authContext: ctx,
@@ -180,7 +199,25 @@ export function withAuth(
         meta,
         bridgeAiceId,
         bridgeCustomerIds,
+        audit: auditMeta,
       });
+
+      if (auditOption && response.ok) {
+        void auditLog({
+          actorId: claims.sub,
+          authContext: ctx,
+          action: auditOption.action,
+          targetType: auditOption.targetType,
+          targetId: auditMeta.targetId,
+          details: auditMeta.details,
+          ipAddress: meta.ipAddress,
+          sid: claims.sid,
+          customerId: auditMeta.customerId,
+          aiceId: auditMeta.aiceId,
+        });
+      }
+
+      return response;
     });
   };
 }

--- a/src/lib/db/__tests__/provision-customer.db.test.ts
+++ b/src/lib/db/__tests__/provision-customer.db.test.ts
@@ -106,7 +106,7 @@ describe.skipIf(!hasPostgres)("provisionCustomerDb (DB integration)", () => {
     const customerId = await createTestCustomer("prov-happy-path");
 
     const { provisionCustomerDb } = await import("../provision-customer");
-    const status = await provisionCustomerDb(authPool, customerId, {
+    const status = await provisionCustomerDb(authPool, customerId, undefined, {
       adminUrl: authDbUrl,
       ownerTemplateUrl: authDbUrl,
       migrationsDir: CUSTOMER_MIGRATIONS_DIR,
@@ -157,7 +157,7 @@ describe.skipIf(!hasPostgres)("provisionCustomerDb (DB integration)", () => {
     const customerId = await createTestCustomer("prov-dek-fail");
 
     const { provisionCustomerDb } = await import("../provision-customer");
-    const status = await provisionCustomerDb(authPool, customerId, {
+    const status = await provisionCustomerDb(authPool, customerId, undefined, {
       adminUrl: authDbUrl,
       ownerTemplateUrl: authDbUrl,
       migrationsDir: CUSTOMER_MIGRATIONS_DIR,
@@ -194,7 +194,7 @@ describe.skipIf(!hasPostgres)("provisionCustomerDb (DB integration)", () => {
     );
 
     const { provisionCustomerDb } = await import("../provision-customer");
-    const status = await provisionCustomerDb(authPool, customerId, {
+    const status = await provisionCustomerDb(authPool, customerId, undefined, {
       adminUrl: authDbUrl,
       ownerTemplateUrl: authDbUrl,
       migrationsDir: tmpDir,
@@ -228,7 +228,7 @@ describe.skipIf(!hasPostgres)("provisionCustomerDb (DB integration)", () => {
     const tmpDir = await mkdtemp(join(tmpdir(), "mig-retry-"));
     await writeFile(join(tmpDir, "0000_bad.sql"), "SELECT 1/0;");
 
-    const status1 = await provisionCustomerDb(authPool, customerId, {
+    const status1 = await provisionCustomerDb(authPool, customerId, undefined, {
       adminUrl: authDbUrl,
       ownerTemplateUrl: authDbUrl,
       migrationsDir: tmpDir,
@@ -246,7 +246,7 @@ describe.skipIf(!hasPostgres)("provisionCustomerDb (DB integration)", () => {
     );
 
     // Second attempt: succeed with correct migrations
-    const status2 = await provisionCustomerDb(authPool, customerId, {
+    const status2 = await provisionCustomerDb(authPool, customerId, undefined, {
       adminUrl: authDbUrl,
       ownerTemplateUrl: authDbUrl,
       migrationsDir: CUSTOMER_MIGRATIONS_DIR,
@@ -280,7 +280,7 @@ describe.skipIf(!hasPostgres)("provisionCustomerDb (DB integration)", () => {
     await writeFile(join(tmpDir, "0000_bad.sql"), "SELECT 1/0;");
 
     // Provision good customer
-    const goodStatus = await provisionCustomerDb(authPool, goodId, {
+    const goodStatus = await provisionCustomerDb(authPool, goodId, undefined, {
       adminUrl: authDbUrl,
       ownerTemplateUrl: authDbUrl,
       migrationsDir: CUSTOMER_MIGRATIONS_DIR,
@@ -289,7 +289,7 @@ describe.skipIf(!hasPostgres)("provisionCustomerDb (DB integration)", () => {
     expect(goodStatus).toBe("active");
 
     // Provision bad customer (migration fails)
-    const badStatus = await provisionCustomerDb(authPool, badId, {
+    const badStatus = await provisionCustomerDb(authPool, badId, undefined, {
       adminUrl: authDbUrl,
       ownerTemplateUrl: authDbUrl,
       migrationsDir: tmpDir,

--- a/src/lib/db/__tests__/provision-customer.unit.test.ts
+++ b/src/lib/db/__tests__/provision-customer.unit.test.ts
@@ -1,0 +1,183 @@
+import { Pool } from "pg";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mockAuditLog = vi.fn();
+vi.mock("../../audit", () => ({
+  auditLog: (...args: unknown[]) => mockAuditLog(...args),
+}));
+
+vi.mock("../../crypto/transit", () => ({
+  getTransitConfig: () => ({ addr: "http://mock:8200", token: "mock" }),
+  generateDataKey: vi.fn().mockResolvedValue({
+    plaintext: Buffer.alloc(32, 0xab),
+    wrappedDek: "vault:v1:mock-dek",
+  }),
+}));
+
+const { provisionCustomerDb } = await import("../provision-customer");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CUSTOMER_ID = "a0000000-0000-0000-0000-000000000001";
+
+const ACTOR_CONTEXT = {
+  actorId: "admin-1",
+  authContext: "admin" as const,
+  ipAddress: "10.0.0.1",
+  sid: "sid-1",
+};
+
+function makeAuthPool() {
+  return { query: vi.fn().mockResolvedValue({ rows: [] }) };
+}
+
+function mockPoolPrototype() {
+  vi.spyOn(Pool.prototype, "query").mockImplementation(
+    async () =>
+      ({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] }) as never,
+  );
+  vi.spyOn(Pool.prototype, "end").mockResolvedValue(undefined);
+}
+
+function makeSuccessDeps() {
+  return {
+    adminUrl: "postgresql://localhost/test",
+    ownerTemplateUrl: "postgresql://localhost/test",
+    migrationsDir: "/tmp/nonexistent",
+    generateDek: vi.fn().mockResolvedValue({ wrappedDek: "vault:v1:test" }),
+  };
+}
+
+function makeFailDeps() {
+  return {
+    adminUrl: "postgresql://localhost/test",
+    ownerTemplateUrl: "postgresql://localhost/test",
+    migrationsDir: "/tmp/nonexistent",
+    generateDek: vi.fn().mockRejectedValue(new Error("Transit down")),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("provisionCustomerDb audit emissions", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it("emits customer_db.provisioned on success with actorContext", async () => {
+    const authPool = makeAuthPool();
+    mockPoolPrototype();
+
+    const migrateModule = await import("../migrate");
+    vi.spyOn(migrateModule, "runMigrations").mockResolvedValue(undefined);
+
+    const status = await provisionCustomerDb(
+      authPool as never,
+      CUSTOMER_ID,
+      { actorContext: ACTOR_CONTEXT },
+      makeSuccessDeps(),
+    );
+
+    expect(status).toBe("active");
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: "admin-1",
+        authContext: "admin",
+        action: "customer_db.provisioned",
+        targetType: "customer_db",
+        targetId: CUSTOMER_ID,
+        customerId: CUSTOMER_ID,
+        details: expect.objectContaining({ outcome: "active" }),
+      }),
+    );
+  });
+
+  it("emits customer_db.provision_retried on success with isRetry=true", async () => {
+    const authPool = makeAuthPool();
+    mockPoolPrototype();
+
+    const migrateModule = await import("../migrate");
+    vi.spyOn(migrateModule, "runMigrations").mockResolvedValue(undefined);
+
+    const status = await provisionCustomerDb(
+      authPool as never,
+      CUSTOMER_ID,
+      { actorContext: ACTOR_CONTEXT, isRetry: true },
+      makeSuccessDeps(),
+    );
+
+    expect(status).toBe("active");
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "customer_db.provision_retried",
+        details: expect.objectContaining({ outcome: "active" }),
+      }),
+    );
+  });
+
+  it("emits customer_db.provision_failed on failure with actorContext", async () => {
+    const authPool = makeAuthPool();
+    mockPoolPrototype();
+
+    const status = await provisionCustomerDb(
+      authPool as never,
+      CUSTOMER_ID,
+      { actorContext: ACTOR_CONTEXT },
+      makeFailDeps(),
+    );
+
+    expect(status).toBe("failed");
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "customer_db.provision_failed",
+        targetType: "customer_db",
+        targetId: CUSTOMER_ID,
+        details: expect.objectContaining({
+          outcome: "failed",
+          error: "Transit down",
+        }),
+      }),
+    );
+  });
+
+  it("emits customer_db.provision_retried on failure with isRetry=true", async () => {
+    const authPool = makeAuthPool();
+    mockPoolPrototype();
+
+    const status = await provisionCustomerDb(
+      authPool as never,
+      CUSTOMER_ID,
+      { actorContext: ACTOR_CONTEXT, isRetry: true },
+      makeFailDeps(),
+    );
+
+    expect(status).toBe("failed");
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "customer_db.provision_retried",
+        details: expect.objectContaining({ outcome: "failed" }),
+      }),
+    );
+  });
+
+  it("does not emit audit events when actorContext is omitted", async () => {
+    const authPool = makeAuthPool();
+    mockPoolPrototype();
+
+    await provisionCustomerDb(
+      authPool as never,
+      CUSTOMER_ID,
+      undefined,
+      makeFailDeps(),
+    );
+
+    expect(mockAuditLog).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/db/provision-customer.ts
+++ b/src/lib/db/provision-customer.ts
@@ -2,6 +2,8 @@ import "server-only";
 
 import { join } from "node:path";
 import { Pool } from "pg";
+import type { ActorContext } from "../audit";
+import { auditLog } from "../audit";
 import { generateDataKey, getTransitConfig } from "../crypto/transit";
 import {
   customerDbName,
@@ -25,6 +27,11 @@ export interface ProvisionDeps {
   generateDek: (keyName: string) => Promise<{ wrappedDek: string }>;
 }
 
+export interface ProvisionOptions {
+  actorContext?: ActorContext;
+  isRetry?: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -46,8 +53,11 @@ export interface ProvisionDeps {
 export async function provisionCustomerDb(
   authPool: Pool,
   customerId: string,
+  options?: ProvisionOptions,
   deps?: ProvisionDeps,
 ): Promise<"active" | "failed"> {
+  const actorContext = options?.actorContext;
+  const isRetry = options?.isRetry ?? false;
   const dbName = customerDbName(customerId);
   const adminUrl = deps?.adminUrl ?? getAdminUrl();
   const ownerTemplateUrl =
@@ -115,6 +125,22 @@ export async function provisionCustomerDb(
       [customerId],
     );
 
+    if (actorContext) {
+      void auditLog({
+        actorId: actorContext.actorId,
+        authContext: actorContext.authContext,
+        action: isRetry
+          ? "customer_db.provision_retried"
+          : "customer_db.provisioned",
+        targetType: "customer_db",
+        targetId: customerId,
+        details: { dbName, outcome: "active" },
+        ipAddress: actorContext.ipAddress,
+        sid: actorContext.sid,
+        customerId,
+      });
+    }
+
     return "active";
   } catch (err) {
     console.error(
@@ -131,6 +157,27 @@ export async function provisionCustomerDb(
           (updateErr as Error).message,
         );
       });
+
+    if (actorContext) {
+      void auditLog({
+        actorId: actorContext.actorId,
+        authContext: actorContext.authContext,
+        action: isRetry
+          ? "customer_db.provision_retried"
+          : "customer_db.provision_failed",
+        targetType: "customer_db",
+        targetId: customerId,
+        details: {
+          dbName,
+          outcome: "failed",
+          error: (err as Error).message,
+        },
+        ipAddress: actorContext.ipAddress,
+        sid: actorContext.sid,
+        customerId,
+      });
+    }
+
     return "failed";
   }
 }


### PR DESCRIPTION
## Summary

- Guard-level structural audit in `withAuth` auto-emits audit events on 2xx responses via declarative `audit` option
- Migrated 8 mutation routes from handler-level to guard-level audit (`customer.created`, `customer.deleted`, `openbao.kek_rotated`, `system.settings_updated`, `invitation.created`, `invitation.revoked`, `membership.removed`, `membership.role_changed`)
- Added missing audit producers: `bridge.write_attempt_blocked`, `invitation.expired`, `customer_db.dropped`, `openbao.dek_destroyed`
- Bridge sessions now block both `write` and `ingest` operations (`bridge_write_blocked`)
- `customer_db.dropped` only emits when the database actually existed (no false positive on `DROP DATABASE IF EXISTS`)
- `customer_db.provision_retried` is acknowledged but deferred to NOT_YET_PRODUCED (no production caller passes `isRetry` yet)
- Added `ActorContext` parameter to `deleteCustomer` and `provisionCustomerDb` for audit emission
- Added `reason` field to `AuthorizeResult` for distinguishing `bridge_write_blocked` denials
- Added audit retention purge API (`POST /api/admin/audit-retention`) with configurable retention days
- Reordered `deleteCustomer` Phase 2: anonymize audit logs BEFORE DEK destruction so backup artifacts are cleaned while data is still readable
- Added taxonomy completeness test verifying all produced categories have emitters

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm vitest run` passes (457 tests, 0 failures)
- [x] `pnpm biome check` passes
- [x] Guard-level audit: 5 tests (emit on 2xx, no emit on 4xx, no emit without option, metadata propagation, no emit on throw)
- [x] `bridge.write_attempt_blocked`: 2 tests (ingest + staged-approve)
- [x] `deleteCustomer` audit: 4 tests (`customer_db.dropped` when exists, no emit when DB missing, `openbao.dek_destroyed`, no emit without actorContext)
- [x] `provisionCustomerDb` audit: 5 tests (provisioned, retried success, failed, retried failure, no emit without actorContext)
- [x] Retention purge: 3 tests (custom days, default 365, null rowCount)
- [x] Audit retention route: 8 tests (happy path, custom days, metadata, validation)
- [x] Taxonomy completeness: 5 tests (all actions accounted, no stale entries, no overlap, categories defined, categories produced)
- [x] Existing route tests updated with `audit: {}` mock field (5 files)
- [x] Authorization DB test updated: ingest now rejected in bridge sessions

Closes #122