### PR TITLE
Add bg-card to admin card-like containers (#145)

### DIFF
--- a/src/app/[locale]/(admin)/admin/accounts/accounts-page.tsx
+++ b/src/app/[locale]/(admin)/admin/accounts/accounts-page.tsx
@@ -191,7 +191,7 @@ export function AccountsPage() {
             <p className="text-sm text-muted-foreground">{t("noResults")}</p>
           </div>
         ) : (
-          <div className="rounded-md border border-border">
+          <div className="rounded-md border border-border bg-card">
             <Table>
               <TableHeader>
                 <TableRow>

--- a/src/app/[locale]/(admin)/admin/admins/admins-page.tsx
+++ b/src/app/[locale]/(admin)/admin/admins/admins-page.tsx
@@ -277,7 +277,7 @@ export function AdminsPage() {
               <p className="text-sm text-muted-foreground">{t("noResults")}</p>
             </div>
           ) : (
-            <div className="rounded-md border border-border">
+            <div className="rounded-md border border-border bg-card">
               <Table>
                 <TableHeader>
                   <TableRow>

--- a/src/app/[locale]/(admin)/admin/audit-logs/audit-logs-page.tsx
+++ b/src/app/[locale]/(admin)/admin/audit-logs/audit-logs-page.tsx
@@ -203,7 +203,7 @@ export function AuditLogsPage() {
       )}
 
       {/* Filter controls */}
-      <div className="rounded-md border border-border p-4">
+      <div className="rounded-md border border-border bg-card p-4">
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
           <Select
             value={filters.authContext}
@@ -305,7 +305,7 @@ export function AuditLogsPage() {
               <p className="text-sm text-muted-foreground">{t("noResults")}</p>
             </div>
           ) : (
-            <div className="overflow-x-auto rounded-md border border-border">
+            <div className="overflow-x-auto rounded-md border border-border bg-card">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b border-border bg-muted/50">

--- a/src/app/[locale]/(admin)/admin/customers/customers-page.tsx
+++ b/src/app/[locale]/(admin)/admin/customers/customers-page.tsx
@@ -327,7 +327,7 @@ export function CustomersPage() {
             <p className="text-sm text-muted-foreground">{t("noResults")}</p>
           </div>
         ) : (
-          <div className="rounded-md border border-border">
+          <div className="rounded-md border border-border bg-card">
             <Table>
               <TableHeader>
                 <TableRow>

--- a/src/app/[locale]/(admin)/admin/environments/environments-page.tsx
+++ b/src/app/[locale]/(admin)/admin/environments/environments-page.tsx
@@ -666,7 +666,7 @@ export function EnvironmentsPage() {
                 {t("noLinkedCustomers")}
               </p>
             ) : (
-              <div className="rounded-md border border-border">
+              <div className="rounded-md border border-border bg-card">
                 <Table>
                   <TableHeader>
                     <TableRow>
@@ -719,7 +719,7 @@ export function EnvironmentsPage() {
                 {t("noKeys")}
               </p>
             ) : (
-              <div className="rounded-md border border-border">
+              <div className="rounded-md border border-border bg-card">
                 <Table>
                   <TableHeader>
                     <TableRow>
@@ -1040,7 +1040,7 @@ export function EnvironmentsPage() {
             <p className="text-sm text-muted-foreground">{t("noResults")}</p>
           </div>
         ) : (
-          <div className="rounded-md border border-border">
+          <div className="rounded-md border border-border bg-card">
             <Table>
               <TableHeader>
                 <TableRow>

--- a/src/app/[locale]/(admin)/admin/page.tsx
+++ b/src/app/[locale]/(admin)/admin/page.tsx
@@ -7,7 +7,7 @@ export default async function AdminPage() {
       <div className="mb-8">
         <h1 className="text-2xl font-bold text-foreground">{t("settings")}</h1>
       </div>
-      <div className="rounded-md border border-border p-8">
+      <div className="rounded-md border border-border bg-card p-8">
         <p className="text-sm text-muted-foreground">
           System administration pages are under construction.
         </p>

--- a/src/app/[locale]/(admin)/admin/suspicious-activity/suspicious-activity-page.tsx
+++ b/src/app/[locale]/(admin)/admin/suspicious-activity/suspicious-activity-page.tsx
@@ -192,7 +192,7 @@ export function SuspiciousActivityPage() {
       )}
 
       {/* Filter controls */}
-      <div className="rounded-md border border-border p-4">
+      <div className="rounded-md border border-border bg-card p-4">
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
           <Select
             value={filters.severity}
@@ -273,7 +273,7 @@ export function SuspiciousActivityPage() {
               <p className="text-sm text-muted-foreground">{t("noResults")}</p>
             </div>
           ) : (
-            <div className="overflow-x-auto rounded-md border border-border">
+            <div className="overflow-x-auto rounded-md border border-border bg-card">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b border-border bg-muted/50">


### PR DESCRIPTION
## Summary

- Add `bg-card` to all 11 card-like containers across 7 admin page files, giving them the white surface specified in Figma instead of being transparent over the `#F5F6F7` canvas.
- This also resolves the row-divider "darkening" effect on light mode, where translucent `border-border` dividers appeared darker than the outer container border due to compositing over the canvas background.
- No `shadow-sm` added, no changes to `table.tsx` or border classes — only the missing background.

Closes #145

## Test plan

- [x] All 11 containers listed in the issue include `bg-card` in their className
- [x] No `shadow-sm` is added anywhere
- [x] `pnpm biome check` passes
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm vitest run` passes
- [x] Light mode: tables and filter panels render with a white surface distinct from the `#F5F6F7` canvas
- [x] Light mode: row dividers no longer read as distinct dark bands compared to the outer border
- [x] Dark mode: no visual regression (`--card-bg` already defined)
- [x] Admin screenshots in `docs/assets/` retaken if the diff is visible in the docs