### PR TITLE
Replace pnpm/action-setup with corepack (#149)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - name: Enable corepack
+        run: corepack enable pnpm
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -131,7 +132,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - name: Enable corepack
+        run: corepack enable pnpm
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -161,7 +163,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Create databases and roles
         run: psql "postgres://postgres:postgres@localhost:5432/auth_db" -f infra/postgres/init-databases.sql
-      - uses: pnpm/action-setup@v5
+      - name: Enable corepack
+        run: corepack enable pnpm
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -214,7 +217,8 @@ jobs:
             -d '{"type": "transit"}'
           curl -sf -X POST http://localhost:8200/v1/transit/keys/staging-events \
             -H "X-Vault-Token: e2e-root-token"
-      - uses: pnpm/action-setup@v5
+      - name: Enable corepack
+        run: corepack enable pnpm
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/e2e/capture-manual-screenshots.spec.ts
+++ b/e2e/capture-manual-screenshots.spec.ts
@@ -352,8 +352,10 @@ base.describe.serial("Manual screenshots", () => {
     await mgrPage.getByLabel("Email address").fill(inviteEmail);
     await mgrPage.getByRole("button", { name: "Send Invitation" }).click();
 
-    // Wait for invitation to appear
-    await expect(mgrPage.getByText(inviteEmail)).toBeVisible();
+    // Wait for invitation to appear in the table
+    await expect(
+      mgrPage.getByRole("cell", { name: inviteEmail }),
+    ).toBeVisible();
     await settle(mgrPage);
 
     await mgrPage.screenshot({


### PR DESCRIPTION
## Summary

- Replace all 4 `pnpm/action-setup@v5` steps in CI with `corepack enable pnpm`
- Prevents breakage from `pnpm/action-setup@v6` which installs pnpm via npm, causing `ERR_PNPM_BROKEN_LOCKFILE` with lockfile v9.0 format
- Fix `pending-invitations.png` E2E test strict-mode violation by targeting the table cell instead of ambiguous `getByText` (toast + cell both matched)

Closes #149

## Test plan

- [x] CI pipeline passes on this PR (all jobs: Check, Unit Test, DB Test, E2E, Image Build)
- [x] `pnpm install --frozen-lockfile` succeeds without lockfile rewriting
- [x] No `ERR_PNPM_BROKEN_LOCKFILE` errors in any job
- [x] `pending-invitations.png` screenshot test passes without strict-mode violation