### PR TITLE
Restrict Dependabot TypeScript updates to v5 (#157)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,11 @@ updates:
           - version-update:semver-major
         versions:
           - ">= 25"
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
+        versions:
+          - ">= 6"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

- Add an `ignore` rule for `typescript` in `.github/dependabot.yml` that skips major-version bumps (`>= 6`), keeping updates within TypeScript 5.
- This follows the same pattern already used for `node`, `next`, and `@types/node`.

Closes #157

## Test plan

- [x] Verify the YAML is valid and the ignore entry is correctly indented under the npm ecosystem's `ignore` list
- [x] Confirm the rule matches the format shown in the issue (`dependency-name`, `update-types`, `versions`)
- [x] Check that existing ignore rules for `node`, `next`, and `@types/node` are unchanged