### PR TITLE
Install latest Biome in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,6 @@ updates:
           - "@types/react-dom"
       tooling:
         patterns:
-          - "@biomejs/biome"
           - vitest
           - "@playwright/test"
           - markdownlint-cli2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - uses: biomejs/setup-biome@v2
+        with:
+          version: latest
       - run: pnpm check
       - run: pnpm typecheck
       - uses: DavidAnson/markdownlint-cli2-action@v23


### PR DESCRIPTION
## Summary

- Pass `version: latest` to `biomejs/setup-biome@v2` so CI installs the newest published Biome release instead of resolving the version from `biome.json`'s `$schema` URL.
- Drop `@biomejs/biome` from Dependabot's `tooling` group since the package is not declared in `package.json` and Dependabot has no version to bump.

Bumping `biome.json`'s `$schema` URL remains a manual step (out of scope for this PR).

Closes #162

## Test plan

- [x] CI `Check` job installs the latest Biome and `pnpm check` passes.