### PR TITLE
Bump Biome schema URL to 2.4.12

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,9 +1,9 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["**", "!node_modules", "!.next", "!dist", "!build"]
+    "includes": ["**", "!node_modules", "!.next", "!dist", "!build", "!.agents"]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
## Summary

- Update `biome.json` `$schema` URL from `2.4.8` to `2.4.12` so editors and the CLI agree on the configuration shape. With `version: latest` in CI (#163), `biome ci` currently prints a version-mismatch info against the pinned 2.4.8 schema.
- Exclude `.agents` from the Biome scan. The directory holds external skill templates (JS/HTML) that do not satisfy our lint rules. Those files were tolerated only because `.agents/**` is outside the `code` change filter, so the `Check` job is skipped for PRs that only touch it. Any PR that does trigger `Check` (including this one) would otherwise fail on pre-existing errors in those templates. Keeping `.agents` out of scope lets the schema bump land without coupling to unrelated cleanup.

Closes #165

## Test plan

- [x] `pnpm check` passes locally with Biome 2.4.12.
- [ ] CI `Check` job runs and succeeds on this PR.