### PR TITLE
Sync .claude/skills symlinks with the skill allowlist

### DIFF
--- a/.claude/skills/vercel-react-view-transitions
+++ b/.claude/skills/vercel-react-view-transitions
@@ -1,0 +1,1 @@
+../../.agents/skills/vercel-react-view-transitions

--- a/.claude/skills/webapp-testing
+++ b/.claude/skills/webapp-testing
@@ -1,0 +1,1 @@
+../../.agents/skills/webapp-testing

--- a/.github/workflows/update-skills.yml
+++ b/.github/workflows/update-skills.yml
@@ -66,15 +66,18 @@ jobs:
             name=$(basename "$dir")
             is_allowed "$name" || rm -rf "$dir"
           done
-          # 2. Claude Code symlinks under .claude/skills/ (if CLI created any
-          #    for non-allowlisted skills before we pruned the source dirs).
-          if [ -d .claude/skills ]; then
-            for link in .claude/skills/*; do
-              [ -e "$link" ] || [ -L "$link" ] || continue
-              name=$(basename "$link")
-              is_allowed "$name" || rm -rf "$link"
-            done
-          fi
+          # 2. Claude Code reads skills from .claude/skills/, so keep it in
+          #    lockstep with the allowlist: one symlink per allowlisted skill,
+          #    no extras. `ln -sfn` makes the write idempotent.
+          mkdir -p .claude/skills
+          for name in $ALLOWLIST; do
+            ln -sfn "../../.agents/skills/$name" ".claude/skills/$name"
+          done
+          for link in .claude/skills/*; do
+            [ -e "$link" ] || [ -L "$link" ] || continue
+            name=$(basename "$link")
+            is_allowed "$name" || rm -rf "$link"
+          done
           # 3. skills-lock.json — keep only allowlisted entries.
           allow_json=$(printf '%s\n' $ALLOWLIST | jq -Rn '[inputs]')
           tmp=$(mktemp)

--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,11 @@ backups/
 playwright-report/
 test-results/
 
-# Claude Code
-.claude/
+# Claude Code — tool config stays local, but .claude/skills/ is tracked so
+# Claude Code users on teammate machines see the allowlisted skills.
+.claude/*
+!.claude/skills/
+!.claude/skills/**
 
 # IDE
 .vscode/


### PR DESCRIPTION
## Summary
- Add the 2 missing symlinks (`vercel-react-view-transitions`, `webapp-testing`) under [.claude/skills/](.claude/skills/) so Claude Code on teammate machines sees the full allowlist, not just the 4 that were force-added at initial setup.
- Narrow [.gitignore](.gitignore) from `.claude/` to `.claude/*` + `!.claude/skills/` + `!.claude/skills/**`, so `.claude/skills/` is tracked like any other directory while local tool config (e.g. `.claude/launch.json`) stays ignored.
- Extend the `Prune non-allowlisted skills` step in [.github/workflows/update-skills.yml](.github/workflows/update-skills.yml) to `ln -sfn` one symlink per allowlisted skill under `.claude/skills/` and delete any extras. Going forward, editing the `ALLOWLIST` env in one place makes `.agents/skills/`, `.claude/skills/`, and `skills-lock.json` all converge on the next run.

## Test plan
- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm test` passes locally (782 passed, 293 skipped)
- [x] `git check-ignore` confirms: the 2 new symlinks are tracked, `.claude/launch.json` still ignored
- [x] Dry-ran the workflow's `.claude/skills/` sync loop in a temp dir — adds missing allowlisted symlinks, removes extras
- [ ] After merge, manually dispatch `Update Agent Skills` and confirm the resulting PR is empty or only touches allowlisted skills (no drift between `.agents/skills/`, `.claude/skills/`, `skills-lock.json`)

Closes #175