### PR TITLE
Drop port 80 publish from nginx-prod (#204)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,6 @@ services:
     image: nginx:alpine
     profiles: [prod]
     ports:
-      - "80:80"
       - "443:443"
     volumes:
       - ./infra/nginx/nginx.prod.conf:/etc/nginx/conf.d/default.conf:ro


### PR DESCRIPTION
## Summary

Stops publishing host port `80` from the `nginx-prod` service in `docker-compose.yml`. The `nginx-prod` ports list now only contains `"443:443"`.

The product already mandates HTTPS end-to-end (OIDC redirect URIs, CSRF, cookie `Secure` flag), so any traffic that lands on host `:80` either errors or has to be redirected. Doing that redirect in this stack's nginx mixes responsibilities — if an operator wants HTTP→HTTPS upgrade on the host edge, that belongs in their load balancer / reverse proxy. Freeing `:80` also lets a paired closed-network instance (e.g. `aice-web-next` during integration tests) co-locate on the same host, and avoids `docker compose up` failing with no actionable signal on hosts where something already owns `:80`.

`nginx-dev` is left as-is for developer convenience. `nginx-prod.conf` itself is untouched — this PR is purely about whether the host publishes `:80`.

Paired with aicers/aice-web-next#449 (move that side's prod nginx to a non-standard HTTPS port; `aimer-web` claims the conventional `:443` as the internet-facing peer).

Closes #204

## Test plan

- [x] `docker compose --profile prod config` shows `nginx-prod` published ports list only `443`
- [x] `docker compose --profile prod up` does not bind host `:80`
- [x] `https://localhost/...` (host port 443) still reaches the app
- [x] `nginx-dev` ports list is unchanged (still publishes `:80`)
- [x] Manual smoke: sign-in + bridge POST happy path still pass through the prod nginx + Keycloak stack
- [x] `pnpm check` passes