### PR TITLE
Encode events_envelope payload_hash as base64url (#206)

### DIFF
--- a/src/app/api/auth/__tests__/bridge-entry.db.test.ts
+++ b/src/app/api/auth/__tests__/bridge-entry.db.test.ts
@@ -216,7 +216,7 @@ describe.skipIf(!hasPostgres)(
         '{"hello":"world","schema_version":"0.0-stub","event_count":1}';
       const expectedHash = createHash("sha256")
         .update(new TextEncoder().encode(jsonString))
-        .digest("hex");
+        .digest("base64url");
 
       const envelope = await signEnvelope({
         payloadHash: expectedHash,
@@ -288,7 +288,7 @@ describe.skipIf(!hasPostgres)(
       const jsonString = '{"too":"big-for-the-cap"}';
       const hash = createHash("sha256")
         .update(new TextEncoder().encode(jsonString))
-        .digest("hex");
+        .digest("base64url");
       const envelope = await signEnvelope({
         payloadHash: hash,
         contextJti: jti,

--- a/src/lib/auth/__tests__/events-envelope.unit.test.ts
+++ b/src/lib/auth/__tests__/events-envelope.unit.test.ts
@@ -31,7 +31,9 @@ afterEach(() => {
 });
 
 const samplePayload = Buffer.from("detection events binary data");
-const sampleHash = createHash("sha256").update(samplePayload).digest("hex");
+const sampleHash = createHash("sha256")
+  .update(samplePayload)
+  .digest("base64url");
 
 const baseClaims: ContextTokenClaims = {
   iss: "https://aice.test",

--- a/src/lib/auth/events-envelope.ts
+++ b/src/lib/auth/events-envelope.ts
@@ -142,7 +142,11 @@ export async function verifyEventsEnvelope(
   }
 
   // 4. Verify payload_hash matches SHA-256 of events_data
-  const computedHash = createHash("sha256").update(eventsData).digest("hex");
+  // base64url encoding follows RFC 7515 (JWS) conventions used by the
+  // sender (aice-web-next/src/lib/aimer/events-envelope.ts).
+  const computedHash = createHash("sha256")
+    .update(eventsData)
+    .digest("base64url");
   if (computedHash !== payloadHash) {
     throw new Error("Events envelope payload_hash mismatch");
   }


### PR DESCRIPTION
## Summary

Fixes the bridge handoff so receiver-side verification of `events_envelope.payload_hash` agrees with the `aice-web-next` sender.

The sender encodes the SHA-256 digest of `events_data` as base64url (`aice-web-next/src/lib/aimer/events-envelope.ts`). The receiver was computing `digest("hex")`, so equality could never hold (43 vs 64 chars) and every envelope was rejected with `payload_hash mismatch`.

- `src/lib/auth/events-envelope.ts`: switch the comparison digest to `base64url`, matching JWS conventions (RFC 7515 §3) and the sender's existing behavior. Node 24's `digest("base64url")` is supported natively.
- Tests: update fixtures in `src/lib/auth/__tests__/events-envelope.unit.test.ts` and `src/app/api/auth/__tests__/bridge-entry.db.test.ts` so the receiver roundtrip exercises base64url, not hex.
- No DB migration: `staged_event_payloads.payload_hash` is `TEXT` and stores the 43-char base64url value verbatim.
- No paired sender change required — `aice-web-next` is already on base64url.

Cross-repo automated regression coverage is tracked separately under #203 / `aice-web-next#444`.

Closes #206

## Test plan

- [x] `pnpm vitest run src/lib/auth/__tests__/events-envelope.unit.test.ts` passes with base64url fixtures
- [x] `pnpm vitest run src/app/api/auth/__tests__/bridge-entry.db.test.ts` passes against Postgres with base64url fixtures
- [x] `pnpm tsc --noEmit` and `pnpm biome check` clean on changed files
- [x] Manual end-to-end against a real `aice-web-next` BFF: clicking *Send to Aimer* yields a 307 redirect to `/api/auth/sign-in?flow=bridge` on `aimer-web`
- [x] `pending_connections` row created for the request
- [x] `staged_event_payloads` row created with the envelope's base64url `payload_hash` (43 chars, no padding) stored verbatim
- [x] `audit_logs` records `bridge.connection_request` (success), not `bridge.connection_denied` / `envelope_rejected`