### PR TITLE
Switch agent-dir prune from denylist to allowlist

### DIFF
--- a/.github/workflows/update-skills.yml
+++ b/.github/workflows/update-skills.yml
@@ -30,12 +30,29 @@ jobs:
       #   - codex and gemini-cli are universal agents that read directly
       #     from `.agents/skills/`, so no extra dir is needed for them
       # Prune everything else so the weekly PR stays small.
+      #
+      # Deletion is scoped to the shapes the `skills` CLI actually produces:
+      #   - root `skills/` (legacy top-level dir)
+      #   - `.<agent>/skills/`
+      #   - `.<agent>/agent/skills/`
+      # The dot-prefix gate protects future non-dotted project dirs that may
+      # happen to contain a `skills/` subdir (e.g. `tools/skills/`) from being
+      # wiped. If the CLI ever introduces a structurally different layout, the
+      # next weekly PR will surface it and we extend the shape list here.
       - name: Prune non-allowlisted agent directories
         run: |
-          rm -rf .adal .agent .augment .bob .codebuddy .commandcode .continue \
-            .cortex .crush .factory .goose .iflow .junie .kilocode .kiro \
-            .kode .mcpjam .mux .neovate .openhands .pi .pochi .qoder .qwen \
-            .roo .trae .vibe .windsurf .zencoder skills
+          shopt -s nullglob dotglob
+          for entry in */ .*/; do
+            name=${entry%/}
+            case "$name" in
+              .|..|.git|.github|.agents|.claude) continue ;;
+            esac
+            if [ "$name" = "skills" ] ||
+               { [ "${name#.}" != "$name" ] &&
+                 { [ -d "$name/skills" ] || [ -d "$name/agent/skills" ]; }; }; then
+              rm -rf "$name"
+            fi
+          done
       # `skills update` pulls every skill its configured source repos expose,
       # including new ones we never opted in to (see PR #172: it re-added the
       # previously-removed `vercel-react-native-skills` and added a brand-new


### PR DESCRIPTION
## Summary

Replace the hardcoded agent-dir denylist in `.github/workflows/update-skills.yml` with a shape-based prune that catches any future `.<agent>/skills/` or `.<agent>/agent/skills/` layout the `skills` CLI may produce.

This mirrors the workflow already shipped in the sibling `aice-web-next` repo.

## What changed

- Removed the long `rm -rf .adal .agent .augment …` line.
- Added a loop that walks `*/ .*/`, skips `.git`, `.github`, `.agents`, `.claude`, and removes:
  - the legacy root `skills/` dir
  - any dot-prefixed dir containing `skills/` or `agent/skills/`
- Expanded the comment block to document the deletion shapes and the dot-prefix safety gate.

## Why

When the `skills` CLI adds support for new agents, those directories slip past the denylist and end up in the auto-generated PR (see #190 for an example: `.aider-desk`, `.codeartsdoer`, `.codemaker`, `.codestudio`, `.devin`, `.forge`, `.rovodev`, `.tabnine` all leaked through). The allowlist-by-shape approach is name-agnostic and self-extending.

The dot-prefix gate protects future non-dotted project dirs that may happen to contain a `skills/` subdir (e.g. a hypothetical `tools/skills/`) from being wiped — a full-root allowlist would be unsafe because the prune step runs after `actions/checkout`, with tracked repo dirs (`src/`, `docs/`, …) present alongside CLI-generated ones.

## Test plan

Simulated the issue's verification scenario locally:

```bash
mkdir -p .devin/skills .tabnine/agent/skills .aider-desk/skills skills tools/skills src docs .github .agents/skills .claude/skills
# ran the new prune script
```

Results:
- [x] `.devin`, `.tabnine`, `.aider-desk`, root `skills/` removed
- [x] `tools/skills/` survives (dot-prefix gate works)
- [x] `src/`, `docs/`, `.github/`, `.agents/`, `.claude/` untouched

Closes #191