### PR TITLE
Add Phase 2 customer DB tables (#216)

### DIFF
--- a/migrations/customer/0002_phase2_tables.sql
+++ b/migrations/customer/0002_phase2_tables.sql
@@ -1,0 +1,187 @@
+-- Phase 2 ingestion tables (per RFC 0002 §5).
+--
+-- Encryption-at-rest decision (RFC 0002 §11.1): this migration ships
+-- option (c) — plaintext columns with relational integrity, relying on
+-- DB-level TDE / disk-level encryption. The plaintext shape enables the
+-- range scans, joins and category/kind filters Phase 2 reports need.
+-- If a future security review requires column-level encryption (options
+-- (a) full or (b) selective), the migration can be extended in a
+-- follow-up. analysis_narrative.narrative inherits the same plaintext +
+-- DB-level-TDE assumption as the source events; if column-level
+-- encryption is re-introduced for ingest payloads, narratives MUST
+-- follow under the same envelope.
+
+-- ---------------------------------------------------------------
+-- baseline_event
+-- ---------------------------------------------------------------
+-- baseline_score is NOT stored — it is a read-time
+-- CUME_DIST() OVER (kind, baseline_version) per RFC 0001 §3. The exact
+-- value at push time is captured in score_window_context.baseline_rank_snapshot.
+--
+-- event_key is NOT unique across baseline_version values — the same
+-- REview event can appear under multiple baseline_versions if it
+-- survives a rebaseline. The standalone event_key index supports
+-- event_key-only joins from policy_event; read helpers MUST dedupe
+-- with a "latest by received_at" (or equivalent) rule.
+CREATE TABLE baseline_event (
+    baseline_version    TEXT          NOT NULL,
+    event_key           NUMERIC(39, 0) NOT NULL,
+    event_time          TIMESTAMPTZ   NOT NULL,
+    kind                TEXT          NOT NULL,
+    category            TEXT,
+    primary_asset       TEXT,
+    raw_score           DOUBLE PRECISION NOT NULL,
+    selector_tags       TEXT[]        NOT NULL DEFAULT '{}',
+    raw_event           JSONB         NOT NULL,
+    score_window_context JSONB        NOT NULL,
+    window_signals      JSONB         NOT NULL,
+    asset_context       JSONB,
+    scoring_weights_snapshot JSONB    NOT NULL,
+    source_aice_id      TEXT          NOT NULL,
+    received_at         TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (baseline_version, event_key)
+);
+
+CREATE INDEX baseline_event_event_time_idx ON baseline_event (event_time);
+CREATE INDEX baseline_event_kind_idx ON baseline_event (kind);
+CREATE INDEX baseline_event_category_idx ON baseline_event (category);
+CREATE INDEX baseline_event_primary_asset_idx ON baseline_event (primary_asset);
+CREATE INDEX baseline_event_raw_score_idx ON baseline_event (raw_score);
+CREATE INDEX baseline_event_event_key_idx ON baseline_event (event_key);
+
+-- ---------------------------------------------------------------
+-- story / story_member
+-- ---------------------------------------------------------------
+CREATE TABLE story (
+    story_id            BIGINT        NOT NULL,
+    story_version       TEXT          NOT NULL,
+    kind                TEXT          NOT NULL CHECK (kind IN ('auto_correlated', 'analyst_curated')),
+    correlation_rule_id TEXT,
+    primary_asset       TEXT,
+    time_window_start   TIMESTAMPTZ   NOT NULL,
+    time_window_end     TIMESTAMPTZ   NOT NULL,
+    score               DOUBLE PRECISION,
+    summary_payload     JSONB         NOT NULL,
+    source_aice_id      TEXT          NOT NULL,
+    received_at         TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (story_id, story_version)
+);
+
+CREATE INDEX story_time_window_idx ON story (time_window_start, time_window_end);
+CREATE INDEX story_primary_asset_idx ON story (primary_asset);
+CREATE INDEX story_score_idx ON story (score);
+
+CREATE TABLE story_member (
+    story_id            BIGINT        NOT NULL,
+    story_version       TEXT          NOT NULL,
+    member_event_key    NUMERIC(39, 0) NOT NULL,
+    role                TEXT          NOT NULL CHECK (role IN ('primary', 'context')),
+    event               JSONB         NOT NULL,
+    PRIMARY KEY (story_id, story_version, member_event_key),
+    FOREIGN KEY (story_id, story_version) REFERENCES story (story_id, story_version) ON DELETE CASCADE
+);
+
+-- ---------------------------------------------------------------
+-- policy_run / policy_event
+-- ---------------------------------------------------------------
+-- replaces is a soft reference (no FK) — the prior run may never have
+-- been ingested (sender does not guarantee predecessor delivery) or
+-- may have been retention-swept.
+--
+-- summary_stats has NO CHECK constraint on shape: a DB-level
+-- jsonb_typeof = 'object' check would couple the schema to today's
+-- payload variant and break forward-compat with future
+-- phase2.policy_run.v1 minor extensions. The "is JSON object"
+-- guarantee lives in the ingest endpoint (Zod), not this column.
+CREATE TABLE policy_run (
+    run_id              BIGINT        PRIMARY KEY,
+    owner_account_id    UUID,
+    period_start        TIMESTAMPTZ   NOT NULL,
+    period_end          TIMESTAMPTZ   NOT NULL,
+    created_at_source   TIMESTAMPTZ   NOT NULL,
+    finalized_at_source TIMESTAMPTZ,
+    baseline_version    TEXT          NOT NULL,
+    policies_fingerprint   TEXT       NOT NULL,
+    exclusions_fingerprint TEXT       NOT NULL,
+    status              TEXT          NOT NULL CHECK (status IN ('ready', 'superseded')),
+    replaces            BIGINT,
+    summary_stats       JSONB,
+    source_aice_id      TEXT          NOT NULL,
+    received_at         TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX policy_run_created_at_idx ON policy_run (created_at_source);
+CREATE INDEX policy_run_finalized_at_idx ON policy_run (finalized_at_source);
+CREATE INDEX policy_run_baseline_version_idx ON policy_run (baseline_version);
+
+-- policy_event intentionally omits raw_score / selector_tags /
+-- window_signals — corpus B on aice-web-next is policy-mode only and
+-- does not store baseline-centric snapshots. Aimer-web can join
+-- against baseline_event by event_key (supported by
+-- baseline_event_event_key_idx above) for baseline enrichment.
+CREATE TABLE policy_event (
+    run_id              BIGINT        NOT NULL,
+    event_key           NUMERIC(39, 0) NOT NULL,
+    event_time          TIMESTAMPTZ   NOT NULL,
+    kind                TEXT          NOT NULL,
+    sensor              TEXT,
+    orig_addr           INET,
+    orig_port           INTEGER,
+    resp_addr           INET,
+    resp_port           INTEGER,
+    proto               INTEGER,
+    host                TEXT,
+    dns_query           TEXT,
+    uri                 TEXT,
+    category            TEXT,
+    policy_triage_snapshot JSONB     NOT NULL,
+    PRIMARY KEY (run_id, event_key),
+    FOREIGN KEY (run_id) REFERENCES policy_run (run_id) ON DELETE CASCADE
+);
+
+CREATE INDEX policy_event_event_time_idx ON policy_event (event_time);
+CREATE INDEX policy_event_kind_idx ON policy_event (kind);
+CREATE INDEX policy_event_category_idx ON policy_event (category);
+
+-- ---------------------------------------------------------------
+-- analysis_narrative
+-- ---------------------------------------------------------------
+-- content_hash is computed by aimer-web at insert time as
+-- hash(target_kind, target_keys, summary_payload, signals,
+-- prompt_version, model_version). Insert-once semantics: every input
+-- that feeds content_hash is in the hash, so any change produces a
+-- new row — there is no UPDATE path. A model version bump produces a
+-- new row; the old row remains until retention sweeps it.
+--
+-- v1 access pattern is content_hash lookup only. Reverse lookup by
+-- target_keys is not supported in v1 — add CREATE INDEX
+-- CONCURRENTLY ... USING GIN (target_keys) in a follow-up if needed.
+--
+-- No FK to target tables — narrative rows outlive their target row
+-- when retention removes the source (RFC 0002 §5).
+CREATE TABLE analysis_narrative (
+    content_hash        TEXT          PRIMARY KEY,
+    target_kind         TEXT          NOT NULL CHECK (target_kind IN ('baseline_event', 'story', 'policy_run')),
+    target_keys         JSONB         NOT NULL,
+    narrative           TEXT          NOT NULL,
+    prompt_version      TEXT          NOT NULL,
+    model_version       TEXT          NOT NULL,
+    generated_at        TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX analysis_narrative_target_kind_generated_at_idx
+    ON analysis_narrative (target_kind, generated_at);
+
+-- ---------------------------------------------------------------
+-- Runtime role grants
+-- ---------------------------------------------------------------
+-- DELETE is granted for the Phase 2 mutation endpoints (withdraw,
+-- refresh-window) and for retention sweeps. analysis_narrative is
+-- insert-once at the app level (no UPDATE); DELETE is granted for
+-- retention sweeps and potential cache invalidation.
+GRANT SELECT, INSERT, DELETE ON baseline_event TO aimer_customer;
+GRANT SELECT, INSERT, DELETE ON story TO aimer_customer;
+GRANT SELECT, INSERT, DELETE ON story_member TO aimer_customer;
+GRANT SELECT, INSERT, DELETE ON policy_run TO aimer_customer;
+GRANT SELECT, INSERT, DELETE ON policy_event TO aimer_customer;
+GRANT SELECT, INSERT, DELETE ON analysis_narrative TO aimer_customer;

--- a/src/lib/db/__tests__/customer-schema.db.test.ts
+++ b/src/lib/db/__tests__/customer-schema.db.test.ts
@@ -407,7 +407,12 @@ describe.skipIf(!hasPostgres)("Schema verification (customer_db)", () => {
       }
     });
 
-    it("can INSERT and DELETE on baseline_event", async () => {
+    it("can INSERT and DELETE on every Phase 2 table", async () => {
+      // INSERT order respects FK dependencies: story before story_member,
+      // policy_run before policy_event. DELETE walks the children first
+      // so each child-table DELETE grant is exercised directly (not via
+      // ON DELETE CASCADE from the parent).
+
       await rolePool.query(
         `INSERT INTO baseline_event (
           baseline_version, event_key, event_time, kind,
@@ -418,9 +423,67 @@ describe.skipIf(!hasPostgres)("Schema verification (customer_db)", () => {
           0.1, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 'aice'
         )`,
       );
+
+      await rolePool.query(
+        `INSERT INTO story (
+          story_id, story_version, kind,
+          time_window_start, time_window_end,
+          summary_payload, source_aice_id
+        ) VALUES (
+          900, 'role-test', 'auto_correlated',
+          NOW(), NOW(),
+          '{}'::jsonb, 'aice'
+        )`,
+      );
+      await rolePool.query(
+        `INSERT INTO story_member (
+          story_id, story_version, member_event_key, role, event
+        ) VALUES (900, 'role-test', 1, 'primary', '{}'::jsonb)`,
+      );
+
+      await rolePool.query(
+        `INSERT INTO policy_run (
+          run_id, period_start, period_end, created_at_source,
+          baseline_version, policies_fingerprint, exclusions_fingerprint,
+          status, source_aice_id
+        ) VALUES (
+          900, NOW(), NOW(), NOW(),
+          'v1', 'p', 'e', 'ready', 'aice'
+        )`,
+      );
+      await rolePool.query(
+        `INSERT INTO policy_event (
+          run_id, event_key, event_time, kind,
+          policy_triage_snapshot
+        ) VALUES (900, 1, NOW(), 'http', '[]'::jsonb)`,
+      );
+
+      await rolePool.query(
+        `INSERT INTO analysis_narrative (
+          content_hash, target_kind, target_keys, narrative,
+          prompt_version, model_version
+        ) VALUES (
+          'role-test-hash', 'story', '{"story_id":900}'::jsonb, 'n',
+          'pv', 'mv'
+        )`,
+      );
+
+      // DELETE children directly to confirm the DELETE grant on each
+      // child table (not just the cascade from the parent).
+      await rolePool.query(
+        "DELETE FROM story_member WHERE story_id = 900 AND story_version = 'role-test'",
+      );
+      await rolePool.query("DELETE FROM policy_event WHERE run_id = 900");
+      await rolePool.query(
+        "DELETE FROM analysis_narrative WHERE content_hash = 'role-test-hash'",
+      );
       await rolePool.query(
         "DELETE FROM baseline_event WHERE baseline_version = 'role-test'",
       );
+      await rolePool.query(
+        "DELETE FROM story WHERE story_id = 900 AND story_version = 'role-test'",
+      );
+      await rolePool.query("DELETE FROM policy_run WHERE run_id = 900");
     });
 
     it("cannot UPDATE on any Phase 2 table", async () => {

--- a/src/lib/db/__tests__/customer-schema.db.test.ts
+++ b/src/lib/db/__tests__/customer-schema.db.test.ts
@@ -1,0 +1,447 @@
+import { join } from "node:path";
+import type { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { runMigrations } from "../migrate";
+import {
+  closeAdminPool,
+  createRolePool,
+  createTestDatabase,
+  dropTestDatabase,
+  hasPostgres,
+} from "./db-test-helpers";
+
+const CUSTOMER_MIGRATIONS_DIR = join(process.cwd(), "migrations", "customer");
+const LOCK_ID_CUSTOMER = 1002;
+
+describe.skipIf(!hasPostgres)("Schema verification (customer_db)", () => {
+  let dbName: string;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    const db = await createTestDatabase("schema_customer");
+    dbName = db.dbName;
+    pool = db.pool;
+
+    await runMigrations(pool, CUSTOMER_MIGRATIONS_DIR, LOCK_ID_CUSTOMER);
+  });
+
+  afterAll(async () => {
+    await dropTestDatabase(dbName, pool);
+    await closeAdminPool();
+  });
+
+  it("applies all customer migrations cleanly", async () => {
+    const { rows } = await pool.query(
+      "SELECT version FROM _migrations ORDER BY version",
+    );
+    // 0000_extensions, 0001_detection_events, 0002_phase2_tables
+    expect(rows.map((r) => r.version)).toEqual(["0000", "0001", "0002"]);
+  });
+
+  it("creates all six Phase 2 tables", async () => {
+    const { rows } = await pool.query(`
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_schema = 'public'
+        AND table_name IN (
+          'baseline_event',
+          'story',
+          'story_member',
+          'policy_run',
+          'policy_event',
+          'analysis_narrative'
+        )
+      ORDER BY table_name
+    `);
+    expect(rows.map((r) => r.table_name)).toEqual([
+      "analysis_narrative",
+      "baseline_event",
+      "policy_event",
+      "policy_run",
+      "story",
+      "story_member",
+    ]);
+  });
+
+  // -- Representative inserts --
+
+  describe("representative inserts", () => {
+    it("accepts a baseline_event row", async () => {
+      await pool.query(
+        `INSERT INTO baseline_event (
+          baseline_version, event_key, event_time, kind, category,
+          primary_asset, raw_score, selector_tags, raw_event,
+          score_window_context, window_signals, asset_context,
+          scoring_weights_snapshot, source_aice_id
+        ) VALUES (
+          'v1', 12345, NOW(), 'dns', 'recon',
+          'host-1', 0.75, ARRAY['t1','t2']::TEXT[], '{"foo":"bar"}'::jsonb,
+          '{"baseline_rank_snapshot":0.9}'::jsonb,
+          '{"s1":1,"s3":2,"s4":3}'::jsonb, '{"peer_event_summary":{}}'::jsonb,
+          '{"weights":{}}'::jsonb, 'aice-1'
+        )`,
+      );
+
+      const { rows } = await pool.query(
+        "SELECT event_key::text AS event_key FROM baseline_event WHERE baseline_version = 'v1'",
+      );
+      expect(rows[0].event_key).toBe("12345");
+    });
+
+    it("supports event_key-only joins via baseline_event_event_key_idx", async () => {
+      // Insert two rows with the same event_key but different baseline_versions
+      // — the standalone event_key index must permit this lookup.
+      await pool.query(
+        `INSERT INTO baseline_event (
+          baseline_version, event_key, event_time, kind,
+          raw_score, raw_event, score_window_context, window_signals,
+          scoring_weights_snapshot, source_aice_id
+        ) VALUES
+          ('v-a', 99, NOW(), 'http', 0.1, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 'aice'),
+          ('v-b', 99, NOW(), 'http', 0.2, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 'aice')`,
+      );
+      const { rows } = await pool.query(
+        "SELECT COUNT(*)::int AS c FROM baseline_event WHERE event_key = 99",
+      );
+      expect(rows[0].c).toBe(2);
+    });
+
+    it("accepts a story and its story_member rows", async () => {
+      await pool.query(
+        `INSERT INTO story (
+          story_id, story_version, kind, primary_asset,
+          time_window_start, time_window_end, score,
+          summary_payload, source_aice_id
+        ) VALUES (
+          1, 's1', 'auto_correlated', 'asset-1',
+          NOW(), NOW(), 0.5,
+          '{}'::jsonb, 'aice-1'
+        )`,
+      );
+
+      await pool.query(
+        `INSERT INTO story_member (
+          story_id, story_version, member_event_key, role, event
+        ) VALUES (1, 's1', 100, 'primary', '{}'::jsonb)`,
+      );
+
+      const { rows } = await pool.query(
+        "SELECT role FROM story_member WHERE story_id = 1 AND story_version = 's1'",
+      );
+      expect(rows[0].role).toBe("primary");
+    });
+
+    it("rejects story.kind outside the allowed set", async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO story (
+            story_id, story_version, kind,
+            time_window_start, time_window_end,
+            summary_payload, source_aice_id
+          ) VALUES (
+            2, 's1', 'invalid_kind',
+            NOW(), NOW(),
+            '{}'::jsonb, 'aice-1'
+          )`,
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("rejects story_member.role outside the allowed set", async () => {
+      await pool.query(
+        `INSERT INTO story (
+          story_id, story_version, kind,
+          time_window_start, time_window_end,
+          summary_payload, source_aice_id
+        ) VALUES (
+          3, 's1', 'analyst_curated',
+          NOW(), NOW(),
+          '{}'::jsonb, 'aice'
+        )`,
+      );
+      await expect(
+        pool.query(
+          `INSERT INTO story_member (
+            story_id, story_version, member_event_key, role, event
+          ) VALUES (3, 's1', 1, 'invalid_role', '{}'::jsonb)`,
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("accepts a policy_run and policy_event row", async () => {
+      await pool.query(
+        `INSERT INTO policy_run (
+          run_id, period_start, period_end, created_at_source,
+          baseline_version, policies_fingerprint, exclusions_fingerprint,
+          status, source_aice_id
+        ) VALUES (
+          10, NOW(), NOW(), NOW(),
+          'v1', 'pfp', 'efp',
+          'ready', 'aice-1'
+        )`,
+      );
+      await pool.query(
+        `INSERT INTO policy_event (
+          run_id, event_key, event_time, kind, sensor,
+          orig_addr, orig_port, resp_addr, resp_port, proto,
+          host, dns_query, uri, category,
+          policy_triage_snapshot
+        ) VALUES (
+          10, 200, NOW(), 'http', 'sensor-1',
+          '10.0.0.1'::inet, 1234, '10.0.0.2'::inet, 80, 6,
+          'example.com', NULL, '/x', 'recon',
+          '[{"policyId":"p1","score":0.5}]'::jsonb
+        )`,
+      );
+      const { rows } = await pool.query(
+        "SELECT event_key::text AS event_key FROM policy_event WHERE run_id = 10",
+      );
+      expect(rows[0].event_key).toBe("200");
+    });
+
+    it("rejects policy_run.status outside the allowed set", async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO policy_run (
+            run_id, period_start, period_end, created_at_source,
+            baseline_version, policies_fingerprint, exclusions_fingerprint,
+            status, source_aice_id
+          ) VALUES (
+            11, NOW(), NOW(), NOW(),
+            'v1', 'p', 'e', 'invalid', 'aice'
+          )`,
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("accepts varied summary_stats shapes (no sub-shape enforced)", async () => {
+      // Per RFC 0002 §11 / issue #216: the DB intentionally does NOT
+      // enforce a sub-shape on summary_stats.
+      const shapes: Array<Record<string, unknown> | null> = [
+        null,
+        {},
+        { total_events: 1 },
+        {
+          event_count: 100,
+          policy_breakdown: [{ policy_id: "p1", count: 10, score_sum: 1.5 }],
+          kind_breakdown: [{ kind: "http", count: 50 }],
+          category_breakdown: [{ category: "recon", count: 20 }],
+        },
+      ];
+      for (let i = 0; i < shapes.length; i++) {
+        await pool.query(
+          `INSERT INTO policy_run (
+            run_id, period_start, period_end, created_at_source,
+            baseline_version, policies_fingerprint, exclusions_fingerprint,
+            status, summary_stats, source_aice_id
+          ) VALUES (
+            $1, NOW(), NOW(), NOW(),
+            'v1', 'p', 'e', 'ready', $2::jsonb, 'aice'
+          )`,
+          [1000 + i, shapes[i] === null ? null : JSON.stringify(shapes[i])],
+        );
+      }
+    });
+
+    it("accepts an analysis_narrative row", async () => {
+      await pool.query(
+        `INSERT INTO analysis_narrative (
+          content_hash, target_kind, target_keys, narrative,
+          prompt_version, model_version
+        ) VALUES (
+          'hash-1', 'story', '{"story_id":1}'::jsonb, 'narrative text',
+          'p-v1', 'm-v1'
+        )`,
+      );
+    });
+
+    it("rejects analysis_narrative.target_kind outside the allowed set", async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO analysis_narrative (
+            content_hash, target_kind, target_keys, narrative,
+            prompt_version, model_version
+          ) VALUES (
+            'hash-bad', 'invalid', '{}'::jsonb, 'n', 'pv', 'mv'
+          )`,
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  // -- FK cascades + soft references --
+
+  describe("FK cascade behavior", () => {
+    it("deletes story_member rows when their story is deleted", async () => {
+      await pool.query(
+        `INSERT INTO story (
+          story_id, story_version, kind,
+          time_window_start, time_window_end,
+          summary_payload, source_aice_id
+        ) VALUES (
+          50, 's1', 'auto_correlated',
+          NOW(), NOW(),
+          '{}'::jsonb, 'aice'
+        )`,
+      );
+      await pool.query(
+        `INSERT INTO story_member (
+          story_id, story_version, member_event_key, role, event
+        ) VALUES
+          (50, 's1', 1, 'primary', '{}'::jsonb),
+          (50, 's1', 2, 'context', '{}'::jsonb)`,
+      );
+
+      await pool.query(
+        "DELETE FROM story WHERE story_id = 50 AND story_version = 's1'",
+      );
+
+      const { rows } = await pool.query(
+        "SELECT COUNT(*)::int AS c FROM story_member WHERE story_id = 50",
+      );
+      expect(rows[0].c).toBe(0);
+    });
+
+    it("deletes policy_event rows when their policy_run is deleted", async () => {
+      await pool.query(
+        `INSERT INTO policy_run (
+          run_id, period_start, period_end, created_at_source,
+          baseline_version, policies_fingerprint, exclusions_fingerprint,
+          status, source_aice_id
+        ) VALUES (
+          60, NOW(), NOW(), NOW(),
+          'v1', 'p', 'e', 'ready', 'aice'
+        )`,
+      );
+      await pool.query(
+        `INSERT INTO policy_event (
+          run_id, event_key, event_time, kind,
+          policy_triage_snapshot
+        ) VALUES
+          (60, 1, NOW(), 'http', '[]'::jsonb),
+          (60, 2, NOW(), 'dns', '[]'::jsonb)`,
+      );
+
+      await pool.query("DELETE FROM policy_run WHERE run_id = 60");
+
+      const { rows } = await pool.query(
+        "SELECT COUNT(*)::int AS c FROM policy_event WHERE run_id = 60",
+      );
+      expect(rows[0].c).toBe(0);
+    });
+
+    it("policy_run.replaces is a soft reference (no FK) — referenced run can be deleted", async () => {
+      await pool.query(
+        `INSERT INTO policy_run (
+          run_id, period_start, period_end, created_at_source,
+          baseline_version, policies_fingerprint, exclusions_fingerprint,
+          status, source_aice_id
+        ) VALUES (
+          70, NOW(), NOW(), NOW(),
+          'v1', 'p', 'e', 'superseded', 'aice'
+        )`,
+      );
+      await pool.query(
+        `INSERT INTO policy_run (
+          run_id, period_start, period_end, created_at_source,
+          baseline_version, policies_fingerprint, exclusions_fingerprint,
+          status, replaces, source_aice_id
+        ) VALUES (
+          71, NOW(), NOW(), NOW(),
+          'v1', 'p', 'e', 'ready', 70, 'aice'
+        )`,
+      );
+
+      // Deleting the referenced run must succeed (no FK to enforce).
+      await pool.query("DELETE FROM policy_run WHERE run_id = 70");
+
+      // The dangling replaces value remains as-is.
+      const { rows } = await pool.query(
+        "SELECT replaces FROM policy_run WHERE run_id = 71",
+      );
+      expect(rows[0].replaces).toBe("70");
+    });
+  });
+
+  // -- aimer_customer role grants --
+
+  describe("aimer_customer role grants", () => {
+    let rolePool: Pool;
+
+    beforeAll(async () => {
+      // Ensure the runtime role exists in this test DB cluster and can
+      // connect / use the public schema. Re-grant the per-table
+      // privileges (the migration's GRANT statements already ran as
+      // superuser; we're just confirming via a separate connection).
+      await pool.query(`
+        DO $$ BEGIN
+          IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'aimer_customer') THEN
+            CREATE ROLE aimer_customer LOGIN PASSWORD 'changeme';
+          END IF;
+        END $$
+      `);
+      await pool.query(`GRANT CONNECT ON DATABASE ${dbName} TO aimer_customer`);
+      await pool.query("GRANT USAGE ON SCHEMA public TO aimer_customer");
+
+      rolePool = createRolePool(dbName, "aimer_customer", "changeme");
+    });
+
+    afterAll(async () => {
+      rolePool.on("error", () => {});
+      await rolePool.end();
+    });
+
+    const phase2Tables = [
+      "baseline_event",
+      "story",
+      "story_member",
+      "policy_run",
+      "policy_event",
+      "analysis_narrative",
+    ];
+
+    it("can SELECT on all Phase 2 tables", async () => {
+      for (const table of phase2Tables) {
+        const { rows } = await rolePool.query(`SELECT COUNT(*) FROM ${table}`);
+        expect(Number(rows[0].count)).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it("can INSERT and DELETE on baseline_event", async () => {
+      await rolePool.query(
+        `INSERT INTO baseline_event (
+          baseline_version, event_key, event_time, kind,
+          raw_score, raw_event, score_window_context, window_signals,
+          scoring_weights_snapshot, source_aice_id
+        ) VALUES (
+          'role-test', 1, NOW(), 'http',
+          0.1, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 'aice'
+        )`,
+      );
+      await rolePool.query(
+        "DELETE FROM baseline_event WHERE baseline_version = 'role-test'",
+      );
+    });
+
+    it("cannot UPDATE on any Phase 2 table", async () => {
+      // Choose a real column per table so the statement parses; if the
+      // role had UPDATE rights it would succeed (zero rows affected).
+      // Without UPDATE it fails with permission denied.
+      const updateCols: Record<string, string> = {
+        baseline_event: "source_aice_id",
+        story: "source_aice_id",
+        story_member: "role",
+        policy_run: "source_aice_id",
+        policy_event: "kind",
+        analysis_narrative: "narrative",
+      };
+      for (const table of phase2Tables) {
+        await expect(
+          rolePool.query(
+            `UPDATE ${table} SET ${updateCols[table]} = 'x' WHERE false`,
+          ),
+        ).rejects.toThrow(/permission denied/);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the foundational Phase 2 schema per RFC 0002 §5 — six new per-customer tables under `migrations/customer/0002_phase2_tables.sql`:

- `baseline_event` — REview baseline events with PK `(baseline_version, event_key)` and a standalone `event_key` index to support `event_key`-only joins from `policy_event`. `baseline_score` is intentionally not stored (read-time `CUME_DIST()` per RFC 0001 §3).
- `story` / `story_member` — auto-correlated and analyst-curated stories with `ON DELETE CASCADE` from `story` to `story_member`. `kind` and `role` are constrained by `CHECK`.
- `policy_run` / `policy_event` — policy-mode runs with `ON DELETE CASCADE`. `replaces` is a soft reference (no FK) since the prior run may never have been ingested or may have been retention-swept. `summary_stats` has no `CHECK` on shape — the "is JSON object" guarantee belongs to the Zod ingest layer (#218), not the column, so future minor extensions of `phase2.policy_run.v1` remain forward-compatible.
- `analysis_narrative` — LLM output keyed by `content_hash`; insert-once at the app level (no UPDATE grant). No FK to target tables so narratives can outlive retention sweeps of their targets.

Encryption-at-rest ships **option (c) — plaintext with relational integrity** — relying on DB-level/disk TDE. This enables the range scans, joins, and category/kind filters Phase 2 reports need. `analysis_narrative.narrative` inherits the same assumption; if a future security review re-introduces column-level encryption, narratives must follow under the same envelope. The decision is documented inline in the migration.

Runtime role grants extend `aimer_customer` with `SELECT, INSERT, DELETE` on all six tables — `DELETE` is required by the Phase 2 withdraw / refresh-window mutation endpoints and by retention sweeps. No `UPDATE` is granted on any of the six tables.

Adds `src/lib/db/__tests__/customer-schema.db.test.ts` (new file — `schema.db.test.ts` only covers auth/audit) covering migration apply, representative inserts, `CHECK` enforcement, FK cascade, soft-reference behavior of `policy_run.replaces`, varied `summary_stats` shapes, and the `aimer_customer` role grant matrix.

Closes #216

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm check` passes (Biome)
- [x] `pnpm test` passes (unit tests verified locally; DB tests skip without Postgres but run in CI)
- [x] `pnpm build` passes
- [x] Migration `0002_phase2_tables.sql` applies cleanly against a fresh per-customer DB
- [x] All six tables exist after migration with expected columns and indexes
- [x] `baseline_event` accepts representative inserts; standalone `event_key` index supports multi-`baseline_version` lookups for the same `event_key`
- [x] `story` / `story_member` accept representative inserts; `kind` and `role` `CHECK` constraints reject invalid values; deleting a `story` cascades to its `story_member` rows
- [x] `policy_run` / `policy_event` accept representative inserts; `status` `CHECK` rejects invalid values; deleting a `policy_run` cascades to its `policy_event` rows
- [x] `policy_run.replaces` is a soft reference — deleting a referenced run succeeds and leaves the dangling value as-is
- [x] `summary_stats` accepts varied shapes (`null`, `{}`, `{ total_events: 1 }`, the full breakdown example) with no sub-shape enforced
- [x] `analysis_narrative` accepts representative inserts; `target_kind` `CHECK` rejects values outside `baseline_event` / `story` / `policy_run`
- [x] `aimer_customer` role has `SELECT`, `INSERT`, `DELETE` on all six tables and is denied `UPDATE` on each
