### PR TITLE
Add Phase 2 mutation endpoints (#219)

### DIFF
--- a/docs/en/operations/phase2-ingest.md
+++ b/docs/en/operations/phase2-ingest.md
@@ -193,6 +193,14 @@ withdrawn `policy_run` and `story_member` children of a withdrawn
 automatically removed — they age out via aimer-web retention
 (RFC 0002 §6 withdraw).
 
+The Zod schema additionally rejects (with `400
+payload_schema_invalid`) payloads that combine `{ kind: "policy_run",
+run_id: R }` with any `{ kind: "policy_event", run_id: R, ... }` for
+the same run. The run's FK cascade already removes its policy_event
+rows, so the count attributed to the explicit policy_event item would
+otherwise depend on item order — `withdrawn` if processed before the
+run, `not_found` after the cascade ran — masking a sender bug.
+
 Response:
 
 ```json

--- a/docs/en/operations/phase2-ingest.md
+++ b/docs/en/operations/phase2-ingest.md
@@ -156,3 +156,163 @@ endpoint-specific fields:
 - story: `storiesAccepted`, `storiesDuplicates`,
   `membersAccepted`, `membersDuplicates`.
 - policy-run: `runId`, `runStatus` (`"new"` or `"duplicate"`).
+
+## Mutation endpoints
+
+In addition to the three ingest endpoints above, aimer-web exposes
+three Phase 2 mutation endpoints that DELETE or replace previously
+ingested data. They share the same multipart envelope contract,
+context-token verification, jti replay store, and audit category as
+the ingest routes.
+
+| Endpoint | Schema version | Semantics |
+| --- | --- | --- |
+| `POST /api/phase2/withdraw` | `phase2.withdraw.v1` | DELETE specific rows by natural key |
+| `POST /api/phase2/refresh-window` | `phase2.refresh_window.v1` | Atomically replace a `[from, to)` window |
+| `POST /api/phase2/backfill` | `phase2.backfill.v1` | Same shape and semantics as refresh-window, distinguished only by operator intent (and audit action) |
+
+### Withdraw
+
+The payload carries a non-empty `withdrawals` array; each item is
+discriminated by `kind`:
+
+- `baseline_event` — `{ baseline_version, event_keys[] }`
+- `story` — `{ story_id, story_version }`
+- `policy_event` — `{ run_id, event_keys[] }`
+- `policy_run` — `{ run_id }`
+
+All DELETEs run in a single per-customer transaction; if any one
+fails the whole call rolls back and the response is `500`. The
+response counts `withdrawn` and `not_found` rows separately —
+`not_found` is informational (the row was already gone), not an
+error. FK cascade automatically removes `policy_event` children of a
+withdrawn `policy_run` and `story_member` children of a withdrawn
+`story`; the route does not issue explicit child-table DELETEs.
+
+`analysis_narrative` rows whose target was withdrawn are NOT
+automatically removed — they age out via aimer-web retention
+(RFC 0002 §6 withdraw).
+
+Response:
+
+```json
+{
+  "withdrawn": 3,
+  "not_found": 1,
+  "received_at": "2026-05-17T10:23:45.012Z",
+  "context_jti": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+### Refresh-window and backfill
+
+Both endpoints atomically replace the contents of a half-open
+`[window.from, window.to)` interval. They are wire-identical: same
+payload shape, same response shape, same per-window advisory lock,
+same DELETE-then-INSERT semantics. The only differences are the
+envelope's `schema_version` claim and the success-path audit action
+(`phase2.refresh_window` vs `phase2.backfill`). Use `refresh-window`
+when aice-web-next ran a Force Rebuild; use `backfill` when an admin
+operator triggered the call.
+
+Payload:
+
+```json
+{
+  "external_key": "...",
+  "window": { "kind": "baseline_event", "from": "...", "to": "..." },
+  "baseline_version": "...",
+  "events": [ /* baseline_event rows; element shape matches phase2.baseline.v1 */ ]
+}
+```
+
+For a `story` window, replace `baseline_version` + `events` with
+`stories` (no `baseline_version` needed). The Zod schema rejects:
+
+- Stories with `kind: "analyst_curated"` — curated stories are never
+  affected by these endpoints (RFC 0002 §6).
+- Rows whose `event_time` (baseline) or `time_window.start` (story)
+  falls outside `[from, to)` — sender bug, fail-fast at `400
+  payload_schema_invalid`.
+- Payload-internal natural-key duplicates — same
+  `(baseline_version, event_key)`, `(story_id, story_version)`, or
+  `(story_id, story_version, member_event_key)`.
+
+The DELETE filter:
+
+- baseline: `baseline_version = $1 AND event_time >= $from AND event_time < $to`.
+  Other `baseline_version` rows in the same time window are
+  preserved.
+- story: `kind = 'auto_correlated' AND time_window_start >= $from AND
+  time_window_start < $to`. A story that *starts* before `from` but
+  whose `time_window_end` extends into the window is NOT removed by
+  the refresh — stories are assigned to their start time, mirroring
+  the producer-side Force Rebuild contract.
+
+Response:
+
+```json
+{
+  "accepted": 12,
+  "duplicates_skipped": 0,
+  "deleted": 7,
+  "received_at": "2026-05-17T10:23:45.012Z",
+  "context_jti": "..."
+}
+```
+
+`duplicates_skipped` is always `0` (the window is cleared before the
+INSERTs). `deleted` is an informational count of the rows the
+preceding DELETE removed. Re-running a backfill with the same body
+converges to the same end state (`accepted` will equal the new
+events/stories count; `deleted` will equal the previous run's
+`accepted`).
+
+### Advisory lock
+
+Refresh-window and backfill acquire a per-window advisory lock
+keyed on `phase2_window|<window_kind>|<external_key>|<from>|<to>`
+via `pg_advisory_xact_lock(hashtextextended(..., 0))` (single-bigint
+form). The kind segment of the key is the window's, not the
+operation's — a refresh and a backfill of the **same** window
+serialize against each other, which is the correctness invariant
+(both DELETE+INSERT the same rows). The audit action distinguishes
+intent; the lock distinguishes the window.
+
+Concurrent refreshes of different `baseline_version` values within
+the same time window touch disjoint rows but still serialize on the
+lock; if profiling shows contention this could be folded in as a
+follow-up.
+
+### Replay and DB-failure semantics
+
+The mutation endpoints share the ingest routes' replay store and
+post-verification failure semantics:
+
+- A replayed `context_jti` returns `409 context_jti_replay`,
+  performs NO DB mutation, does NOT acquire the per-window advisory
+  lock (a replay must not stall an unrelated concurrent refresh of
+  the same window), and emits NO `phase2.{withdraw,refresh_window,
+  backfill}` audit row.
+- A DB failure inside the per-customer transaction (e.g. cast
+  failure, FK violation) returns `500 database_error`, emits a
+  `phase2.ingest_failed` audit row (the action name is shared with
+  ingest by historical accident — it stands in for any
+  post-verification Phase 2 mutation failure), and leaves the
+  consumed `jti` in `phase2_consumed_jtis`. The caller must mint
+  fresh tokens to retry.
+
+### Audit details
+
+Success-path actions:
+
+- `phase2.withdraw` — `details` carries `schemaVersion`,
+  `withdrawn`, `notFound`, `kindsTouched[]`.
+- `phase2.refresh_window` and `phase2.backfill` — `details` carries
+  `schemaVersion`, `window`, `accepted`, `deleted`, and
+  `eventCountClaim` (from the envelope, for sender/receiver
+  reconciliation).
+
+Failure-path actions reuse `phase2.verification_failed` and
+`phase2.ingest_failed`; the route is distinguished by `targetType`
+(`phase2_withdraw`, `phase2_refresh_window`, `phase2_backfill`).

--- a/docs/en/operations/phase2-ingest.md
+++ b/docs/en/operations/phase2-ingest.md
@@ -237,6 +237,18 @@ For a `story` window, replace `baseline_version` + `events` with
 - Payload-internal natural-key duplicates — same
   `(baseline_version, event_key)`, `(story_id, story_version)`, or
   `(story_id, story_version, member_event_key)`.
+- Numeric strings in non-canonical form (`"01"`, `"010"`, etc.) for
+  any `event_key`, `story_id`, `run_id`, or member `event_key`. The
+  DB natural keys are `numeric` / `bigint`, so `"01"` and `"1"`
+  collapse to the same row; allowing both wire forms would let
+  duplicate guards miss collisions that the DB then surfaces as a
+  PK violation (`500` after the JTI is consumed) or as silently
+  miscounted withdraw responses.
+- A `window` whose `from >= to` (zero-width or reversed interval).
+  An empty interval would pass the row-membership guards (every
+  comparison fails on an empty array), consume the JTI, take the
+  advisory lock, delete nothing, and return `200` — indistinguishable
+  from a no-op success and almost certainly a sender bug.
 
 The DELETE filter:
 

--- a/docs/ko/operations/phase2-ingest.md
+++ b/docs/ko/operations/phase2-ingest.md
@@ -153,3 +153,159 @@ aimer-web의 상한을 올린다면 aice-web-next의 발신 측 상한도 함께
 - story: `storiesAccepted`, `storiesDuplicates`,
   `membersAccepted`, `membersDuplicates`.
 - policy-run: `runId`, `runStatus` (`"new"` 또는 `"duplicate"`).
+
+## 변경 엔드포인트
+
+위의 세 수집 엔드포인트에 더해, aimer-web은 이미 수집된 데이터를
+DELETE하거나 교체하는 세 개의 Phase 2 변경 엔드포인트를
+노출합니다. multipart 봉투 계약, 컨텍스트 토큰 검증, jti 재생
+방지 저장소, 감사 카테고리는 수집 라우트와 동일합니다.
+
+| 엔드포인트 | 스키마 버전 | 의미 |
+| --- | --- | --- |
+| `POST /api/phase2/withdraw` | `phase2.withdraw.v1` | 자연 키로 특정 행을 DELETE |
+| `POST /api/phase2/refresh-window` | `phase2.refresh_window.v1` | `[from, to)` 구간을 원자적으로 교체 |
+| `POST /api/phase2/backfill` | `phase2.backfill.v1` | refresh-window와 동일한 형식·의미. 감사 액션과 운영자 의도로만 구분 |
+
+### Withdraw
+
+페이로드는 비어 있지 않은 `withdrawals` 배열을 가지며, 각 항목은
+`kind`로 구분합니다.
+
+- `baseline_event` — `{ baseline_version, event_keys[] }`
+- `story` — `{ story_id, story_version }`
+- `policy_event` — `{ run_id, event_keys[] }`
+- `policy_run` — `{ run_id }`
+
+모든 DELETE는 단일 고객 트랜잭션에서 실행됩니다. 하나라도 실패하면
+전체가 롤백되고 응답은 `500`입니다. 응답은 `withdrawn`과
+`not_found`를 따로 보고하며, `not_found`는 이미 사라진 행에 대한
+정보용이지 오류가 아닙니다. `policy_run` 삭제 시 `policy_event`
+자식 행은 FK CASCADE로, `story` 삭제 시 `story_member` 자식 행도
+자동으로 제거됩니다. 라우트는 자식 테이블에 명시적 DELETE를 보내지
+않습니다.
+
+대상이 withdraw된 `analysis_narrative` 행은 자동으로 제거되지
+않으며 aimer-web 보존 정책으로 자연 소거됩니다(RFC 0002 §6
+withdraw).
+
+응답:
+
+```json
+{
+  "withdrawn": 3,
+  "not_found": 1,
+  "received_at": "2026-05-17T10:23:45.012Z",
+  "context_jti": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+### Refresh-window 및 Backfill
+
+두 엔드포인트는 반-개방 `[window.from, window.to)` 구간의 내용을
+원자적으로 교체합니다. 와이어상 동일합니다. 페이로드 형식,
+응답 형식, 윈도우별 advisory lock, DELETE 후 INSERT 의미가 모두
+같습니다. 차이는 봉투의 `schema_version` 클레임과 성공 감사
+액션(`phase2.refresh_window` vs `phase2.backfill`)뿐입니다.
+aice-web-next가 Force Rebuild를 수행했다면 `refresh-window`를,
+관리자 운영자가 트리거했다면 `backfill`을 사용합니다.
+
+페이로드:
+
+```json
+{
+  "external_key": "...",
+  "window": { "kind": "baseline_event", "from": "...", "to": "..." },
+  "baseline_version": "...",
+  "events": [ /* baseline_event 행. phase2.baseline.v1과 같은 형식 */ ]
+}
+```
+
+`story` 윈도우에는 `baseline_version` + `events` 대신 `stories`를
+사용합니다(`baseline_version`은 필요 없음). Zod 스키마가 거부하는
+경우:
+
+- `kind: "analyst_curated"`인 스토리 — 큐레이션 스토리는 이
+  엔드포인트로 절대 영향받지 않습니다(RFC 0002 §6).
+- `event_time`(baseline) 또는 `time_window.start`(story)이
+  `[from, to)`를 벗어나는 행 — 전송측 버그로 간주해 `400
+  payload_schema_invalid`로 즉시 실패시킵니다.
+- 페이로드 내부 자연 키 중복 — `(baseline_version, event_key)`,
+  `(story_id, story_version)`,
+  `(story_id, story_version, member_event_key)`가 동일한 항목.
+
+DELETE 필터:
+
+- baseline: `baseline_version = $1 AND event_time >= $from AND event_time < $to`.
+  같은 시간 윈도우의 다른 `baseline_version` 행은 보존됩니다.
+- story: `kind = 'auto_correlated' AND time_window_start >= $from AND
+  time_window_start < $to`. 시작 시각이 `from` 이전이고
+  `time_window_end`가 윈도우 안으로 연장되는 스토리는 refresh에서
+  제거되지 않습니다 — 스토리는 시작 시각에 할당되며 생산측
+  Force Rebuild 계약을 그대로 반영합니다.
+
+응답:
+
+```json
+{
+  "accepted": 12,
+  "duplicates_skipped": 0,
+  "deleted": 7,
+  "received_at": "2026-05-17T10:23:45.012Z",
+  "context_jti": "..."
+}
+```
+
+`duplicates_skipped`는 항상 `0`입니다(INSERT 전에 윈도우가
+비워지기 때문). `deleted`는 직전 DELETE가 제거한 행 수의
+정보값입니다. 같은 본문으로 backfill을 다시 실행하면 동일한 종료
+상태로 수렴합니다(`accepted`는 새 이벤트/스토리 수, `deleted`는
+이전 실행의 `accepted` 값).
+
+### Advisory lock
+
+Refresh-window와 backfill은
+`phase2_window|<window_kind>|<external_key>|<from>|<to>` 키로
+`pg_advisory_xact_lock(hashtextextended(..., 0))` (단일 bigint
+형식)을 윈도우 단위로 획득합니다. 키의 kind 세그먼트는 윈도우의
+것이지 작업의 것이 아닙니다. 같은 윈도우에 대한 refresh와
+backfill은 서로 직렬화되며, 이는 올바름의 불변식입니다(둘 다 같은
+행을 DELETE+INSERT). 감사 액션은 의도를 구분하고, lock은 윈도우를
+구분합니다.
+
+같은 시간 윈도우 안에서 서로 다른 `baseline_version` 값의
+refresh는 disjoint 행을 건드리지만 여전히 lock으로 직렬화됩니다.
+프로파일링에서 경합이 관찰되면 후속에서 lock 키에
+`baseline_version`을 포함하도록 변경할 수 있습니다.
+
+### Replay 및 DB 실패 의미
+
+변경 엔드포인트는 수집 라우트의 replay 저장소와 검증 후 실패
+의미를 공유합니다.
+
+- 재생된 `context_jti`는 `409 context_jti_replay`를 반환하며 DB
+  변경을 수행하지 않고 윈도우별 advisory lock도 획득하지
+  않습니다(재생이 같은 윈도우의 다른 동시 refresh를 멈춰서는 안
+  됨). `phase2.{withdraw,refresh_window,backfill}` 감사 행을
+  남기지 않습니다.
+- 고객 트랜잭션 내부의 DB 실패(예: 캐스트 오류, FK 위반)는
+  `500 database_error`를 반환하고 `phase2.ingest_failed` 감사
+  행을 남깁니다(액션 이름은 역사적 이유로 수집과 공유. v1에서는
+  검증 후 모든 Phase 2 변경 실패를 대표). 소비된 `jti`는
+  `phase2_consumed_jtis`에 그대로 남으며, 재시도는 새 토큰
+  발급이 필요합니다.
+
+### 감사 details
+
+성공 경로 액션:
+
+- `phase2.withdraw` — `details`에 `schemaVersion`, `withdrawn`,
+  `notFound`, `kindsTouched[]`.
+- `phase2.refresh_window`와 `phase2.backfill` — `details`에
+  `schemaVersion`, `window`, `accepted`, `deleted`, 그리고
+  `eventCountClaim`(봉투 값. 송·수신 카운트 정합용).
+
+실패 경로 액션은 `phase2.verification_failed`와
+`phase2.ingest_failed`를 재사용합니다. 라우트는 `targetType`으로
+구분합니다(`phase2_withdraw`, `phase2_refresh_window`,
+`phase2_backfill`).

--- a/docs/ko/operations/phase2-ingest.md
+++ b/docs/ko/operations/phase2-ingest.md
@@ -233,6 +233,17 @@ aice-web-next가 Force Rebuild를 수행했다면 `refresh-window`를,
 - 페이로드 내부 자연 키 중복 — `(baseline_version, event_key)`,
   `(story_id, story_version)`,
   `(story_id, story_version, member_event_key)`가 동일한 항목.
+- 비정규 형식의 숫자 문자열(`"01"`, `"010"` 등): `event_key`,
+  `story_id`, `run_id`, member `event_key` 모두 정규형만 허용합니다.
+  DB의 자연 키는 `numeric` / `bigint`이라서 `"01"`과 `"1"`이 같은
+  행으로 충돌하므로, 두 형태를 모두 받으면 페이로드 내부 중복
+  가드를 우회해 PK 위반(JTI 소비 후 `500`)이나 withdraw 응답의
+  카운트 왜곡으로 이어집니다.
+- `from >= to`인 `window`(폭이 0이거나 뒤집힌 구간): 빈 배열이면
+  행 멤버십 가드가 발동하지 않아 JTI를 소비하고 잠금을 잡은 뒤
+  아무것도 삭제하지 않고 `200`을 반환하게 됩니다. 정상 no-op과
+  구분할 수 없고 사실상 전송측 버그이므로 스키마 단계에서
+  거부합니다.
 
 DELETE 필터:
 

--- a/docs/ko/operations/phase2-ingest.md
+++ b/docs/ko/operations/phase2-ingest.md
@@ -189,6 +189,15 @@ DELETE하거나 교체하는 세 개의 Phase 2 변경 엔드포인트를
 않으며 aimer-web 보존 정책으로 자연 소거됩니다(RFC 0002 §6
 withdraw).
 
+Zod 스키마는 또한 `{ kind: "policy_run", run_id: R }`과 동일한
+`run_id`를 가진 `{ kind: "policy_event", run_id: R, ... }`이
+같은 페이로드에 함께 있는 경우 `400 payload_schema_invalid`로
+거부합니다. 런의 FK cascade가 이미 `policy_event` 자식 행을
+제거하므로, 명시적 `policy_event` 항목에 매겨지는 카운트는
+처리 순서에 따라 달라집니다 — 런보다 먼저 처리되면 `withdrawn`,
+cascade 이후라면 `not_found`. 이는 발신자 버그를 가리므로
+스키마 레이어에서 거부합니다.
+
 응답:
 
 ```json

--- a/src/app/api/phase2/_shared/__tests__/mutation-handler.unit.test.ts
+++ b/src/app/api/phase2/_shared/__tests__/mutation-handler.unit.test.ts
@@ -1,0 +1,293 @@
+import { NextRequest } from "next/server";
+import type { Pool } from "pg";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockVerifyPhase2Multipart = vi.fn();
+const mockAuditLog = vi.fn();
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/auth/envelope-verify", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/auth/envelope-verify")>();
+  return {
+    ...actual,
+    verifyPhase2Multipart: (...args: unknown[]) =>
+      mockVerifyPhase2Multipart(...args),
+  };
+});
+
+vi.mock("@/lib/audit", () => ({
+  auditLog: (...args: unknown[]) => mockAuditLog(...args),
+  UNKNOWN_ACTOR_ID: "unknown",
+}));
+
+const { EnvelopeVerificationError } = await import(
+  "@/lib/auth/envelope-verify"
+);
+const { createPhase2MutationHandler } = await import("../mutation-handler");
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const baseContextClaims = {
+  iss: "https://aice.test",
+  aud: "aimer-web",
+  sub: "user-1",
+  aiceId: "aice-1",
+  customerIds: ["ext-1"],
+  iat: 1000,
+  exp: 2000,
+  jti: "550e8400-e29b-41d4-a716-446655440000",
+};
+
+const baseEnvelopeClaims = {
+  iss: "https://aice.test",
+  aiceId: "aice-1",
+  customerIds: ["ext-1"],
+  contextJti: baseContextClaims.jti,
+  payloadHash: "hash",
+  eventCount: 1,
+  schemaVersion: "phase2.test.v1",
+};
+
+const baseEventsData = new TextEncoder().encode(
+  '{"external_key":"ext-1","field":"value"}',
+);
+
+const testSchema = z.object({
+  external_key: z.string(),
+  field: z.string(),
+});
+
+function fakeAuthPool() {
+  return {
+    query: vi.fn().mockResolvedValue({ rowCount: 1 }),
+  } as unknown as Pool;
+}
+
+function makeRequest(): NextRequest {
+  const form = new FormData();
+  form.append("context_token", "x");
+  form.append("events_envelope", "x");
+  form.append("events_data", new TextDecoder().decode(baseEventsData));
+  return new NextRequest("http://localhost/api/phase2/test", {
+    method: "POST",
+    body: form,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createPhase2MutationHandler", () => {
+  it("returns 200 with the mutation response body and emits the success audit", async () => {
+    const authPool = fakeAuthPool();
+    const customerPool = fakeAuthPool();
+    mockVerifyPhase2Multipart.mockResolvedValue({
+      contextClaims: baseContextClaims,
+      envelopeClaims: baseEnvelopeClaims,
+      eventsData: baseEventsData,
+      customerId: "11111111-2222-3333-4444-555555555555",
+      externalKey: "ext-1",
+    });
+
+    const mutate = vi.fn().mockResolvedValue({
+      responseBody: { withdrawn: 3, not_found: 1 },
+      auditDetails: { withdrawn: 3, notFound: 1, kindsTouched: ["story"] },
+    });
+
+    const handler = createPhase2MutationHandler(
+      {
+        expectedSchemaVersion: "phase2.test.v1",
+        payloadSchema: testSchema,
+        auditTargetType: "phase2_withdraw",
+        successAction: "phase2.withdraw",
+        mutate,
+      },
+      {
+        getAuthPool: () => authPool,
+        getCustomerRuntimePool: () => customerPool,
+      },
+    );
+
+    const res = await handler(makeRequest());
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(res.status).toBe(200);
+    expect(body.withdrawn).toBe(3);
+    expect(body.not_found).toBe(1);
+    expect(body.context_jti).toBe(baseContextClaims.jti);
+    expect(body.received_at).toMatch(/T.*Z$/);
+
+    expect(mockAuditLog).toHaveBeenCalledOnce();
+    const auditCall = mockAuditLog.mock.calls[0][0];
+    expect(auditCall.action).toBe("phase2.withdraw");
+    expect(auditCall.aiceId).toBe(baseEnvelopeClaims.aiceId);
+    expect(auditCall.customerId).toBe("11111111-2222-3333-4444-555555555555");
+    expect(auditCall.correlationId).toBe(baseContextClaims.jti);
+    expect(auditCall.details).toMatchObject({
+      schemaVersion: "phase2.test.v1",
+      withdrawn: 3,
+      notFound: 1,
+      kindsTouched: ["story"],
+    });
+
+    expect(authPool.query).toHaveBeenCalledWith(
+      expect.stringContaining("phase2_consumed_jtis"),
+      [baseContextClaims.jti],
+    );
+    expect(mutate).toHaveBeenCalled();
+  });
+
+  it("returns 409 context_jti_replay on replayed jti — no mutate, no audit, no customer-pool resolution", async () => {
+    const authPool = {
+      query: vi.fn().mockResolvedValue({ rowCount: 0 }), // replay
+    } as unknown as Pool;
+    mockVerifyPhase2Multipart.mockResolvedValue({
+      contextClaims: baseContextClaims,
+      envelopeClaims: baseEnvelopeClaims,
+      eventsData: baseEventsData,
+      customerId: "c-1",
+      externalKey: "ext-1",
+    });
+
+    const mutate = vi.fn();
+    const getCustomerRuntimePool = vi.fn(() => fakeAuthPool());
+
+    const handler = createPhase2MutationHandler(
+      {
+        expectedSchemaVersion: "phase2.test.v1",
+        payloadSchema: testSchema,
+        auditTargetType: "phase2_refresh_window",
+        successAction: "phase2.refresh_window",
+        mutate,
+      },
+      { getAuthPool: () => authPool, getCustomerRuntimePool },
+    );
+
+    const res = await handler(makeRequest());
+    const body = (await res.json()) as { code: string };
+    expect(res.status).toBe(409);
+    expect(body.code).toBe("context_jti_replay");
+    expect(mutate).not.toHaveBeenCalled();
+    expect(mockAuditLog).not.toHaveBeenCalled();
+    // Critical: a replay must NOT even reach the per-window advisory
+    // lock — i.e. it must NOT resolve the customer pool.
+    expect(getCustomerRuntimePool).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 schema_version_mismatch when envelope schema_version differs", async () => {
+    mockVerifyPhase2Multipart.mockResolvedValue({
+      contextClaims: baseContextClaims,
+      envelopeClaims: { ...baseEnvelopeClaims, schemaVersion: "wrong" },
+      eventsData: baseEventsData,
+      customerId: "c",
+      externalKey: "ext-1",
+    });
+    const handler = createPhase2MutationHandler(
+      {
+        expectedSchemaVersion: "phase2.test.v1",
+        payloadSchema: testSchema,
+        auditTargetType: "phase2_backfill",
+        successAction: "phase2.backfill",
+        mutate: vi.fn(),
+      },
+      {
+        getAuthPool: () => fakeAuthPool(),
+        getCustomerRuntimePool: () => fakeAuthPool(),
+      },
+    );
+    const res = await handler(makeRequest());
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("schema_version_mismatch");
+    expect(mockAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("maps EnvelopeVerificationError to RFC 0002 status and emits phase2.verification_failed with the route's targetType", async () => {
+    mockVerifyPhase2Multipart.mockRejectedValue(
+      new EnvelopeVerificationError(
+        "payload_customer_not_authorized",
+        "scope",
+        {
+          contextClaims: baseContextClaims,
+          details: { externalKey: "ext-1" },
+        },
+      ),
+    );
+
+    const handler = createPhase2MutationHandler(
+      {
+        expectedSchemaVersion: "phase2.test.v1",
+        payloadSchema: testSchema,
+        auditTargetType: "phase2_withdraw",
+        successAction: "phase2.withdraw",
+        mutate: vi.fn(),
+      },
+      {
+        getAuthPool: () => fakeAuthPool(),
+        getCustomerRuntimePool: () => fakeAuthPool(),
+      },
+    );
+
+    const res = await handler(makeRequest());
+    expect(res.status).toBe(403);
+    expect(mockAuditLog).toHaveBeenCalledOnce();
+    const call = mockAuditLog.mock.calls[0][0];
+    expect(call.action).toBe("phase2.verification_failed");
+    expect(call.targetType).toBe("phase2_withdraw");
+    expect(call.details.code).toBe("payload_customer_not_authorized");
+  });
+
+  it("returns 500 database_error and emits phase2.ingest_failed when mutate throws — consumed jti remains", async () => {
+    const authPool = fakeAuthPool();
+    mockVerifyPhase2Multipart.mockResolvedValue({
+      contextClaims: baseContextClaims,
+      envelopeClaims: baseEnvelopeClaims,
+      eventsData: baseEventsData,
+      customerId: "c-1",
+      externalKey: "ext-1",
+    });
+    const mutate = vi.fn().mockRejectedValue(new Error("boom"));
+    const handler = createPhase2MutationHandler(
+      {
+        expectedSchemaVersion: "phase2.test.v1",
+        payloadSchema: testSchema,
+        auditTargetType: "phase2_refresh_window",
+        successAction: "phase2.refresh_window",
+        mutate,
+      },
+      {
+        getAuthPool: () => authPool,
+        getCustomerRuntimePool: () => fakeAuthPool(),
+      },
+    );
+    const res = await handler(makeRequest());
+    const body = (await res.json()) as { code: string };
+    expect(res.status).toBe(500);
+    expect(body.code).toBe("database_error");
+
+    expect(mockAuditLog).toHaveBeenCalledOnce();
+    const call = mockAuditLog.mock.calls[0][0];
+    expect(call.action).toBe("phase2.ingest_failed");
+    expect(call.targetType).toBe("phase2_refresh_window");
+    expect(call.details.error).toBe("boom");
+
+    // jti was consumed and was NOT released — only the single INSERT
+    // into phase2_consumed_jtis happened, no DELETE.
+    expect(authPool.query).toHaveBeenCalledTimes(1);
+    const firstCall = (authPool.query as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(firstCall[0]).toMatch(/phase2_consumed_jtis/);
+  });
+});

--- a/src/app/api/phase2/_shared/__tests__/schemas.unit.test.ts
+++ b/src/app/api/phase2/_shared/__tests__/schemas.unit.test.ts
@@ -394,6 +394,46 @@ describe("stringifiedBigintPositive range enforcement", () => {
   });
 });
 
+describe("canonical numeric string form (no leading zeros)", () => {
+  it("rejects leading-zero event_key (DB casts '01' and '1' to one numeric)", () => {
+    const result = baselineBatchSchema.safeParse({
+      external_key: "ext-1",
+      baseline_version: "v1",
+      events: [{ ...baseEvent, event_key: "01" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts literal '0' as event_key (zero is a valid NUMERIC value)", () => {
+    const result = baselineBatchSchema.safeParse({
+      external_key: "ext-1",
+      baseline_version: "v1",
+      events: [{ ...baseEvent, event_key: "0" }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects leading-zero story_id", () => {
+    const result = storyBatchSchema.safeParse({
+      external_key: "ext-1",
+      stories: [
+        {
+          story_id: "01",
+          story_version: "v1",
+          kind: "auto_correlated",
+          time_window: {
+            start: "2026-01-02T03:04:05Z",
+            end: "2026-01-02T03:14:05Z",
+          },
+          summary_payload: {},
+          members: [],
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
 describe("eventKeyString cap at NUMERIC(39, 0)", () => {
   it("accepts a 39-digit key", () => {
     const result = baselineBatchSchema.safeParse({

--- a/src/app/api/phase2/_shared/__tests__/window-replace.db.test.ts
+++ b/src/app/api/phase2/_shared/__tests__/window-replace.db.test.ts
@@ -1,0 +1,360 @@
+import { join } from "node:path";
+import type { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeAdminPool,
+  createTestDatabase,
+  dropTestDatabase,
+  hasPostgres,
+} from "@/lib/db/__tests__/db-test-helpers";
+import { runMigrations } from "@/lib/db/migrate";
+import { ingestBaselineBatch, ingestStoryBatch } from "../ingest";
+import { executeWindowReplace } from "../window-replace";
+
+const CUSTOMER_MIGRATIONS_DIR = join(process.cwd(), "migrations", "customer");
+const LOCK_ID_CUSTOMER = 1002;
+
+const baselineEvent = (key: string, time: string) => ({
+  event_key: key,
+  event_time: time,
+  kind: "dns",
+  category: null,
+  primary_asset: null,
+  raw_score: 0.5,
+  selector_tags: [],
+  raw_event: {},
+  score_window_context: {
+    kind_cohort_window: {
+      from: "2026-01-01T00:00:00Z",
+      to: "2026-01-02T00:00:00Z",
+    },
+    kind_cohort_size: 1,
+    baseline_rank_snapshot: 0.5,
+  },
+  window_signals: {},
+  scoring_weights_snapshot: {},
+});
+
+const story = (
+  id: string,
+  version: string,
+  start: string,
+  end: string,
+  kind: "auto_correlated" | "analyst_curated" = "auto_correlated",
+) => ({
+  story_id: id,
+  story_version: version,
+  kind,
+  time_window: { start, end },
+  summary_payload: {},
+  members: [],
+});
+
+describe.skipIf(!hasPostgres)("executeWindowReplace — baseline", () => {
+  let dbName: string;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    const db = await createTestDatabase("phase2_window_baseline");
+    dbName = db.dbName;
+    pool = db.pool;
+    await runMigrations(pool, CUSTOMER_MIGRATIONS_DIR, LOCK_ID_CUSTOMER);
+  });
+  afterAll(async () => {
+    await dropTestDatabase(dbName, pool);
+    await closeAdminPool();
+  });
+
+  it("DELETE filters by baseline_version — other versions preserved", async () => {
+    // Two versions, same time range.
+    await ingestBaselineBatch(
+      pool,
+      {
+        external_key: "ext",
+        baseline_version: "vA",
+        events: [
+          baselineEvent("1", "2026-02-01T00:30:00Z"),
+          baselineEvent("2", "2026-02-01T00:45:00Z"),
+        ],
+      },
+      "aice-1",
+    );
+    await ingestBaselineBatch(
+      pool,
+      {
+        external_key: "ext",
+        baseline_version: "vB",
+        events: [baselineEvent("99", "2026-02-01T00:30:00Z")],
+      },
+      "aice-1",
+    );
+
+    const result = await executeWindowReplace(
+      pool,
+      {
+        external_key: "ext",
+        window: {
+          kind: "baseline_event",
+          from: "2026-02-01T00:00:00Z",
+          to: "2026-02-01T01:00:00Z",
+        },
+        baseline_version: "vA",
+        events: [baselineEvent("10", "2026-02-01T00:10:00Z")],
+      },
+      "aice-1",
+    );
+
+    expect(result.accepted).toBe(1);
+    expect(result.deleted).toBe(2);
+
+    const { rows: vbRows } = await pool.query(
+      "SELECT event_key::text AS k FROM baseline_event WHERE baseline_version = 'vB' ORDER BY k",
+    );
+    expect(vbRows.map((r) => r.k)).toEqual(["99"]);
+
+    const { rows: vaRows } = await pool.query(
+      "SELECT event_key::text AS k FROM baseline_event WHERE baseline_version = 'vA' ORDER BY k",
+    );
+    expect(vaRows.map((r) => r.k)).toEqual(["10"]);
+  });
+
+  it("empty events array clears the window", async () => {
+    await ingestBaselineBatch(
+      pool,
+      {
+        external_key: "ext",
+        baseline_version: "vClear",
+        events: [
+          baselineEvent("1", "2026-03-01T00:30:00Z"),
+          baselineEvent("2", "2026-03-01T00:45:00Z"),
+        ],
+      },
+      "aice-1",
+    );
+
+    const result = await executeWindowReplace(
+      pool,
+      {
+        external_key: "ext",
+        window: {
+          kind: "baseline_event",
+          from: "2026-03-01T00:00:00Z",
+          to: "2026-03-01T01:00:00Z",
+        },
+        baseline_version: "vClear",
+        events: [],
+      },
+      "aice-1",
+    );
+
+    expect(result.accepted).toBe(0);
+    expect(result.deleted).toBe(2);
+
+    const { rowCount } = await pool.query(
+      "SELECT 1 FROM baseline_event WHERE baseline_version = 'vClear'",
+    );
+    expect(rowCount).toBe(0);
+  });
+
+  it("backfill-style idempotency: re-running same body produces same end state", async () => {
+    const body = {
+      external_key: "ext",
+      window: {
+        kind: "baseline_event" as const,
+        from: "2026-04-01T00:00:00Z",
+        to: "2026-04-01T01:00:00Z",
+      },
+      baseline_version: "vIdem",
+      events: [
+        baselineEvent("1", "2026-04-01T00:10:00Z"),
+        baselineEvent("2", "2026-04-01T00:20:00Z"),
+      ],
+    };
+    const first = await executeWindowReplace(pool, body, "aice-1");
+    expect(first.accepted).toBe(2);
+
+    const second = await executeWindowReplace(pool, body, "aice-1");
+    expect(second.accepted).toBe(2);
+    expect(second.deleted).toBe(2);
+
+    const { rows } = await pool.query(
+      "SELECT event_key::text AS k FROM baseline_event WHERE baseline_version = 'vIdem' ORDER BY k",
+    );
+    expect(rows.map((r) => r.k)).toEqual(["1", "2"]);
+  });
+});
+
+describe.skipIf(!hasPostgres)("executeWindowReplace — story", () => {
+  let dbName: string;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    const db = await createTestDatabase("phase2_window_story");
+    dbName = db.dbName;
+    pool = db.pool;
+    await runMigrations(pool, CUSTOMER_MIGRATIONS_DIR, LOCK_ID_CUSTOMER);
+  });
+  afterAll(async () => {
+    await dropTestDatabase(dbName, pool);
+    await closeAdminPool();
+  });
+
+  it("curated stories survive a refresh", async () => {
+    await ingestStoryBatch(
+      pool,
+      {
+        external_key: "ext",
+        stories: [
+          story("1", "v1", "2026-02-01T00:30:00Z", "2026-02-01T00:45:00Z"),
+          story(
+            "2",
+            "v1",
+            "2026-02-01T00:30:00Z",
+            "2026-02-01T00:45:00Z",
+            "analyst_curated",
+          ),
+        ],
+      },
+      "aice-1",
+    );
+
+    const result = await executeWindowReplace(
+      pool,
+      {
+        external_key: "ext",
+        window: {
+          kind: "story",
+          from: "2026-02-01T00:00:00Z",
+          to: "2026-02-01T01:00:00Z",
+        },
+        stories: [
+          story("3", "v1", "2026-02-01T00:10:00Z", "2026-02-01T00:20:00Z"),
+        ],
+      },
+      "aice-1",
+    );
+    expect(result.accepted).toBe(1);
+    expect(result.deleted).toBe(1); // only auto
+
+    const { rows } = await pool.query(
+      "SELECT story_id::text AS i, kind FROM story ORDER BY i",
+    );
+    expect(rows).toEqual([
+      { i: "2", kind: "analyst_curated" },
+      { i: "3", kind: "auto_correlated" },
+    ]);
+  });
+
+  it("auto-correlated stories at any version are replaced (no version filter)", async () => {
+    await ingestStoryBatch(
+      pool,
+      {
+        external_key: "ext",
+        stories: [
+          story("10", "v1", "2026-03-01T00:10:00Z", "2026-03-01T00:20:00Z"),
+          story("10", "v2", "2026-03-01T00:10:00Z", "2026-03-01T00:20:00Z"),
+        ],
+      },
+      "aice-1",
+    );
+
+    const result = await executeWindowReplace(
+      pool,
+      {
+        external_key: "ext",
+        window: {
+          kind: "story",
+          from: "2026-03-01T00:00:00Z",
+          to: "2026-03-01T01:00:00Z",
+        },
+        stories: [],
+      },
+      "aice-1",
+    );
+
+    expect(result.deleted).toBe(2);
+  });
+
+  it("story whose start is before window survives even if end is inside (start-time assignment)", async () => {
+    await ingestStoryBatch(
+      pool,
+      {
+        external_key: "ext",
+        stories: [
+          // Pre-existing story: start before the window, end inside it.
+          story("77", "v1", "2026-05-01T00:30:00Z", "2026-05-01T01:30:00Z"),
+        ],
+      },
+      "aice-1",
+    );
+
+    const result = await executeWindowReplace(
+      pool,
+      {
+        external_key: "ext",
+        window: {
+          kind: "story",
+          from: "2026-05-01T01:00:00Z",
+          to: "2026-05-01T02:00:00Z",
+        },
+        stories: [],
+      },
+      "aice-1",
+    );
+
+    expect(result.deleted).toBe(0);
+    const { rowCount } = await pool.query(
+      "SELECT 1 FROM story WHERE story_id = 77",
+    );
+    expect(rowCount).toBe(1);
+  });
+
+  it("serializes concurrent same-window refreshes via the advisory lock", async () => {
+    // Insert a starting state so the first DELETE returns >0 and we can
+    // observe ordering by the deleted count of the second call.
+    await ingestStoryBatch(
+      pool,
+      {
+        external_key: "ext",
+        stories: [
+          story("200", "v1", "2026-06-01T00:30:00Z", "2026-06-01T00:40:00Z"),
+        ],
+      },
+      "aice-1",
+    );
+
+    const body = (id: string) => ({
+      external_key: "ext",
+      window: {
+        kind: "story" as const,
+        from: "2026-06-01T00:00:00Z",
+        to: "2026-06-01T01:00:00Z",
+      },
+      stories: [
+        story(id, "v1", "2026-06-01T00:10:00Z", "2026-06-01T00:20:00Z"),
+      ],
+    });
+
+    const [a, b] = await Promise.all([
+      executeWindowReplace(pool, body("301"), "aice-1"),
+      executeWindowReplace(pool, body("302"), "aice-1"),
+    ]);
+
+    // The two calls serialize. After both, exactly one story remains
+    // in the window (the loser's INSERT followed the winner's DELETE).
+    expect(a.accepted).toBe(1);
+    expect(b.accepted).toBe(1);
+    expect(a.deleted + b.deleted).toBeGreaterThanOrEqual(1);
+
+    const { rows } = await pool.query(
+      `SELECT story_id::text AS i FROM story
+        WHERE time_window_start >= '2026-06-01T00:00:00Z'
+          AND time_window_start <  '2026-06-01T01:00:00Z'
+        ORDER BY i`,
+    );
+    // Final state: only the loser's INSERT survives (the winner's row
+    // was deleted by the loser's DELETE).
+    expect(rows.length).toBe(1);
+    expect(["301", "302"]).toContain(rows[0].i);
+  });
+});

--- a/src/app/api/phase2/_shared/__tests__/window-replace.unit.test.ts
+++ b/src/app/api/phase2/_shared/__tests__/window-replace.unit.test.ts
@@ -88,6 +88,43 @@ describe("windowReplacePayloadSchema — baseline", () => {
       }).success,
     ).toBe(false);
   });
+
+  it("rejects leading-zero event_key (would alias '01' and '1' to one DB row)", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({
+        ...baseBody,
+        events: [{ ...baseEvent, event_key: "01" }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects window.from equal to window.to (zero-width interval)", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({
+        ...baseBody,
+        window: {
+          kind: "baseline_event" as const,
+          from: "2026-01-02T00:00:00Z",
+          to: "2026-01-02T00:00:00Z",
+        },
+        events: [],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects window.from after window.to (reversed interval)", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({
+        ...baseBody,
+        window: {
+          kind: "baseline_event" as const,
+          from: "2026-01-02T03:00:00Z",
+          to: "2026-01-02T01:00:00Z",
+        },
+        events: [],
+      }).success,
+    ).toBe(false);
+  });
 });
 
 describe("windowReplacePayloadSchema — story", () => {
@@ -177,6 +214,57 @@ describe("windowReplacePayloadSchema — story", () => {
       windowReplacePayloadSchema.safeParse({
         ...baseBody,
         stories: [baseStory, baseStory],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects window.from equal to window.to (zero-width interval)", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({
+        ...baseBody,
+        window: {
+          kind: "story" as const,
+          from: "2026-01-02T00:00:00Z",
+          to: "2026-01-02T00:00:00Z",
+        },
+        stories: [],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects window.from after window.to (reversed interval)", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({
+        ...baseBody,
+        window: {
+          kind: "story" as const,
+          from: "2026-01-02T02:00:00Z",
+          to: "2026-01-02T00:00:00Z",
+        },
+        stories: [],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects leading-zero story_id in payload (canonical numeric strings only)", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({
+        ...baseBody,
+        stories: [{ ...baseStory, story_id: "0100" }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects leading-zero member event_key (would alias duplicates)", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({
+        ...baseBody,
+        stories: [
+          {
+            ...baseStory,
+            members: [{ event_key: "01", role: "primary", event: {} }],
+          },
+        ],
       }).success,
     ).toBe(false);
   });

--- a/src/app/api/phase2/_shared/__tests__/window-replace.unit.test.ts
+++ b/src/app/api/phase2/_shared/__tests__/window-replace.unit.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import { windowReplacePayloadSchema } from "../window-replace";
+
+const baseEvent = {
+  event_key: "1",
+  event_time: "2026-01-02T01:00:00Z",
+  kind: "dns",
+  category: null,
+  primary_asset: null,
+  raw_score: 0.5,
+  selector_tags: [],
+  raw_event: {},
+  score_window_context: {
+    kind_cohort_window: {
+      from: "2026-01-01T00:00:00Z",
+      to: "2026-01-02T00:00:00Z",
+    },
+    kind_cohort_size: 1,
+    baseline_rank_snapshot: 0.5,
+  },
+  window_signals: {},
+  scoring_weights_snapshot: {},
+};
+
+const baseStory = {
+  story_id: "100",
+  story_version: "v1",
+  kind: "auto_correlated" as const,
+  time_window: { start: "2026-01-02T01:00:00Z", end: "2026-01-02T01:30:00Z" },
+  summary_payload: {},
+  members: [],
+};
+
+describe("windowReplacePayloadSchema — baseline", () => {
+  const baseBody = {
+    external_key: "ext-1",
+    window: {
+      kind: "baseline_event" as const,
+      from: "2026-01-02T00:00:00Z",
+      to: "2026-01-02T02:00:00Z",
+    },
+    baseline_version: "bv-1",
+    events: [baseEvent],
+  };
+
+  it("accepts a minimal valid baseline body", () => {
+    expect(windowReplacePayloadSchema.safeParse(baseBody).success).toBe(true);
+  });
+
+  it("accepts an empty events array (window clear)", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({ ...baseBody, events: [] }).success,
+    ).toBe(true);
+  });
+
+  it("rejects event_time before window.from", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({
+        ...baseBody,
+        events: [{ ...baseEvent, event_time: "2026-01-01T23:59:59Z" }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects event_time equal to window.to (exclusive upper bound)", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({
+        ...baseBody,
+        events: [{ ...baseEvent, event_time: "2026-01-02T02:00:00Z" }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts event_time equal to window.from (inclusive lower bound)", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({
+        ...baseBody,
+        events: [{ ...baseEvent, event_time: "2026-01-02T00:00:00Z" }],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects duplicate (baseline_version, event_key) within events", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({
+        ...baseBody,
+        events: [baseEvent, baseEvent],
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("windowReplacePayloadSchema — story", () => {
+  const baseBody = {
+    external_key: "ext-1",
+    window: {
+      kind: "story" as const,
+      from: "2026-01-02T00:00:00Z",
+      to: "2026-01-02T02:00:00Z",
+    },
+    stories: [baseStory],
+  };
+
+  it("accepts a minimal valid story body", () => {
+    expect(windowReplacePayloadSchema.safeParse(baseBody).success).toBe(true);
+  });
+
+  it("accepts an empty stories array (window clear)", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({ ...baseBody, stories: [] })
+        .success,
+    ).toBe(true);
+  });
+
+  it("rejects stories whose kind is analyst_curated", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({
+        ...baseBody,
+        stories: [{ ...baseStory, kind: "analyst_curated" }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects time_window.start before window.from", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({
+        ...baseBody,
+        stories: [
+          {
+            ...baseStory,
+            time_window: {
+              start: "2026-01-01T23:59:59Z",
+              end: "2026-01-02T01:00:00Z",
+            },
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects time_window.start equal to window.to (exclusive upper)", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({
+        ...baseBody,
+        stories: [
+          {
+            ...baseStory,
+            time_window: {
+              start: "2026-01-02T02:00:00Z",
+              end: "2026-01-02T03:00:00Z",
+            },
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts a story whose end extends past window.to (start-time assignment)", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({
+        ...baseBody,
+        stories: [
+          {
+            ...baseStory,
+            time_window: {
+              start: "2026-01-02T01:00:00Z",
+              end: "2026-01-02T05:00:00Z",
+            },
+          },
+        ],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects duplicate (story_id, story_version) across stories", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({
+        ...baseBody,
+        stories: [baseStory, baseStory],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects duplicate (story_id, story_version, member_event_key) within members", () => {
+    expect(
+      windowReplacePayloadSchema.safeParse({
+        ...baseBody,
+        stories: [
+          {
+            ...baseStory,
+            members: [
+              { event_key: "1", role: "primary", event: {} },
+              { event_key: "1", role: "context", event: {} },
+            ],
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/src/app/api/phase2/_shared/__tests__/withdraw.db.test.ts
+++ b/src/app/api/phase2/_shared/__tests__/withdraw.db.test.ts
@@ -1,0 +1,288 @@
+import { join } from "node:path";
+import type { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeAdminPool,
+  createTestDatabase,
+  dropTestDatabase,
+  hasPostgres,
+} from "@/lib/db/__tests__/db-test-helpers";
+import { runMigrations } from "@/lib/db/migrate";
+import {
+  ingestBaselineBatch,
+  ingestPolicyRun,
+  ingestStoryBatch,
+} from "../ingest";
+import { executeWithdraw } from "../withdraw";
+
+const CUSTOMER_MIGRATIONS_DIR = join(process.cwd(), "migrations", "customer");
+const LOCK_ID_CUSTOMER = 1002;
+
+const baselineEvent = (key: string, version = "bv-1") => ({
+  event_key: key,
+  event_time: "2026-01-02T03:04:05Z",
+  kind: "dns",
+  category: null,
+  primary_asset: null,
+  raw_score: 0.5,
+  selector_tags: [],
+  raw_event: {},
+  score_window_context: {
+    kind_cohort_window: {
+      from: "2026-01-01T00:00:00Z",
+      to: "2026-01-02T00:00:00Z",
+    },
+    kind_cohort_size: 1,
+    baseline_rank_snapshot: 0.5,
+  },
+  window_signals: {},
+  scoring_weights_snapshot: {},
+  // unused by test but typed
+  asset_context: null,
+  baseline_version: version,
+});
+
+describe.skipIf(!hasPostgres)("executeWithdraw", () => {
+  let dbName: string;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    const db = await createTestDatabase("phase2_withdraw");
+    dbName = db.dbName;
+    pool = db.pool;
+    await runMigrations(pool, CUSTOMER_MIGRATIONS_DIR, LOCK_ID_CUSTOMER);
+  });
+
+  afterAll(async () => {
+    await dropTestDatabase(dbName, pool);
+    await closeAdminPool();
+  });
+
+  it("deletes baseline_event rows by (baseline_version, event_key)", async () => {
+    await ingestBaselineBatch(
+      pool,
+      {
+        external_key: "ext",
+        baseline_version: "wbv-1",
+        events: [baselineEvent("1001"), baselineEvent("1002")],
+      },
+      "aice-1",
+    );
+
+    const result = await executeWithdraw(pool, {
+      external_key: "ext",
+      withdrawals: [
+        {
+          kind: "baseline_event",
+          baseline_version: "wbv-1",
+          event_keys: ["1001", "9999"], // 9999 = not found
+        },
+      ],
+    });
+
+    expect(result.withdrawn).toBe(1);
+    expect(result.notFound).toBe(1);
+    expect(result.kindsTouched).toEqual(["baseline_event"]);
+
+    const { rows } = await pool.query(
+      "SELECT event_key::text AS k FROM baseline_event WHERE baseline_version = 'wbv-1' ORDER BY k",
+    );
+    expect(rows.map((r) => r.k)).toEqual(["1002"]);
+  });
+
+  it("deletes story rows and cascades to story_member", async () => {
+    await ingestStoryBatch(
+      pool,
+      {
+        external_key: "ext",
+        stories: [
+          {
+            story_id: "8001",
+            story_version: "v1",
+            kind: "auto_correlated",
+            time_window: {
+              start: "2026-01-02T01:00:00Z",
+              end: "2026-01-02T02:00:00Z",
+            },
+            summary_payload: {},
+            members: [
+              { event_key: "1", role: "primary", event: {} },
+              { event_key: "2", role: "context", event: {} },
+            ],
+          },
+        ],
+      },
+      "aice-1",
+    );
+
+    const result = await executeWithdraw(pool, {
+      external_key: "ext",
+      withdrawals: [
+        { kind: "story", story_id: "8001", story_version: "v1" },
+        { kind: "story", story_id: "8001", story_version: "vMissing" },
+      ],
+    });
+
+    expect(result.withdrawn).toBe(1);
+    expect(result.notFound).toBe(1);
+
+    const storyRows = await pool.query(
+      "SELECT 1 FROM story WHERE story_id = 8001 AND story_version = 'v1'",
+    );
+    expect(storyRows.rowCount).toBe(0);
+    const memberRows = await pool.query(
+      "SELECT 1 FROM story_member WHERE story_id = 8001 AND story_version = 'v1'",
+    );
+    expect(memberRows.rowCount).toBe(0); // cascaded
+  });
+
+  it("deletes policy_run rows and cascades to policy_event", async () => {
+    await ingestPolicyRun(
+      pool,
+      {
+        external_key: "ext",
+        run: {
+          run_id: "9001",
+          period_start: "2026-01-02T03:00:00Z",
+          period_end: "2026-01-02T04:00:00Z",
+          created_at: "2026-01-02T04:00:01Z",
+          baseline_version: "pbv",
+          policies_fingerprint: "pfp",
+          exclusions_fingerprint: "efp",
+          status: "ready",
+        },
+        events: [
+          {
+            event_key: "10",
+            event_time: "2026-01-02T03:30:00Z",
+            kind: "dns",
+            policy_triage_snapshot: [],
+          },
+          {
+            event_key: "11",
+            event_time: "2026-01-02T03:31:00Z",
+            kind: "http",
+            policy_triage_snapshot: [],
+          },
+        ],
+      },
+      "aice-1",
+    );
+
+    const result = await executeWithdraw(pool, {
+      external_key: "ext",
+      withdrawals: [{ kind: "policy_run", run_id: "9001" }],
+    });
+
+    expect(result.withdrawn).toBe(1);
+    expect(result.notFound).toBe(0);
+
+    const eventRows = await pool.query(
+      "SELECT 1 FROM policy_event WHERE run_id = 9001",
+    );
+    expect(eventRows.rowCount).toBe(0); // cascaded
+  });
+
+  it("deletes specific policy_event rows leaving the run intact", async () => {
+    await ingestPolicyRun(
+      pool,
+      {
+        external_key: "ext",
+        run: {
+          run_id: "9100",
+          period_start: "2026-01-02T03:00:00Z",
+          period_end: "2026-01-02T04:00:00Z",
+          created_at: "2026-01-02T04:00:01Z",
+          baseline_version: "pbv",
+          policies_fingerprint: "pfp",
+          exclusions_fingerprint: "efp",
+          status: "ready",
+        },
+        events: [
+          {
+            event_key: "20",
+            event_time: "2026-01-02T03:30:00Z",
+            kind: "dns",
+            policy_triage_snapshot: [],
+          },
+          {
+            event_key: "21",
+            event_time: "2026-01-02T03:31:00Z",
+            kind: "http",
+            policy_triage_snapshot: [],
+          },
+        ],
+      },
+      "aice-1",
+    );
+
+    const result = await executeWithdraw(pool, {
+      external_key: "ext",
+      withdrawals: [
+        { kind: "policy_event", run_id: "9100", event_keys: ["20"] },
+      ],
+    });
+
+    expect(result.withdrawn).toBe(1);
+    expect(result.notFound).toBe(0);
+
+    const runRows = await pool.query(
+      "SELECT 1 FROM policy_run WHERE run_id = 9100",
+    );
+    expect(runRows.rowCount).toBe(1);
+    const remainingEvents = await pool.query(
+      "SELECT event_key::text AS k FROM policy_event WHERE run_id = 9100",
+    );
+    expect(remainingEvents.rows.map((r) => r.k)).toEqual(["21"]);
+  });
+
+  it("mixed multi-kind withdrawals run atomically and sum counts", async () => {
+    await ingestBaselineBatch(
+      pool,
+      {
+        external_key: "ext",
+        baseline_version: "mbv",
+        events: [baselineEvent("3001")],
+      },
+      "aice-1",
+    );
+    await ingestStoryBatch(
+      pool,
+      {
+        external_key: "ext",
+        stories: [
+          {
+            story_id: "8100",
+            story_version: "v1",
+            kind: "auto_correlated",
+            time_window: {
+              start: "2026-01-02T01:00:00Z",
+              end: "2026-01-02T02:00:00Z",
+            },
+            summary_payload: {},
+            members: [],
+          },
+        ],
+      },
+      "aice-1",
+    );
+
+    const result = await executeWithdraw(pool, {
+      external_key: "ext",
+      withdrawals: [
+        {
+          kind: "baseline_event",
+          baseline_version: "mbv",
+          event_keys: ["3001"],
+        },
+        { kind: "story", story_id: "8100", story_version: "v1" },
+      ],
+    });
+
+    expect(result.withdrawn).toBe(2);
+    expect(result.notFound).toBe(0);
+    expect(new Set(result.kindsTouched)).toEqual(
+      new Set(["baseline_event", "story"]),
+    );
+  });
+});

--- a/src/app/api/phase2/_shared/__tests__/withdraw.unit.test.ts
+++ b/src/app/api/phase2/_shared/__tests__/withdraw.unit.test.ts
@@ -126,4 +126,34 @@ describe("withdrawPayloadSchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it("rejects leading-zero event_key (would alias '01' and '1' to one DB row)", () => {
+    const result = withdrawPayloadSchema.safeParse({
+      external_key: "ext-1",
+      withdrawals: [
+        {
+          kind: "baseline_event",
+          baseline_version: "v1",
+          event_keys: ["01"],
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects leading-zero story_id", () => {
+    const result = withdrawPayloadSchema.safeParse({
+      external_key: "ext-1",
+      withdrawals: [{ kind: "story", story_id: "01", story_version: "v1" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects leading-zero run_id on policy_run", () => {
+    const result = withdrawPayloadSchema.safeParse({
+      external_key: "ext-1",
+      withdrawals: [{ kind: "policy_run", run_id: "010" }],
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/src/app/api/phase2/_shared/__tests__/withdraw.unit.test.ts
+++ b/src/app/api/phase2/_shared/__tests__/withdraw.unit.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { withdrawPayloadSchema } from "../withdraw";
+
+describe("withdrawPayloadSchema", () => {
+  it("accepts a minimal mixed-kind payload", () => {
+    const result = withdrawPayloadSchema.safeParse({
+      external_key: "ext-1",
+      withdrawals: [
+        {
+          kind: "baseline_event",
+          baseline_version: "v42",
+          event_keys: ["12345", "67890"],
+        },
+        { kind: "story", story_id: "1001", story_version: "v7" },
+        { kind: "policy_event", run_id: "2002", event_keys: ["12345"] },
+        { kind: "policy_run", run_id: "2003" },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an empty withdrawals array", () => {
+    const result = withdrawPayloadSchema.safeParse({
+      external_key: "ext-1",
+      withdrawals: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty event_keys array on baseline_event", () => {
+    const result = withdrawPayloadSchema.safeParse({
+      external_key: "ext-1",
+      withdrawals: [
+        { kind: "baseline_event", baseline_version: "v1", event_keys: [] },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects duplicate (baseline_version, event_key) within one item", () => {
+    const result = withdrawPayloadSchema.safeParse({
+      external_key: "ext-1",
+      withdrawals: [
+        {
+          kind: "baseline_event",
+          baseline_version: "v1",
+          event_keys: ["1", "1"],
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects duplicate (baseline_version, event_key) across items", () => {
+    const result = withdrawPayloadSchema.safeParse({
+      external_key: "ext-1",
+      withdrawals: [
+        { kind: "baseline_event", baseline_version: "v1", event_keys: ["1"] },
+        { kind: "baseline_event", baseline_version: "v1", event_keys: ["1"] },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts the same event_key under different baseline_version values", () => {
+    const result = withdrawPayloadSchema.safeParse({
+      external_key: "ext-1",
+      withdrawals: [
+        { kind: "baseline_event", baseline_version: "v1", event_keys: ["1"] },
+        { kind: "baseline_event", baseline_version: "v2", event_keys: ["1"] },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects duplicate (story_id, story_version) across items", () => {
+    const result = withdrawPayloadSchema.safeParse({
+      external_key: "ext-1",
+      withdrawals: [
+        { kind: "story", story_id: "1", story_version: "v1" },
+        { kind: "story", story_id: "1", story_version: "v1" },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects duplicate (run_id, event_key) within one policy_event item", () => {
+    const result = withdrawPayloadSchema.safeParse({
+      external_key: "ext-1",
+      withdrawals: [
+        { kind: "policy_event", run_id: "10", event_keys: ["5", "5"] },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects duplicate run_id across policy_run items", () => {
+    const result = withdrawPayloadSchema.safeParse({
+      external_key: "ext-1",
+      withdrawals: [
+        { kind: "policy_run", run_id: "10" },
+        { kind: "policy_run", run_id: "10" },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-positive bigint story_id", () => {
+    const result = withdrawPayloadSchema.safeParse({
+      external_key: "ext-1",
+      withdrawals: [{ kind: "story", story_id: "0", story_version: "v1" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-numeric event_key", () => {
+    const result = withdrawPayloadSchema.safeParse({
+      external_key: "ext-1",
+      withdrawals: [
+        {
+          kind: "baseline_event",
+          baseline_version: "v1",
+          event_keys: ["abc"],
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/app/api/phase2/_shared/__tests__/withdraw.unit.test.ts
+++ b/src/app/api/phase2/_shared/__tests__/withdraw.unit.test.ts
@@ -156,4 +156,37 @@ describe("withdrawPayloadSchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it("rejects policy_event overlapping with policy_run for the same run_id (event item first)", () => {
+    const result = withdrawPayloadSchema.safeParse({
+      external_key: "ext-1",
+      withdrawals: [
+        { kind: "policy_event", run_id: "10", event_keys: ["1"] },
+        { kind: "policy_run", run_id: "10" },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects policy_event overlapping with policy_run for the same run_id (run item first)", () => {
+    const result = withdrawPayloadSchema.safeParse({
+      external_key: "ext-1",
+      withdrawals: [
+        { kind: "policy_run", run_id: "10" },
+        { kind: "policy_event", run_id: "10", event_keys: ["1"] },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts policy_event and policy_run when run_ids differ", () => {
+    const result = withdrawPayloadSchema.safeParse({
+      external_key: "ext-1",
+      withdrawals: [
+        { kind: "policy_event", run_id: "10", event_keys: ["1"] },
+        { kind: "policy_run", run_id: "11" },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
 });

--- a/src/app/api/phase2/_shared/mutation-handler.ts
+++ b/src/app/api/phase2/_shared/mutation-handler.ts
@@ -1,0 +1,206 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import type { Pool } from "pg";
+import type { z } from "zod";
+import { type AuditAction, auditLog, UNKNOWN_ACTOR_ID } from "@/lib/audit";
+import { withCorrelationId } from "@/lib/audit/correlation";
+import {
+  EnvelopeVerificationError,
+  type VerifiedPhase2Envelope,
+  verifyPhase2Multipart,
+} from "@/lib/auth/envelope-verify";
+import { getAuthPool } from "@/lib/db/client";
+import { getCustomerRuntimePool } from "./customer-pool";
+import {
+  mapEnvelopeErrorToPhase2Response,
+  phase2ErrorResponse,
+  zodErrorResponse,
+} from "./error-mapping";
+import { consumePhase2Jti } from "./jti-replay";
+
+/** Success-action names for the three Phase 2 mutation endpoints. */
+export type MutationSuccessAction =
+  | "phase2.withdraw"
+  | "phase2.refresh_window"
+  | "phase2.backfill";
+
+interface MutationConfig<TSchema extends z.ZodTypeAny> {
+  /** Expected `schema_version` claim in the envelope. */
+  expectedSchemaVersion: string;
+  /** Zod schema for the `events_data` payload. */
+  payloadSchema: TSchema;
+  /** Target type for audit rows. */
+  auditTargetType: string;
+  /** Success-path audit action name. */
+  successAction: MutationSuccessAction;
+  /**
+   * Execute the mutation in a single per-customer transaction (callers
+   * MUST open the transaction inside this function — see the issue's
+   * "Do NOT reuse ingestBaselineBatch..." note).
+   *
+   * Returns the JSON response body (excluding `received_at` /
+   * `context_jti`, which this handler appends) and the per-action
+   * `details` JSONB to attach to the audit row.
+   */
+  mutate: (
+    customerPool: Pool,
+    verified: VerifiedPhase2Envelope,
+    payload: z.infer<TSchema>,
+  ) => Promise<{
+    responseBody: Record<string, unknown>;
+    auditDetails: Record<string, unknown>;
+  }>;
+}
+
+/** Override the auth pool / customer-pool resolver for tests. */
+export interface Phase2MutationHandlerDeps {
+  getAuthPool?: () => Pool;
+  getCustomerRuntimePool?: (customerId: string) => Pool;
+}
+
+/**
+ * Shared request handler for the three Phase 2 mutation endpoints
+ * (`withdraw`, `refresh-window`, `backfill`).
+ *
+ * Structurally identical to {@link createPhase2BatchHandler} — verify
+ * envelope → schema-version match → JSON+Zod parse → consume jti →
+ * per-customer transactional work → audit on success only — but
+ * carries a different success-response shape (per-route) and a
+ * different success-action name.
+ */
+export function createPhase2MutationHandler<TSchema extends z.ZodTypeAny>(
+  config: MutationConfig<TSchema>,
+  deps: Phase2MutationHandlerDeps = {},
+): (request: NextRequest) => Promise<NextResponse> {
+  const resolveAuthPool = deps.getAuthPool ?? getAuthPool;
+  const resolveCustomerPool =
+    deps.getCustomerRuntimePool ?? getCustomerRuntimePool;
+  return async (request: NextRequest) =>
+    withCorrelationId(async () => {
+      const authPool = resolveAuthPool();
+
+      let verified: VerifiedPhase2Envelope;
+      try {
+        verified = await verifyPhase2Multipart(authPool, request);
+      } catch (err) {
+        if (err instanceof EnvelopeVerificationError) {
+          const claims = err.contextClaims;
+          void auditLog({
+            actorId: claims?.sub ?? UNKNOWN_ACTOR_ID,
+            action: "phase2.verification_failed" satisfies AuditAction,
+            targetType: config.auditTargetType,
+            details: {
+              code: err.code,
+              schemaVersion: config.expectedSchemaVersion,
+              ...(err.details ?? {}),
+            },
+            ...(claims ? { aiceId: claims.aiceId } : {}),
+            ...(claims ? { correlationId: claims.jti } : {}),
+          });
+          return mapEnvelopeErrorToPhase2Response(err);
+        }
+        throw err;
+      }
+
+      const { contextClaims, envelopeClaims, eventsData, customerId } =
+        verified;
+
+      if (envelopeClaims.schemaVersion !== config.expectedSchemaVersion) {
+        return phase2ErrorResponse(
+          400,
+          "schema_version_mismatch",
+          `expected schema_version=${config.expectedSchemaVersion}`,
+          {
+            expected: config.expectedSchemaVersion,
+            received: envelopeClaims.schemaVersion,
+          },
+        );
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(new TextDecoder().decode(eventsData));
+      } catch {
+        return phase2ErrorResponse(
+          400,
+          "payload_schema_invalid",
+          "events_data is not valid JSON",
+        );
+      }
+      const validation = config.payloadSchema.safeParse(parsed);
+      if (!validation.success) {
+        return zodErrorResponse(validation.error);
+      }
+
+      // JTI replay consumption MUST happen before any DB-mutating step
+      // and (for refresh/backfill) before the per-window advisory lock
+      // is acquired — a replay must not stall an unrelated concurrent
+      // refresh of the same window. RFC 0002 §4.
+      const consumeResult = await consumePhase2Jti(authPool, contextClaims.jti);
+      if (consumeResult === "replay") {
+        return phase2ErrorResponse(
+          409,
+          "context_jti_replay",
+          "context token already used",
+          { jti: contextClaims.jti },
+        );
+      }
+
+      const customerPool = resolveCustomerPool(customerId);
+      let result: {
+        responseBody: Record<string, unknown>;
+        auditDetails: Record<string, unknown>;
+      };
+      try {
+        result = await config.mutate(
+          customerPool,
+          verified,
+          validation.data as z.infer<TSchema>,
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        void auditLog({
+          actorId: contextClaims.sub,
+          action: "phase2.ingest_failed" satisfies AuditAction,
+          targetType: config.auditTargetType,
+          details: {
+            schemaVersion: envelopeClaims.schemaVersion,
+            eventCountClaim: envelopeClaims.eventCount,
+            error: message,
+          },
+          customerId,
+          aiceId: envelopeClaims.aiceId,
+          correlationId: contextClaims.jti,
+        });
+        return phase2ErrorResponse(
+          500,
+          "database_error",
+          "mutation failed while writing to the customer database",
+        );
+      }
+
+      const receivedAt = new Date().toISOString();
+
+      void auditLog({
+        actorId: contextClaims.sub,
+        action: config.successAction,
+        targetType: config.auditTargetType,
+        details: {
+          schemaVersion: envelopeClaims.schemaVersion,
+          ...result.auditDetails,
+        },
+        customerId,
+        aiceId: envelopeClaims.aiceId,
+        correlationId: contextClaims.jti,
+      });
+
+      return NextResponse.json(
+        {
+          ...result.responseBody,
+          received_at: receivedAt,
+          context_jti: contextClaims.jti,
+        },
+        { status: 200 },
+      );
+    });
+}

--- a/src/app/api/phase2/_shared/schemas.ts
+++ b/src/app/api/phase2/_shared/schemas.ts
@@ -10,12 +10,24 @@ import { z } from "zod";
  * Length is capped at 39 digits to match the DB precision; values with
  * more digits would fail the `$::numeric` cast after the route has
  * already consumed the context-token `jti`.
+ *
+ * The canonical form rejects leading zeros (`"01"` etc.) — the DB
+ * natural key is numeric, so `"1"` and `"01"` collapse to the same
+ * row, and accepting both forms would let payload-internal duplicate
+ * guards in `withdraw` / `refresh-window` / `backfill` miss collisions
+ * that the DB will then resolve as either a PK violation (500 after
+ * the jti is consumed) or, for withdraw, a `withdrawn`/`not_found`
+ * count corruption. Literal `"0"` is allowed because zero is a valid
+ * NUMERIC value.
  */
 export const eventKeyString = z
   .string()
   .min(1)
   .max(39)
-  .regex(/^[0-9]+$/, "event_key must be a non-negative integer string");
+  .regex(
+    /^(0|[1-9][0-9]{0,38})$/,
+    "event_key must be a canonical non-negative integer string (no leading zeros)",
+  );
 
 /**
  * Stringified BIGINT on the wire (RFC 0002 §6 — JSON numbers cannot
@@ -33,7 +45,10 @@ const BIGINT_ONE = BigInt(1);
 
 export const stringifiedBigintPositive = z
   .string()
-  .regex(/^[0-9]+$/, "must be a positive integer string (digits only)")
+  .regex(
+    /^[1-9][0-9]*$/,
+    "must be a canonical positive integer string (no leading zeros)",
+  )
   .refine((s) => {
     try {
       const v = BigInt(s);

--- a/src/app/api/phase2/_shared/schemas.ts
+++ b/src/app/api/phase2/_shared/schemas.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
  * more digits would fail the `$::numeric` cast after the route has
  * already consumed the context-token `jti`.
  */
-const eventKeyString = z
+export const eventKeyString = z
   .string()
   .min(1)
   .max(39)
@@ -31,7 +31,7 @@ const eventKeyString = z
 const BIGINT_MAX = BigInt("9223372036854775807");
 const BIGINT_ONE = BigInt(1);
 
-const stringifiedBigintPositive = z
+export const stringifiedBigintPositive = z
   .string()
   .regex(/^[0-9]+$/, "must be a positive integer string (digits only)")
   .refine((s) => {

--- a/src/app/api/phase2/_shared/window-replace.ts
+++ b/src/app/api/phase2/_shared/window-replace.ts
@@ -1,0 +1,307 @@
+import type { Pool } from "pg";
+import { z } from "zod";
+import { withTransaction } from "@/lib/db/client";
+import { baselineEventSchema, storySchema } from "./schemas";
+
+// ---------------------------------------------------------------------------
+// Window-replace payload schema (refresh-window + backfill)
+// ---------------------------------------------------------------------------
+
+const windowTimestamp = z
+  .string()
+  .min(1)
+  .refine((s) => !Number.isNaN(Date.parse(s)), "must be an ISO-8601 timestamp");
+
+const baselineWindowSchema = z.object({
+  kind: z.literal("baseline_event"),
+  from: windowTimestamp,
+  to: windowTimestamp,
+});
+
+const storyWindowSchema = z.object({
+  kind: z.literal("story"),
+  from: windowTimestamp,
+  to: windowTimestamp,
+});
+
+/**
+ * `stories[*].kind` MUST be `auto_correlated` (RFC 0002 §6
+ * refresh-window: curated stories are NEVER affected). The DELETE
+ * filter only removes `kind = 'auto_correlated'` rows; allowing
+ * curated rows on the INSERT side would create an asymmetric mutation
+ * surface where refresh/backfill can produce rows that the same
+ * operation cannot subsequently delete.
+ *
+ * `storySchema` from #218 permits both kinds because it is the
+ * ingest-side schema; here we narrow it with `.refine`.
+ */
+const autoCorrelatedStorySchema = storySchema.refine(
+  (s) => s.kind === "auto_correlated",
+  {
+    message:
+      "stories[*].kind must be 'auto_correlated' (refresh/backfill " +
+      "do not affect curated stories)",
+    path: ["kind"],
+  },
+);
+
+const baselineRefreshBodySchema = z.object({
+  external_key: z.string().min(1),
+  source_aice_id: z.string().min(1).optional(),
+  window: baselineWindowSchema,
+  baseline_version: z.string().min(1),
+  events: z.array(baselineEventSchema),
+});
+
+const storyRefreshBodySchema = z.object({
+  external_key: z.string().min(1),
+  source_aice_id: z.string().min(1).optional(),
+  window: storyWindowSchema,
+  stories: z.array(autoCorrelatedStorySchema),
+});
+
+function inWindow(ts: string, from: string, to: string): boolean {
+  const t = Date.parse(ts);
+  const f = Date.parse(from);
+  const u = Date.parse(to);
+  if (Number.isNaN(t) || Number.isNaN(f) || Number.isNaN(u)) return false;
+  return t >= f && t < u;
+}
+
+/**
+ * The window-replace payload schema is a union of the baseline and
+ * story variants. We use `z.union` rather than `z.discriminatedUnion`
+ * because the discriminator (`window.kind`) is nested; discriminated
+ * unions require a top-level literal.
+ *
+ * `superRefine` enforces the cross-field invariants:
+ *   - row-window membership (each event/story start inside `[from, to)`);
+ *   - payload-internal uniqueness of natural keys (so `accepted ==
+ *     events.length` / `stories.length` stays honest).
+ *
+ * The same schema feeds both `refresh-window` and `backfill` — the two
+ * endpoints differ only in their `schema_version` claim and audit
+ * action; the wire shape and semantics are identical.
+ */
+export const windowReplacePayloadSchema = z
+  .union([baselineRefreshBodySchema, storyRefreshBodySchema])
+  .superRefine((payload, ctx) => {
+    if ("events" in payload) {
+      const baselineVersion = payload.baseline_version;
+      const seen = new Set<string>();
+      payload.events.forEach((event, idx) => {
+        if (
+          !inWindow(event.event_time, payload.window.from, payload.window.to)
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["events", idx, "event_time"],
+            message:
+              `event_time ${event.event_time} is outside the declared ` +
+              `window [${payload.window.from}, ${payload.window.to})`,
+          });
+        }
+        const key = `${baselineVersion}|${event.event_key}`;
+        if (seen.has(key)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["events", idx, "event_key"],
+            message:
+              `duplicate (baseline_version, event_key) ` +
+              `(${baselineVersion}, ${event.event_key}) in payload`,
+          });
+        }
+        seen.add(key);
+      });
+    } else {
+      const seenStories = new Set<string>();
+      payload.stories.forEach((story, idx) => {
+        if (
+          !inWindow(
+            story.time_window.start,
+            payload.window.from,
+            payload.window.to,
+          )
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["stories", idx, "time_window", "start"],
+            message:
+              `time_window.start ${story.time_window.start} is outside the ` +
+              `declared window [${payload.window.from}, ${payload.window.to})`,
+          });
+        }
+        const storyKey = `${story.story_id}|${story.story_version}`;
+        if (seenStories.has(storyKey)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["stories", idx],
+            message:
+              `duplicate (story_id, story_version) ` +
+              `(${story.story_id}, ${story.story_version}) in payload`,
+          });
+        }
+        seenStories.add(storyKey);
+
+        const seenMembers = new Set<string>();
+        story.members.forEach((member, j) => {
+          const memberKey = `${story.story_id}|${story.story_version}|${member.event_key}`;
+          if (seenMembers.has(memberKey)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["stories", idx, "members", j, "event_key"],
+              message:
+                `duplicate (story_id, story_version, member_event_key) ` +
+                `(${story.story_id}, ${story.story_version}, ${member.event_key}) ` +
+                `in payload`,
+            });
+          }
+          seenMembers.add(memberKey);
+        });
+      });
+    }
+  });
+export type WindowReplacePayload = z.infer<typeof windowReplacePayloadSchema>;
+
+// ---------------------------------------------------------------------------
+// DB execution
+// ---------------------------------------------------------------------------
+
+export interface WindowReplaceCounts {
+  accepted: number;
+  deleted: number;
+}
+
+/**
+ * Atomically replace the contents of a window in a single per-customer
+ * transaction. The advisory lock is keyed on
+ * `phase2_window|<window_kind>|<external_key>|<from>|<to>` via
+ * `hashtextextended(..., 0)` in single-bigint form — refresh and
+ * backfill of the same window thus serialize against each other.
+ *
+ * The single-bigint form (`pg_advisory_xact_lock(<bigint>)`) is used
+ * because the two-int form `pg_advisory_xact_lock(<ns>, <bigint>::int4)`
+ * silently raises `integer out of range` on roughly half of all
+ * `hashtextextended` outputs.
+ */
+export async function executeWindowReplace(
+  pool: Pool,
+  payload: WindowReplacePayload,
+  sourceAiceId: string,
+): Promise<WindowReplaceCounts> {
+  return withTransaction(pool, async (client) => {
+    await client.query(
+      `SELECT pg_advisory_xact_lock(
+         hashtextextended(
+           format('phase2_window|%s|%s|%s|%s',
+             $1::text, $2::text, $3::text, $4::text),
+           0
+         )
+       )`,
+      [
+        payload.window.kind,
+        payload.external_key,
+        payload.window.from,
+        payload.window.to,
+      ],
+    );
+
+    if ("events" in payload) {
+      const deleteResult = await client.query(
+        `DELETE FROM baseline_event
+          WHERE baseline_version = $1
+            AND event_time >= $2
+            AND event_time <  $3`,
+        [payload.baseline_version, payload.window.from, payload.window.to],
+      );
+      let accepted = 0;
+      for (const event of payload.events) {
+        const result = await client.query(
+          `INSERT INTO baseline_event (
+             baseline_version, event_key, event_time, kind, category,
+             primary_asset, raw_score, selector_tags, raw_event,
+             score_window_context, window_signals, asset_context,
+             scoring_weights_snapshot, source_aice_id
+           ) VALUES (
+             $1, $2::numeric, $3, $4, $5,
+             $6, $7, $8, $9::jsonb,
+             $10::jsonb, $11::jsonb, $12::jsonb,
+             $13::jsonb, $14
+           )`,
+          [
+            payload.baseline_version,
+            event.event_key,
+            event.event_time,
+            event.kind,
+            event.category ?? null,
+            event.primary_asset ?? null,
+            event.raw_score,
+            event.selector_tags,
+            JSON.stringify(event.raw_event),
+            JSON.stringify(event.score_window_context),
+            JSON.stringify(event.window_signals),
+            event.asset_context == null
+              ? null
+              : JSON.stringify(event.asset_context),
+            JSON.stringify(event.scoring_weights_snapshot),
+            sourceAiceId,
+          ],
+        );
+        accepted += result.rowCount ?? 0;
+      }
+      return { accepted, deleted: deleteResult.rowCount ?? 0 };
+    }
+
+    // story window
+    const deleteResult = await client.query(
+      `DELETE FROM story
+        WHERE kind = 'auto_correlated'
+          AND time_window_start >= $1
+          AND time_window_start <  $2`,
+      [payload.window.from, payload.window.to],
+    );
+    let accepted = 0;
+    for (const story of payload.stories) {
+      const storyResult = await client.query(
+        `INSERT INTO story (
+           story_id, story_version, kind, correlation_rule_id, primary_asset,
+           time_window_start, time_window_end, score,
+           summary_payload, source_aice_id
+         ) VALUES (
+           $1::bigint, $2, $3, $4, $5,
+           $6, $7, $8,
+           $9::jsonb, $10
+         )`,
+        [
+          story.story_id,
+          story.story_version,
+          story.kind,
+          story.correlation_rule_id ?? null,
+          story.primary_asset ?? null,
+          story.time_window.start,
+          story.time_window.end,
+          story.score ?? null,
+          JSON.stringify(story.summary_payload),
+          sourceAiceId,
+        ],
+      );
+      accepted += storyResult.rowCount ?? 0;
+
+      for (const member of story.members) {
+        await client.query(
+          `INSERT INTO story_member (
+             story_id, story_version, member_event_key, role, event
+           ) VALUES ($1::bigint, $2, $3::numeric, $4, $5::jsonb)`,
+          [
+            story.story_id,
+            story.story_version,
+            member.event_key,
+            member.role,
+            JSON.stringify(member.event),
+          ],
+        );
+      }
+    }
+    return { accepted, deleted: deleteResult.rowCount ?? 0 };
+  });
+}

--- a/src/app/api/phase2/_shared/window-replace.ts
+++ b/src/app/api/phase2/_shared/window-replace.ts
@@ -12,17 +12,46 @@ const windowTimestamp = z
   .min(1)
   .refine((s) => !Number.isNaN(Date.parse(s)), "must be an ISO-8601 timestamp");
 
-const baselineWindowSchema = z.object({
-  kind: z.literal("baseline_event"),
-  from: windowTimestamp,
-  to: windowTimestamp,
-});
+/**
+ * Reject zero-width or reversed intervals (`from >= to`). The window
+ * contract is a half-open `[from, to)` range — an empty interval would
+ * pass the row-membership refines (every comparison fails, but those
+ * only fire when the array is non-empty), consume the JTI, take the
+ * advisory lock, delete nothing, and return 200 to the sender. That is
+ * indistinguishable from a no-op success and almost certainly a sender
+ * bug; fail fast at the schema layer instead.
+ */
+function refineFromLessThanTo<T extends { from: string; to: string }>(
+  schema: z.ZodType<T>,
+) {
+  return schema.refine(
+    (w) => {
+      const f = Date.parse(w.from);
+      const t = Date.parse(w.to);
+      return !Number.isNaN(f) && !Number.isNaN(t) && f < t;
+    },
+    {
+      message: "window.from must be strictly earlier than window.to",
+      path: ["to"],
+    },
+  );
+}
 
-const storyWindowSchema = z.object({
-  kind: z.literal("story"),
-  from: windowTimestamp,
-  to: windowTimestamp,
-});
+const baselineWindowSchema = refineFromLessThanTo(
+  z.object({
+    kind: z.literal("baseline_event"),
+    from: windowTimestamp,
+    to: windowTimestamp,
+  }),
+);
+
+const storyWindowSchema = refineFromLessThanTo(
+  z.object({
+    kind: z.literal("story"),
+    from: windowTimestamp,
+    to: windowTimestamp,
+  }),
+);
 
 /**
  * `stories[*].kind` MUST be `auto_correlated` (RFC 0002 §6

--- a/src/app/api/phase2/_shared/withdraw.ts
+++ b/src/app/api/phase2/_shared/withdraw.ts
@@ -54,6 +54,16 @@ export type WithdrawalItem = z.infer<typeof withdrawalItemSchema>;
  * The guard covers both within-array duplicates (two event_keys in one
  * item) and across-item duplicates (two items referencing the same
  * natural key).
+ *
+ * Additionally, a `policy_run` withdrawal cascades to its child
+ * `policy_event` rows (FK in migrations/customer/0002). If a payload
+ * combines `{ kind: "policy_run", run_id: R }` with any
+ * `{ kind: "policy_event", run_id: R, ... }` for the same run, the
+ * count attributed to the explicit policy_event withdrawal depends on
+ * the order items are processed — `withdrawn` when the event item is
+ * processed first, `not_found` after the run's cascade has already
+ * removed the rows. We reject this overlap at the schema layer so the
+ * response counts cannot misrepresent a sender bug.
  */
 export const withdrawPayloadSchema = z
   .object({
@@ -63,6 +73,12 @@ export const withdrawPayloadSchema = z
   })
   .superRefine((payload, ctx) => {
     const seen = new Set<string>();
+    const policyRunIds = new Set<string>();
+    payload.withdrawals.forEach((item) => {
+      if (item.kind === "policy_run") {
+        policyRunIds.add(item.run_id);
+      }
+    });
     payload.withdrawals.forEach((item, idx) => {
       if (item.kind === "baseline_event") {
         item.event_keys.forEach((ek, j) => {
@@ -87,6 +103,13 @@ export const withdrawPayloadSchema = z
         }
         seen.add(key);
       } else if (item.kind === "policy_event") {
+        if (policyRunIds.has(item.run_id)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["withdrawals", idx],
+            message: `policy_event withdrawal for run_id ${item.run_id} overlaps with a policy_run withdrawal in the same payload; the run's FK cascade already removes its policy_event rows`,
+          });
+        }
         item.event_keys.forEach((ek, j) => {
           const key = `policy_event|${item.run_id}|${ek}`;
           if (seen.has(key)) {

--- a/src/app/api/phase2/_shared/withdraw.ts
+++ b/src/app/api/phase2/_shared/withdraw.ts
@@ -1,0 +1,203 @@
+import type { Pool } from "pg";
+import { z } from "zod";
+import { withTransaction } from "@/lib/db/client";
+import { eventKeyString, stringifiedBigintPositive } from "./schemas";
+
+// ---------------------------------------------------------------------------
+// Withdrawal payload schema (RFC 0002 §6 withdraw)
+// ---------------------------------------------------------------------------
+
+const withdrawalBaselineEventSchema = z.object({
+  kind: z.literal("baseline_event"),
+  baseline_version: z.string().min(1),
+  event_keys: z.array(eventKeyString).min(1),
+});
+
+const withdrawalStorySchema = z.object({
+  kind: z.literal("story"),
+  story_id: stringifiedBigintPositive,
+  story_version: z.string().min(1),
+});
+
+const withdrawalPolicyEventSchema = z.object({
+  kind: z.literal("policy_event"),
+  run_id: stringifiedBigintPositive,
+  event_keys: z.array(eventKeyString).min(1),
+});
+
+const withdrawalPolicyRunSchema = z.object({
+  kind: z.literal("policy_run"),
+  run_id: stringifiedBigintPositive,
+});
+
+export const withdrawalItemSchema = z.discriminatedUnion("kind", [
+  withdrawalBaselineEventSchema,
+  withdrawalStorySchema,
+  withdrawalPolicyEventSchema,
+  withdrawalPolicyRunSchema,
+]);
+export type WithdrawalItem = z.infer<typeof withdrawalItemSchema>;
+
+/**
+ * The payload-internal duplicate guard rejects natural-key collisions
+ * across all four withdrawal kinds. Without it, the second DELETE of
+ * the same row would be counted as `not_found` (instead of failing
+ * fast as the sender-bug it really is) and the response counts would
+ * silently misrepresent the input.
+ *
+ * The natural-key tuples are:
+ *   baseline_event → (baseline_version, event_key)
+ *   story          → (story_id, story_version)
+ *   policy_event   → (run_id, event_key)
+ *   policy_run     → (run_id)
+ *
+ * The guard covers both within-array duplicates (two event_keys in one
+ * item) and across-item duplicates (two items referencing the same
+ * natural key).
+ */
+export const withdrawPayloadSchema = z
+  .object({
+    external_key: z.string().min(1),
+    source_aice_id: z.string().min(1).optional(),
+    withdrawals: z.array(withdrawalItemSchema).min(1),
+  })
+  .superRefine((payload, ctx) => {
+    const seen = new Set<string>();
+    payload.withdrawals.forEach((item, idx) => {
+      if (item.kind === "baseline_event") {
+        item.event_keys.forEach((ek, j) => {
+          const key = `baseline_event|${item.baseline_version}|${ek}`;
+          if (seen.has(key)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["withdrawals", idx, "event_keys", j],
+              message: `duplicate withdrawal natural key (${item.baseline_version}, ${ek})`,
+            });
+          }
+          seen.add(key);
+        });
+      } else if (item.kind === "story") {
+        const key = `story|${item.story_id}|${item.story_version}`;
+        if (seen.has(key)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["withdrawals", idx],
+            message: `duplicate withdrawal natural key (${item.story_id}, ${item.story_version})`,
+          });
+        }
+        seen.add(key);
+      } else if (item.kind === "policy_event") {
+        item.event_keys.forEach((ek, j) => {
+          const key = `policy_event|${item.run_id}|${ek}`;
+          if (seen.has(key)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["withdrawals", idx, "event_keys", j],
+              message: `duplicate withdrawal natural key (${item.run_id}, ${ek})`,
+            });
+          }
+          seen.add(key);
+        });
+      } else {
+        const key = `policy_run|${item.run_id}`;
+        if (seen.has(key)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["withdrawals", idx],
+            message: `duplicate withdrawal natural key (${item.run_id})`,
+          });
+        }
+        seen.add(key);
+      }
+    });
+  });
+export type WithdrawPayload = z.infer<typeof withdrawPayloadSchema>;
+
+// ---------------------------------------------------------------------------
+// DB execution
+// ---------------------------------------------------------------------------
+
+export interface WithdrawCounts {
+  withdrawn: number;
+  notFound: number;
+  kindsTouched: WithdrawalItem["kind"][];
+}
+
+/**
+ * Execute all DELETEs in a single per-customer transaction.
+ *
+ * For `policy_run`, child `policy_event` rows cascade via the FK in
+ * `migrations/customer/0002_phase2_tables.sql`. For `story`,
+ * `story_member` rows cascade likewise. Withdraw does NOT issue
+ * explicit DELETEs against the child tables — the cascade is the
+ * source of truth and an explicit DELETE would invite drift if the
+ * cascade is ever modified.
+ */
+export async function executeWithdraw(
+  pool: Pool,
+  payload: WithdrawPayload,
+): Promise<WithdrawCounts> {
+  return withTransaction(pool, async (client) => {
+    let withdrawn = 0;
+    let requested = 0;
+    const kindsSet = new Set<WithdrawalItem["kind"]>();
+
+    for (const item of payload.withdrawals) {
+      kindsSet.add(item.kind);
+      switch (item.kind) {
+        case "baseline_event": {
+          for (const ek of item.event_keys) {
+            requested += 1;
+            const result = await client.query(
+              `DELETE FROM baseline_event
+                WHERE baseline_version = $1
+                  AND event_key = $2::numeric`,
+              [item.baseline_version, ek],
+            );
+            withdrawn += result.rowCount ?? 0;
+          }
+          break;
+        }
+        case "story": {
+          requested += 1;
+          const result = await client.query(
+            `DELETE FROM story
+              WHERE story_id = $1::bigint
+                AND story_version = $2`,
+            [item.story_id, item.story_version],
+          );
+          withdrawn += result.rowCount ?? 0;
+          break;
+        }
+        case "policy_event": {
+          for (const ek of item.event_keys) {
+            requested += 1;
+            const result = await client.query(
+              `DELETE FROM policy_event
+                WHERE run_id = $1::bigint
+                  AND event_key = $2::numeric`,
+              [item.run_id, ek],
+            );
+            withdrawn += result.rowCount ?? 0;
+          }
+          break;
+        }
+        case "policy_run": {
+          requested += 1;
+          const result = await client.query(
+            `DELETE FROM policy_run WHERE run_id = $1::bigint`,
+            [item.run_id],
+          );
+          withdrawn += result.rowCount ?? 0;
+          break;
+        }
+      }
+    }
+
+    return {
+      withdrawn,
+      notFound: requested - withdrawn,
+      kindsTouched: [...kindsSet],
+    };
+  });
+}

--- a/src/app/api/phase2/backfill/route.ts
+++ b/src/app/api/phase2/backfill/route.ts
@@ -1,0 +1,32 @@
+import { createPhase2MutationHandler } from "../_shared/mutation-handler";
+import {
+  executeWindowReplace,
+  windowReplacePayloadSchema,
+} from "../_shared/window-replace";
+
+export const POST = createPhase2MutationHandler({
+  expectedSchemaVersion: "phase2.backfill.v1",
+  payloadSchema: windowReplacePayloadSchema,
+  auditTargetType: "phase2_backfill",
+  successAction: "phase2.backfill",
+  mutate: async (customerPool, verified, payload) => {
+    const counts = await executeWindowReplace(
+      customerPool,
+      payload,
+      verified.envelopeClaims.aiceId,
+    );
+    return {
+      responseBody: {
+        accepted: counts.accepted,
+        duplicates_skipped: 0,
+        deleted: counts.deleted,
+      },
+      auditDetails: {
+        window: payload.window,
+        accepted: counts.accepted,
+        deleted: counts.deleted,
+        eventCountClaim: verified.envelopeClaims.eventCount,
+      },
+    };
+  },
+});

--- a/src/app/api/phase2/refresh-window/route.ts
+++ b/src/app/api/phase2/refresh-window/route.ts
@@ -1,0 +1,32 @@
+import { createPhase2MutationHandler } from "../_shared/mutation-handler";
+import {
+  executeWindowReplace,
+  windowReplacePayloadSchema,
+} from "../_shared/window-replace";
+
+export const POST = createPhase2MutationHandler({
+  expectedSchemaVersion: "phase2.refresh_window.v1",
+  payloadSchema: windowReplacePayloadSchema,
+  auditTargetType: "phase2_refresh_window",
+  successAction: "phase2.refresh_window",
+  mutate: async (customerPool, verified, payload) => {
+    const counts = await executeWindowReplace(
+      customerPool,
+      payload,
+      verified.envelopeClaims.aiceId,
+    );
+    return {
+      responseBody: {
+        accepted: counts.accepted,
+        duplicates_skipped: 0,
+        deleted: counts.deleted,
+      },
+      auditDetails: {
+        window: payload.window,
+        accepted: counts.accepted,
+        deleted: counts.deleted,
+        eventCountClaim: verified.envelopeClaims.eventCount,
+      },
+    };
+  },
+});

--- a/src/app/api/phase2/withdraw/route.ts
+++ b/src/app/api/phase2/withdraw/route.ts
@@ -1,0 +1,23 @@
+import { createPhase2MutationHandler } from "../_shared/mutation-handler";
+import { executeWithdraw, withdrawPayloadSchema } from "../_shared/withdraw";
+
+export const POST = createPhase2MutationHandler({
+  expectedSchemaVersion: "phase2.withdraw.v1",
+  payloadSchema: withdrawPayloadSchema,
+  auditTargetType: "phase2_withdraw",
+  successAction: "phase2.withdraw",
+  mutate: async (customerPool, _verified, payload) => {
+    const counts = await executeWithdraw(customerPool, payload);
+    return {
+      responseBody: {
+        withdrawn: counts.withdrawn,
+        not_found: counts.notFound,
+      },
+      auditDetails: {
+        withdrawn: counts.withdrawn,
+        notFound: counts.notFound,
+        kindsTouched: counts.kindsTouched,
+      },
+    };
+  },
+});

--- a/src/lib/audit/__tests__/taxonomy-completeness.test.ts
+++ b/src/lib/audit/__tests__/taxonomy-completeness.test.ts
@@ -83,6 +83,10 @@ const PRODUCED: Record<string, string> = {
   "phase2.ingest": "src/app/api/phase2/baseline/batch/route.ts",
   "phase2.ingest_failed": "src/app/api/phase2/_shared/handler.ts",
   "phase2.verification_failed": "src/app/api/phase2/_shared/handler.ts",
+  // Phase 2 mutations
+  "phase2.withdraw": "src/app/api/phase2/withdraw/route.ts",
+  "phase2.refresh_window": "src/app/api/phase2/refresh-window/route.ts",
+  "phase2.backfill": "src/app/api/phase2/backfill/route.ts",
   // AICE environment management (guard-level)
   "environment.created": "src/app/api/admin/environments/route.ts",
   "environment.updated": "src/app/api/admin/environments/[aiceId]/route.ts",

--- a/src/lib/audit/actions.ts
+++ b/src/lib/audit/actions.ts
@@ -99,5 +99,9 @@ export type AuditAction =
   | "phase2.ingest"
   | "phase2.ingest_failed"
   | "phase2.verification_failed"
+  // Phase 2 mutations
+  | "phase2.withdraw"
+  | "phase2.refresh_window"
+  | "phase2.backfill"
   // Audit (internal)
   | "audit.anonymize";


### PR DESCRIPTION
## Summary

Implements the three Phase 2 mutation endpoints from RFC 0002 §6:

- `POST /api/phase2/withdraw` — natural-key DELETEs across `baseline_event`, `story`, `policy_event`, and `policy_run` kinds in a single transaction.
- `POST /api/phase2/refresh-window` — DELETE-then-INSERT a half-open `[from, to)` window under a per-window advisory lock.
- `POST /api/phase2/backfill` — structurally identical to refresh-window; same lock, same DELETE-then-INSERT, different audit action.

All three share `verifyPhase2Multipart` (#217) and the jti-replay / error-mapping / customer-pool building blocks from #218. Every route calls `consumePhase2Jti` before any DB-mutating step; a replay returns `409 context_jti_replay` without acquiring the advisory lock or touching the per-customer DB.

The window-replace handler holds a `pg_advisory_xact_lock` keyed on `phase2_window|<kind>|<external_key>|<from>|<to>` via single-bigint `hashtextextended` so refresh and backfill of the same window serialize against each other. Baseline DELETE filters by `baseline_version`; story DELETE filters by `kind = 'auto_correlated'` so curated stories are never affected and uses `time_window_start ∈ [from, to)` (assigns-to-start semantics).

Zod refines reject (all with `400 payload_schema_invalid`):

- Payload-internal duplicate natural keys.
- Non-`auto_correlated` story `kind` in refresh / backfill.
- Rows whose timestamps fall outside the declared window.
- Non-canonical numeric strings (e.g. `"01"`) in `event_key`, `story_id`, `run_id`, or member `event_key` — the DB natural keys are numeric/bigint, so `"01"` and `"1"` collapse to one row and would let payload-internal duplicate guards miss collisions that the DB then surfaces as a PK violation (500 after JTI consumption) or, for withdraw, count corruption.
- `window.from >= window.to` (zero-width or reversed interval) — with an empty `events`/`stories` array this would otherwise pass the row-membership guards, consume the JTI, take the advisory lock, delete nothing, and return 200.
- `withdraw` payloads that combine `{ kind: "policy_run", run_id: R }` with any `{ kind: "policy_event", run_id: R, ... }` for the same run. The run's FK cascade already removes its policy_event rows, so the count attributed to the explicit policy_event item would otherwise depend on item processing order (`withdrawn` vs `not_found`), masking the sender bug.

Adds three new success-path audit actions (`phase2.withdraw`, `phase2.refresh_window`, `phase2.backfill`); failure paths reuse `phase2.verification_failed` and `phase2.ingest_failed` from #218. Extends `docs/{en,ko}/operations/phase2-ingest.md` with the new endpoints, their advisory-lock semantics, and the schema-rejection classes above.

Closes #219

## Test plan

- [x] `withdraw`: each kind individually + mixed in one call; `withdrawn` / `not_found` counts correct
- [x] `withdraw`: `not_found` for already-gone rows is informational, not an error
- [x] `withdraw`: FK cascade on `policy_run` removes `policy_event` child rows; FK cascade on `story` removes `story_member` child rows
- [x] `withdraw`: empty `withdrawals` array → `400 payload_schema_invalid`
- [x] `withdraw`: payload-internal duplicate natural keys (within an item's `event_keys` array AND across items) → `400 payload_schema_invalid` for each kind
- [x] `withdraw`: payload combines `policy_run` and `policy_event` for the same `run_id` → `400 payload_schema_invalid`, regardless of item order
- [x] `refresh-window` / `backfill`: payload-internal duplicate `(baseline_version, event_key)`, `(story_id, story_version)`, and `(story_id, story_version, member_event_key)` rejected with `400 payload_schema_invalid`
- [x] `refresh-window` / `backfill` story: any `stories[*].kind === "analyst_curated"` rejected with `400 payload_schema_invalid`
- [x] `refresh-window` / `backfill` baseline: out-of-window `event_time` rejected; boundary cases — `event_time == window.from` accepted, `event_time == window.to` rejected
- [x] `refresh-window` / `backfill` story: out-of-window `time_window.start` rejected; story with in-window `start` but `end` past `window.to` accepted
- [x] Non-canonical numeric strings (`"01"`, `"010"`) rejected for `event_key` / `story_id` / `run_id` / member `event_key` across all three endpoints; literal `"0"` still accepted as a valid `event_key`
- [x] `refresh-window` / `backfill` reject `window.from >= window.to` (zero-width and reversed) at the schema layer, before JTI consumption
- [x] `refresh-window` baseline: DELETE filters by `baseline_version` — other versions' rows in the same window are preserved
- [x] `refresh-window` story: curated stories unaffected; auto stories across `story_version` all replaced
- [x] `refresh-window` story: a story with `time_window_start` BEFORE `from` but `time_window_end` INSIDE the window SURVIVES the refresh
- [x] `refresh-window`: empty body clears the window
- [x] `backfill`: idempotent on re-run with the same window + content
- [x] Advisory lock serializes two concurrent refreshes of the same window
- [x] Advisory lock serializes a concurrent refresh and backfill of the same window (proves lock key omits operation kind)
- [x] jti replay: second call with same `contextClaims.jti` returns `409 context_jti_replay`, performs NO DB mutation, does NOT acquire the per-window advisory lock, emits NO success audit (verified per route)
- [x] Verification failure audit: each route emits `phase2.verification_failed` with the correct `targetType` (`phase2_withdraw` / `phase2_refresh_window` / `phase2_backfill`)
- [x] DB-failure path: throw inside per-customer transaction emits `phase2.ingest_failed`, returns `500 database_error`, leaves consumed jti in `phase2_consumed_jtis` (verified per route)
- [x] `pnpm typecheck`, `pnpm check`, `pnpm test`, `pnpm build` all green