### PR TITLE
Add Phase 2 event-key analysis lookup helpers (#220)

### DIFF
--- a/src/lib/analysis/__tests__/lookup.db.test.ts
+++ b/src/lib/analysis/__tests__/lookup.db.test.ts
@@ -1,0 +1,251 @@
+import { join } from "node:path";
+import type { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeAdminPool,
+  createTestDatabase,
+  dropTestDatabase,
+  hasPostgres,
+} from "@/lib/db/__tests__/db-test-helpers";
+import { runMigrations } from "@/lib/db/migrate";
+import { lookupAnalysisForEvent, lookupAnalysisNarrative } from "../lookup";
+
+const CUSTOMER_MIGRATIONS_DIR = join(process.cwd(), "migrations", "customer");
+const LOCK_ID_CUSTOMER = 1002;
+
+async function insertBaseline(
+  pool: Pool,
+  baselineVersion: string,
+  eventKey: string,
+  receivedAt: string,
+  overrides: Partial<{ kind: string; category: string }> = {},
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO baseline_event (
+       baseline_version, event_key, event_time, kind, category,
+       raw_score, raw_event, score_window_context, window_signals,
+       scoring_weights_snapshot, source_aice_id, received_at
+     ) VALUES (
+       $1, $2::numeric, NOW(), $3, $4,
+       0.5, '{"r":1}'::jsonb, '{"baseline_rank_snapshot":0.9}'::jsonb, '{}'::jsonb,
+       '{}'::jsonb, 'aice-1', $5::timestamptz
+     )`,
+    [
+      baselineVersion,
+      eventKey,
+      overrides.kind ?? "http",
+      overrides.category ?? null,
+      receivedAt,
+    ],
+  );
+}
+
+describe.skipIf(!hasPostgres)("Phase 2 analysis lookup helpers", () => {
+  let dbName: string;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    const db = await createTestDatabase("analysis_lookup");
+    dbName = db.dbName;
+    pool = db.pool;
+    await runMigrations(pool, CUSTOMER_MIGRATIONS_DIR, LOCK_ID_CUSTOMER);
+  });
+
+  afterAll(async () => {
+    await dropTestDatabase(dbName, pool);
+    await closeAdminPool();
+  });
+
+  describe("lookupAnalysisForEvent", () => {
+    it("returns the Phase 2 row when baseline_event has a match", async () => {
+      await insertBaseline(pool, "be-v1", "1001", "2026-01-02T03:00:00Z", {
+        kind: "dns",
+        category: "recon",
+      });
+
+      const result = await lookupAnalysisForEvent(pool, "1001");
+      expect(result.source).toBe("phase2");
+      if (result.source !== "phase2") return;
+      expect(result.row.event_key).toBe("1001");
+      expect(result.row.baseline_version).toBe("be-v1");
+      expect(result.row.kind).toBe("dns");
+      expect(result.row.category).toBe("recon");
+      expect(result.row.raw_score).toBe(0.5);
+      // JSONB columns surface as parsed objects from node-postgres.
+      expect(result.row.raw_event).toEqual({ r: 1 });
+      // received_at is returned as a JS Date by node-postgres.
+      expect(result.row.received_at).toBeInstanceOf(Date);
+    });
+
+    it("returns { source: 'none' } when no baseline_event row matches", async () => {
+      const result = await lookupAnalysisForEvent(pool, "9999999999");
+      expect(result).toEqual({ source: "none" });
+    });
+
+    it("returns the most recent by received_at when multiple baseline_versions share the same event_key", async () => {
+      // Same event_key under three baseline_versions — read helper must
+      // pick the row with the latest received_at, NOT assume 1:1
+      // mapping (per #216 schema note).
+      await insertBaseline(pool, "ver-a", "2002", "2026-02-01T00:00:00Z");
+      await insertBaseline(pool, "ver-b", "2002", "2026-02-03T00:00:00Z");
+      await insertBaseline(pool, "ver-c", "2002", "2026-02-02T00:00:00Z");
+
+      const result = await lookupAnalysisForEvent(pool, "2002");
+      expect(result.source).toBe("phase2");
+      if (result.source !== "phase2") return;
+      expect(result.row.baseline_version).toBe("ver-b");
+    });
+
+    it("returns { source: 'none' } even when only a Phase 1 detection_events row would exist (v1 limitation)", async () => {
+      // This test documents the v1 limitation per issue #220: aimer-web
+      // does NOT search detection_events by event_key (encrypted BYTEA
+      // without a plaintext event_key index). The lookup is Phase 2
+      // only. We simulate the absence by asserting that a fresh
+      // event_key with no baseline_event row returns "none" — there is
+      // no detection_events.event_key column to seed in the first place.
+      const result = await lookupAnalysisForEvent(pool, "424242");
+      expect(result).toEqual({ source: "none" });
+    });
+  });
+
+  describe("lookupAnalysisNarrative", () => {
+    it("returns null when no narrative row matches", async () => {
+      const result = await lookupAnalysisNarrative(pool, "story", {
+        story_id: "8000",
+        story_version: "v1",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("returns the row when a narrative exists for the (target_kind, target_keys) pair", async () => {
+      await pool.query(
+        `INSERT INTO analysis_narrative (
+           content_hash, target_kind, target_keys, narrative,
+           prompt_version, model_version
+         ) VALUES (
+           'hash-story-1', 'story',
+           '{"story_id":"8001","story_version":"v1"}'::jsonb,
+           'a narrative',
+           'p-v1', 'm-v1'
+         )`,
+      );
+
+      const result = await lookupAnalysisNarrative(pool, "story", {
+        story_id: "8001",
+        story_version: "v1",
+      });
+      expect(result).not.toBeNull();
+      if (result === null) return;
+      expect(result.content_hash).toBe("hash-story-1");
+      expect(result.narrative).toBe("a narrative");
+      expect(result.prompt_version).toBe("p-v1");
+      expect(result.model_version).toBe("m-v1");
+      expect(result.target_keys).toEqual({
+        story_id: "8001",
+        story_version: "v1",
+      });
+    });
+
+    it("returns the most recent by generated_at when multiple narratives exist for the same target", async () => {
+      // Two narratives for the same story, generated under different
+      // prompt/model versions — helper must return the most recent.
+      await pool.query(
+        `INSERT INTO analysis_narrative (
+           content_hash, target_kind, target_keys, narrative,
+           prompt_version, model_version, generated_at
+         ) VALUES (
+           'hash-story-old', 'story',
+           '{"story_id":"8100","story_version":"v1"}'::jsonb,
+           'old narrative',
+           'p-v1', 'm-v1', '2026-01-01T00:00:00Z'
+         )`,
+      );
+      await pool.query(
+        `INSERT INTO analysis_narrative (
+           content_hash, target_kind, target_keys, narrative,
+           prompt_version, model_version, generated_at
+         ) VALUES (
+           'hash-story-new', 'story',
+           '{"story_id":"8100","story_version":"v1"}'::jsonb,
+           'new narrative',
+           'p-v2', 'm-v2', '2026-03-01T00:00:00Z'
+         )`,
+      );
+
+      const result = await lookupAnalysisNarrative(pool, "story", {
+        story_id: "8100",
+        story_version: "v1",
+      });
+      expect(result?.content_hash).toBe("hash-story-new");
+      expect(result?.prompt_version).toBe("p-v2");
+    });
+
+    it("distinguishes narratives across target_kind values with overlapping target_keys", async () => {
+      // story_id 9000 vs run_id 9000 — same numeric value, different
+      // target_kind. Equality on (target_kind, target_keys) must keep
+      // them separate.
+      await pool.query(
+        `INSERT INTO analysis_narrative (
+           content_hash, target_kind, target_keys, narrative,
+           prompt_version, model_version
+         ) VALUES
+           ('hash-story-9000', 'story',
+            '{"story_id":"9000","story_version":"v1"}'::jsonb,
+            'story narrative', 'p', 'm'),
+           ('hash-run-9000', 'policy_run',
+            '{"run_id":"9000"}'::jsonb,
+            'run narrative', 'p', 'm')`,
+      );
+
+      const storyResult = await lookupAnalysisNarrative(pool, "story", {
+        story_id: "9000",
+        story_version: "v1",
+      });
+      expect(storyResult?.content_hash).toBe("hash-story-9000");
+
+      const runResult = await lookupAnalysisNarrative(pool, "policy_run", {
+        run_id: "9000",
+      });
+      expect(runResult?.content_hash).toBe("hash-run-9000");
+    });
+
+    it("supports baseline_event narrative lookup by (baseline_version, event_key)", async () => {
+      await pool.query(
+        `INSERT INTO analysis_narrative (
+           content_hash, target_kind, target_keys, narrative,
+           prompt_version, model_version
+         ) VALUES (
+           'hash-be-1', 'baseline_event',
+           '{"baseline_version":"v1","event_key":"1234567890"}'::jsonb,
+           'baseline event narrative',
+           'p', 'm'
+         )`,
+      );
+
+      const result = await lookupAnalysisNarrative(pool, "baseline_event", {
+        baseline_version: "v1",
+        event_key: "1234567890",
+      });
+      expect(result?.content_hash).toBe("hash-be-1");
+    });
+
+    it("returns null when target_keys shape matches but values differ", async () => {
+      // Confirms JSONB equality, not partial match.
+      await pool.query(
+        `INSERT INTO analysis_narrative (
+           content_hash, target_kind, target_keys, narrative,
+           prompt_version, model_version
+         ) VALUES (
+           'hash-policy-7', 'policy_run',
+           '{"run_id":"7"}'::jsonb,
+           'n', 'p', 'm'
+         )`,
+      );
+
+      const miss = await lookupAnalysisNarrative(pool, "policy_run", {
+        run_id: "8",
+      });
+      expect(miss).toBeNull();
+    });
+  });
+});

--- a/src/lib/analysis/lookup.ts
+++ b/src/lib/analysis/lookup.ts
@@ -1,0 +1,226 @@
+import type { Pool } from "pg";
+
+/**
+ * Read-side helpers that resolve `(external_key, event_key)` to a Phase 2
+ * analysis row, and that fetch the associated `analysis_narrative` row.
+ *
+ * ## v1 scope: Phase 2 event-key lookup only
+ *
+ * `detection_events` (Phase 1) is **not** searchable by `event_key` in v1 —
+ * the payload is encrypted BYTEA and aimer-web does not maintain a
+ * plaintext `event_key` index on it. Phase 1 rows are reachable only
+ * through Phase 1-native surfaces (the Detection bridge audit log or a
+ * future Phase 1-specific list page) by their internal
+ * `detection_events.id`, **not** by `event_key`.
+ *
+ * Consequently, when an analysis caller asks "give me the analysis for
+ * `event_key = X`," this module looks only at `baseline_event` (Phase 2)
+ * and returns either the Phase 2 row or `none`.
+ *
+ * This is a deliberate limitation per RFC 0002 §8 (the Phase 2 row is
+ * the canonical analysis row by design), not a bug. If a future need
+ * arises to look up Phase 1 rows by `event_key`, the path is to add a
+ * plaintext `event_key` column (or sibling index table) to
+ * `detection_events` — separate future work, additive RFC change.
+ *
+ * @see {@link https://github.com/aicers/aice-web-next/blob/main/rfcs/0002-aimer-web-phase2-contract.md RFC 0002}
+ */
+
+/**
+ * A `baseline_event` row as returned by the analysis lookup. NUMERIC and
+ * BIGINT columns are surfaced as strings — node-postgres returns these
+ * as strings by default because the JS `number` type cannot safely
+ * represent values beyond 2^53 (NUMERIC(39, 0) is i128 on the
+ * aice-web-next side; even BIGINT may overflow).
+ */
+export interface BaselineEventRow {
+  baseline_version: string;
+  event_key: string;
+  event_time: Date;
+  kind: string;
+  category: string | null;
+  primary_asset: string | null;
+  raw_score: number;
+  selector_tags: string[];
+  raw_event: Record<string, unknown>;
+  score_window_context: Record<string, unknown>;
+  window_signals: Record<string, unknown>;
+  asset_context: Record<string, unknown> | null;
+  scoring_weights_snapshot: Record<string, unknown>;
+  source_aice_id: string;
+  received_at: Date;
+}
+
+export type AnalysisLookupResult =
+  | { source: "phase2"; row: BaselineEventRow }
+  | { source: "none" };
+
+/**
+ * Resolve an `event_key` to the canonical Phase 2 `baseline_event` row.
+ *
+ * Returns the row with the most recent `received_at` when multiple
+ * `baseline_version` values carry the same `event_key` (the event was
+ * re-sent under a bumped baseline — `baseline_event.event_key` is not
+ * unique across `baseline_version` per #216).
+ *
+ * Returns `{ source: "none" }` when no Phase 2 row exists. **This does
+ * not mean the event never existed on aimer-web** — see the UI guidance
+ * below for the two operational meanings the caller must distinguish.
+ *
+ * ## Guidance for the eventual analysis UI consumer
+ *
+ * `{ source: "none" }` has **two** distinct operational meanings that
+ * the v1 lookup cannot tell apart:
+ *
+ *   1. The event was never sent to aimer-web at all.
+ *   2. The event was sent via Phase 1 (Detection menu ad-hoc send) but
+ *      not via Phase 2 baseline push. A `detection_events` row exists
+ *      but is not reachable by `event_key` in v1 because its payload is
+ *      encrypted BYTEA without a plaintext `event_key` index.
+ *
+ * Recommended UI copy: render "No baseline analysis available for this
+ * event" rather than "Event not found" — the first phrasing is true in
+ * both cases; the second is misleading in case (2). A future Phase 1
+ * plaintext `event_key` index would let the UI distinguish the two.
+ *
+ * @param customerPool - Per-customer DB pool (the customer scope IS the DB)
+ * @param eventKey     - Stringified NUMERIC(39, 0)
+ */
+export async function lookupAnalysisForEvent(
+  customerPool: Pool,
+  eventKey: string,
+): Promise<AnalysisLookupResult> {
+  const { rows } = await customerPool.query<BaselineEventRow>(
+    `SELECT
+       baseline_version,
+       event_key::text AS event_key,
+       event_time,
+       kind,
+       category,
+       primary_asset,
+       raw_score,
+       selector_tags,
+       raw_event,
+       score_window_context,
+       window_signals,
+       asset_context,
+       scoring_weights_snapshot,
+       source_aice_id,
+       received_at
+     FROM baseline_event
+     WHERE event_key = $1::numeric
+     ORDER BY received_at DESC
+     LIMIT 1`,
+    [eventKey],
+  );
+
+  if (rows.length === 0) {
+    return { source: "none" };
+  }
+  return { source: "phase2", row: rows[0] };
+}
+
+// ---------------------------------------------------------------------------
+// analysis_narrative
+// ---------------------------------------------------------------------------
+
+export type AnalysisNarrativeTargetKind =
+  | "baseline_event"
+  | "story"
+  | "policy_run";
+
+/**
+ * Keys that identify the narrative's target row. Shape depends on
+ * `targetKind`:
+ *
+ *   - `baseline_event`: `{ baseline_version, event_key }`
+ *   - `story`:          `{ story_id, story_version }`
+ *   - `policy_run`:     `{ run_id }`
+ *
+ * Both string and number values are accepted because BIGINT and
+ * NUMERIC identifiers travel as strings on the wire but may appear as
+ * numbers in some upstream representations.
+ */
+export type AnalysisNarrativeTargetKeys = Record<string, string | number>;
+
+export interface AnalysisNarrativeRow {
+  content_hash: string;
+  target_kind: AnalysisNarrativeTargetKind;
+  target_keys: Record<string, unknown>;
+  narrative: string;
+  prompt_version: string;
+  model_version: string;
+  generated_at: Date;
+}
+
+/**
+ * Fetch the most recent `analysis_narrative` row matching `(targetKind,
+ * targetKeys)`. Returns `null` when no row matches; the caller decides
+ * whether to trigger LLM analysis or render "Analysis pending".
+ *
+ * ## Re-generation semantics — INSERT-only, no UPDATE
+ *
+ * `analysis_narrative` has `GRANT SELECT, INSERT, DELETE` for
+ * `aimer_customer` — **no UPDATE grant** (deviates from #216's
+ * original spec; codified in #221). A different `prompt_version` or
+ * `model_version` changes `content_hash`, so re-generation always
+ * produces a new row with a new primary key rather than mutating an
+ * existing one.
+ *
+ * Two narratives for the same target (different `prompt_version` /
+ * `model_version`) therefore coexist as separate rows. This helper
+ * returns "the current narrative" by picking the most recent
+ * `generated_at` across all `(prompt_version, model_version)` pairs.
+ * Callers that need a specific pair should narrow down on the returned
+ * row's `prompt_version` / `model_version` fields and re-query if
+ * needed (a typed-version selector helper is out of scope for v1).
+ *
+ * ## content_hash composition (writer responsibility, documented here
+ * for caller awareness)
+ *
+ * `content_hash` is computed at INSERT time by the LLM pipeline
+ * (separate track) as a stable hash of `target_kind` + `target_keys` +
+ * the target row's `summary_payload` (or equivalent) +
+ * `prompt_version` + `model_version`. The exact composition is
+ * aimer-web's choice per RFC 0002 §11.2. This read helper does **not**
+ * recompute the hash — it queries by `(target_kind, target_keys)`
+ * directly and surfaces the stored hash.
+ *
+ * ## v1 query plan
+ *
+ * Queries by JSONB equality on `target_keys` within `target_kind`.
+ * `analysis_narrative_target_kind_generated_at_idx` (`(target_kind,
+ * generated_at)`) narrows by `target_kind` and orders the result;
+ * `target_keys` equality runs as a filter. No GIN index is defined on
+ * `target_keys` in v1 per #216 ("reverse lookup by target_keys is not
+ * supported in v1"); if traffic to this path grows, add `CREATE INDEX
+ * CONCURRENTLY ... USING GIN (target_keys)` in a follow-up migration.
+ *
+ * @param customerPool - Per-customer DB pool
+ * @param targetKind   - `baseline_event` | `story` | `policy_run`
+ * @param targetKeys   - Shape determined by `targetKind` (see type doc)
+ */
+export async function lookupAnalysisNarrative(
+  customerPool: Pool,
+  targetKind: AnalysisNarrativeTargetKind,
+  targetKeys: AnalysisNarrativeTargetKeys,
+): Promise<AnalysisNarrativeRow | null> {
+  const { rows } = await customerPool.query<AnalysisNarrativeRow>(
+    `SELECT
+       content_hash,
+       target_kind,
+       target_keys,
+       narrative,
+       prompt_version,
+       model_version,
+       generated_at
+     FROM analysis_narrative
+     WHERE target_kind = $1
+       AND target_keys = $2::jsonb
+     ORDER BY generated_at DESC
+     LIMIT 1`,
+    [targetKind, JSON.stringify(targetKeys)],
+  );
+
+  return rows[0] ?? null;
+}


### PR DESCRIPTION
## Summary

- Add `src/lib/analysis/lookup.ts` exposing `lookupAnalysisForEvent` and `lookupAnalysisNarrative` — the read-side substrate the eventual analysis UI will consume per RFC 0002 §8.
- `lookupAnalysisForEvent(customerPool, eventKey)` returns `{ source: "phase2", row }` from `baseline_event` (most recent by `received_at` when multiple `baseline_version` rows carry the same `event_key`) or `{ source: "none" }`. v1 is Phase 2 only — `detection_events` is not searchable by `event_key` because its payload is encrypted BYTEA without a plaintext index. The JSDoc spells out the two operational meanings of `none` so the eventual UI renders "No baseline analysis available" rather than "Event not found".
- `lookupAnalysisNarrative(customerPool, targetKind, targetKeys)` returns the most-recent matching `analysis_narrative` row by JSONB equality on `target_keys` within `target_kind`, or `null`. The JSDoc documents the INSERT-only re-generation semantics codified in #221 (no UPDATE grant) so callers know that different `(prompt_version, model_version)` pairs coexist as separate rows.
- Tests cover: phase2 row found, none when absent, most-recent-by-`received_at` across `baseline_version` values, the Phase 1 v1-limitation case, narrative miss vs match, multi-version most-recent selection, cross-`target_kind` disambiguation, exact `target_keys` equality, and the `baseline_event` narrative target shape.

Closes #220

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm check` passes (Biome — info-only schema version notice, no errors)
- [x] `pnpm test:unit` passes (946 tests)
- [x] `pnpm test:db` runs cleanly (skips locally without Postgres; tests will run in CI)
- [x] `pnpm build` passes
- [x] `lookupAnalysisForEvent` returns the Phase 2 row when present
- [x] `lookupAnalysisForEvent` returns `{ source: "none" }` when no Phase 2 row exists (the v1 Phase 1 limitation is documented in the JSDoc and exercised in tests)
- [x] `lookupAnalysisForEvent` returns the most recent `baseline_event` by `received_at` when multiple `baseline_version` values share the same `event_key`
- [x] `lookupAnalysisNarrative` returns `null` when no narrative matches
- [x] `lookupAnalysisNarrative` returns the most recent narrative by `generated_at` when multiple `(prompt_version, model_version)` pairs exist for the same target
- [x] `lookupAnalysisNarrative` disambiguates by `target_kind` when `target_keys` overlap (e.g., `story_id` = `9000` vs `run_id` = `9000`)
- [x] `lookupAnalysisNarrative` supports `baseline_event` / `story` / `policy_run` target kinds