### PR TITLE
Add Phase 2 event-key analysis lookup (#220)

### DIFF
--- a/src/lib/analysis/__tests__/lookup.db.test.ts
+++ b/src/lib/analysis/__tests__/lookup.db.test.ts
@@ -1,0 +1,354 @@
+import { join } from "node:path";
+import type { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeAdminPool,
+  createTestDatabase,
+  dropTestDatabase,
+  hasPostgres,
+} from "@/lib/db/__tests__/db-test-helpers";
+import { runMigrations } from "@/lib/db/migrate";
+import {
+  type AnalysisLookupResult,
+  type AnalysisNarrativeRow,
+  type BaselineEventRow,
+  lookupAnalysisForEvent,
+  lookupAnalysisNarrative,
+} from "../lookup";
+
+const CUSTOMER_MIGRATIONS_DIR = join(process.cwd(), "migrations", "customer");
+const LOCK_ID_CUSTOMER = 1002;
+
+async function insertBaselineRow(
+  pool: Pool,
+  opts: {
+    baseline_version: string;
+    event_key: string;
+    received_at: string;
+    event_time?: string;
+    kind?: string;
+    category?: string | null;
+    primary_asset?: string | null;
+    raw_score?: number;
+    selector_tags?: string[];
+    raw_event?: Record<string, unknown>;
+    score_window_context?: Record<string, unknown>;
+    window_signals?: Record<string, unknown>;
+    asset_context?: Record<string, unknown> | null;
+    scoring_weights_snapshot?: Record<string, unknown>;
+    source_aice_id?: string;
+  },
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO baseline_event (
+       baseline_version, event_key, event_time, kind, category,
+       primary_asset, raw_score, selector_tags, raw_event,
+       score_window_context, window_signals, asset_context,
+       scoring_weights_snapshot, source_aice_id, received_at
+     ) VALUES (
+       $1, $2::numeric, $3, $4, $5,
+       $6, $7, $8, $9::jsonb,
+       $10::jsonb, $11::jsonb, $12::jsonb,
+       $13::jsonb, $14, $15
+     )`,
+    [
+      opts.baseline_version,
+      opts.event_key,
+      opts.event_time ?? "2026-01-01T00:00:00Z",
+      opts.kind ?? "dns",
+      opts.category ?? null,
+      opts.primary_asset ?? null,
+      opts.raw_score ?? 0.5,
+      opts.selector_tags ?? [],
+      JSON.stringify(opts.raw_event ?? {}),
+      JSON.stringify(opts.score_window_context ?? {}),
+      JSON.stringify(opts.window_signals ?? {}),
+      opts.asset_context == null ? null : JSON.stringify(opts.asset_context),
+      JSON.stringify(opts.scoring_weights_snapshot ?? {}),
+      opts.source_aice_id ?? "aice-1",
+      opts.received_at,
+    ],
+  );
+}
+
+async function insertNarrativeRow(
+  pool: Pool,
+  opts: {
+    content_hash: string;
+    target_kind: "baseline_event" | "story" | "policy_run";
+    target_keys: Record<string, string>;
+    narrative?: string;
+    prompt_version?: string;
+    model_version?: string;
+    generated_at: string;
+  },
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO analysis_narrative (
+       content_hash, target_kind, target_keys, narrative,
+       prompt_version, model_version, generated_at
+     ) VALUES ($1, $2, $3::jsonb, $4, $5, $6, $7)`,
+    [
+      opts.content_hash,
+      opts.target_kind,
+      JSON.stringify(opts.target_keys),
+      opts.narrative ?? "narrative-body",
+      opts.prompt_version ?? "p1",
+      opts.model_version ?? "m1",
+      opts.generated_at,
+    ],
+  );
+}
+
+describe.skipIf(!hasPostgres)("lookupAnalysisForEvent", () => {
+  let dbName: string;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    const db = await createTestDatabase("analysis_lookup_event");
+    dbName = db.dbName;
+    pool = db.pool;
+    await runMigrations(pool, CUSTOMER_MIGRATIONS_DIR, LOCK_ID_CUSTOMER);
+  });
+
+  afterAll(async () => {
+    await dropTestDatabase(dbName, pool);
+    await closeAdminPool();
+  });
+
+  it("returns { source: 'phase2', row } when a baseline_event row exists", async () => {
+    await insertBaselineRow(pool, {
+      baseline_version: "vA",
+      event_key: "1001",
+      received_at: "2026-02-01T00:00:00Z",
+      event_time: "2026-01-15T12:00:00Z",
+      kind: "http",
+      category: "exfil",
+      primary_asset: "host-7",
+      raw_score: 0.91,
+      selector_tags: ["alpha", "beta"],
+      raw_event: { hello: "world" },
+      asset_context: { owner: "team-x" },
+    });
+
+    const result = await lookupAnalysisForEvent(pool, "1001");
+    expect(result.source).toBe("phase2");
+    if (result.source !== "phase2") throw new Error("unreachable");
+    const row: BaselineEventRow = result.row;
+    expect(row.event_key).toBe("1001");
+    expect(row.baseline_version).toBe("vA");
+    expect(row.kind).toBe("http");
+    expect(row.category).toBe("exfil");
+    expect(row.primary_asset).toBe("host-7");
+    expect(row.raw_score).toBeCloseTo(0.91);
+    expect(row.selector_tags).toEqual(["alpha", "beta"]);
+    expect(row.raw_event).toEqual({ hello: "world" });
+    expect(row.asset_context).toEqual({ owner: "team-x" });
+    expect(row.event_time).toBeInstanceOf(Date);
+    expect(row.received_at).toBeInstanceOf(Date);
+  });
+
+  it("returns { source: 'none' } when no baseline_event row matches", async () => {
+    const result: AnalysisLookupResult = await lookupAnalysisForEvent(
+      pool,
+      "9999999999",
+    );
+    expect(result).toEqual({ source: "none" });
+  });
+
+  it("returns { source: 'none' } for a Phase 1 detection_events row (v1 limitation)", async () => {
+    // v1 limitation case: detection_events rows carry encrypted payloads and
+    // aimer-web maintains NO plaintext event_key index on them. Even if the
+    // ad-hoc-sent payload happened to contain some event_key value, the
+    // lookup-by-event_key path is Phase 2 only in v1 and must return `none`.
+    //
+    // This test MUST NOT attempt to decrypt the payload or extract event_key
+    // from it — the whole point of the v1 limitation is that aimer-web does
+    // neither. The detection_events row below is constructed with arbitrary
+    // BYTEA bytes; the fixture-only "event_key 4242" assertion lives in
+    // this comment, not in the DB row.
+    await pool.query(
+      `INSERT INTO detection_events
+         (aice_id, payload, wrapped_dek, event_count, schema_version,
+          payload_hash, source, ingested_by)
+       VALUES
+         ('aice-1', $1::bytea, 'wrapped', 1, 'v1', 'hash', 'manual',
+          '00000000-0000-0000-0000-000000000001')`,
+      [Buffer.from([0xde, 0xad, 0xbe, 0xef])],
+    );
+
+    const result = await lookupAnalysisForEvent(pool, "4242");
+    expect(result).toEqual({ source: "none" });
+  });
+
+  it("picks the most recent baseline_event by received_at across baseline_versions", async () => {
+    await insertBaselineRow(pool, {
+      baseline_version: "vOld",
+      event_key: "2002",
+      received_at: "2026-03-01T00:00:00Z",
+      kind: "old-kind",
+    });
+    await insertBaselineRow(pool, {
+      baseline_version: "vNew",
+      event_key: "2002",
+      received_at: "2026-03-02T00:00:00Z",
+      kind: "new-kind",
+    });
+
+    const result = await lookupAnalysisForEvent(pool, "2002");
+    expect(result.source).toBe("phase2");
+    if (result.source !== "phase2") throw new Error("unreachable");
+    expect(result.row.baseline_version).toBe("vNew");
+    expect(result.row.kind).toBe("new-kind");
+  });
+
+  it("breaks received_at ties with baseline_version DESC for determinism", async () => {
+    const tiedAt = "2026-04-01T00:00:00Z";
+    await insertBaselineRow(pool, {
+      baseline_version: "vAA",
+      event_key: "3003",
+      received_at: tiedAt,
+      kind: "from-vAA",
+    });
+    await insertBaselineRow(pool, {
+      baseline_version: "vZZ",
+      event_key: "3003",
+      received_at: tiedAt,
+      kind: "from-vZZ",
+    });
+
+    const result = await lookupAnalysisForEvent(pool, "3003");
+    expect(result.source).toBe("phase2");
+    if (result.source !== "phase2") throw new Error("unreachable");
+    // Textual DESC: "vZZ" > "vAA".
+    expect(result.row.baseline_version).toBe("vZZ");
+    expect(result.row.kind).toBe("from-vZZ");
+  });
+});
+
+describe.skipIf(!hasPostgres)("lookupAnalysisNarrative", () => {
+  let dbName: string;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    const db = await createTestDatabase("analysis_lookup_narrative");
+    dbName = db.dbName;
+    pool = db.pool;
+    await runMigrations(pool, CUSTOMER_MIGRATIONS_DIR, LOCK_ID_CUSTOMER);
+  });
+
+  afterAll(async () => {
+    await dropTestDatabase(dbName, pool);
+    await closeAdminPool();
+  });
+
+  it("returns null when no narrative row matches", async () => {
+    const result = await lookupAnalysisNarrative(pool, "baseline_event", {
+      baseline_version: "vNope",
+      event_key: "0",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns the matched row when a narrative exists", async () => {
+    await insertNarrativeRow(pool, {
+      content_hash: "hash-be-1",
+      target_kind: "baseline_event",
+      target_keys: { baseline_version: "vA", event_key: "1001" },
+      narrative: "Phase 2 analysis text.",
+      prompt_version: "p1",
+      model_version: "m1",
+      generated_at: "2026-02-10T00:00:00Z",
+    });
+
+    const result = await lookupAnalysisNarrative(pool, "baseline_event", {
+      baseline_version: "vA",
+      event_key: "1001",
+    });
+    expect(result).not.toBeNull();
+    const row = result as AnalysisNarrativeRow;
+    expect(row.content_hash).toBe("hash-be-1");
+    expect(row.target_kind).toBe("baseline_event");
+    expect(row.narrative).toBe("Phase 2 analysis text.");
+    expect(row.generated_at).toBeInstanceOf(Date);
+    // target_keys is intentionally typed `Record<string, unknown>` on the
+    // read side. Tests MAY assert specific string values (the wire
+    // convention is string-only) but MUST NOT cast to narrow the return
+    // type — the asymmetry between input (Record<string, string>) and
+    // output (Record<string, unknown>) is deliberate.
+    expect(row.target_keys.baseline_version).toBe("vA");
+    expect(row.target_keys.event_key).toBe("1001");
+  });
+
+  it("picks the most recent narrative across (prompt_version, model_version) pairs", async () => {
+    const keys = { baseline_version: "vB", event_key: "2002" };
+    await insertNarrativeRow(pool, {
+      content_hash: "hash-old",
+      target_kind: "baseline_event",
+      target_keys: keys,
+      narrative: "old",
+      prompt_version: "p1",
+      model_version: "m1",
+      generated_at: "2026-03-01T00:00:00Z",
+    });
+    await insertNarrativeRow(pool, {
+      content_hash: "hash-new",
+      target_kind: "baseline_event",
+      target_keys: keys,
+      narrative: "new",
+      prompt_version: "p2",
+      model_version: "m2",
+      generated_at: "2026-03-02T00:00:00Z",
+    });
+
+    const result = await lookupAnalysisNarrative(pool, "baseline_event", keys);
+    expect(result).not.toBeNull();
+    expect(result?.content_hash).toBe("hash-new");
+    expect(result?.narrative).toBe("new");
+    expect(result?.prompt_version).toBe("p2");
+    expect(result?.model_version).toBe("m2");
+  });
+
+  it("disambiguates by target_kind when target_keys shapes collide", async () => {
+    // A story_id and a run_id can both be the string "9000" but live under
+    // different target_kind values — JSONB equality alone would match both
+    // if the keys-by-shape were identical, so we ensure the helper's
+    // target_kind filter is doing real work.
+    await insertNarrativeRow(pool, {
+      content_hash: "hash-story-9000",
+      target_kind: "story",
+      target_keys: { story_id: "9000", story_version: "v1" },
+      narrative: "story narrative",
+      generated_at: "2026-04-01T00:00:00Z",
+    });
+    await insertNarrativeRow(pool, {
+      content_hash: "hash-run-9000",
+      target_kind: "policy_run",
+      target_keys: { run_id: "9000" },
+      narrative: "policy_run narrative",
+      generated_at: "2026-04-02T00:00:00Z",
+    });
+
+    const story = await lookupAnalysisNarrative(pool, "story", {
+      story_id: "9000",
+      story_version: "v1",
+    });
+    expect(story?.content_hash).toBe("hash-story-9000");
+    expect(story?.target_kind).toBe("story");
+
+    const run = await lookupAnalysisNarrative(pool, "policy_run", {
+      run_id: "9000",
+    });
+    expect(run?.content_hash).toBe("hash-run-9000");
+    expect(run?.target_kind).toBe("policy_run");
+
+    // Same string id under the wrong kind should miss.
+    const miss = await lookupAnalysisNarrative(pool, "policy_run", {
+      run_id: "9000",
+      // story_version doesn't belong to policy_run; including an
+      // extra key forces JSONB inequality even though the run_id matches.
+      story_version: "v1",
+    });
+    expect(miss).toBeNull();
+  });
+});

--- a/src/lib/analysis/lookup.ts
+++ b/src/lib/analysis/lookup.ts
@@ -1,0 +1,226 @@
+import type { Pool } from "pg";
+
+/**
+ * Row returned for a `baseline_event` row found by `event_key`.
+ *
+ * Typing rules (per RFC 0002 §8 / issue #220):
+ * - `event_key` is `string`: the column is `NUMERIC(39, 0)`, which overflows
+ *   JS `number` and which `pg` returns as a string by default.
+ * - `event_time` / `received_at` are `Date`: `pg` parses `TIMESTAMPTZ` to
+ *   `Date`; the helper does not stringify.
+ * - JSONB columns are typed `Record<string, unknown>` (or nullable for
+ *   `asset_context`) because `pg` already JSON-parses the value. The Phase 2
+ *   ingest schema (#216) only stores objects, so the narrower typing is safe
+ *   in practice even though JSONB in general may hold scalars.
+ */
+export interface BaselineEventRow {
+  baseline_version: string;
+  event_key: string;
+  event_time: Date;
+  kind: string;
+  category: string | null;
+  primary_asset: string | null;
+  raw_score: number;
+  selector_tags: string[];
+  raw_event: Record<string, unknown>;
+  score_window_context: Record<string, unknown>;
+  window_signals: Record<string, unknown>;
+  asset_context: Record<string, unknown> | null;
+  scoring_weights_snapshot: Record<string, unknown>;
+  source_aice_id: string;
+  received_at: Date;
+}
+
+/**
+ * Discriminated result of an analysis lookup by `event_key`.
+ *
+ * The union (rather than `BaselineEventRow | null`) is intentional: it leaves
+ * room for a future `"phase1"` variant without an API break, once a plaintext
+ * `event_key` index on `detection_events` lands. See the v1 limitation note
+ * on {@link lookupAnalysisForEvent}.
+ */
+export type AnalysisLookupResult =
+  | { source: "phase2"; row: BaselineEventRow }
+  | { source: "none" };
+
+/**
+ * Resolve `event_key` to a Phase 2 baseline analysis row.
+ *
+ * **Customer scoping (caller contract).** `customerPool` MUST already be a
+ * `Pool` scoped to the target customer's per-customer DB. The customer scope
+ * IS the DB — this helper never sees `external_key` / `customer_id` and
+ * never inspects them. RFC 0002 §8 describes the lookup key as
+ * `(external_key, event_key)`; the `external_key` half is implied by the
+ * caller's choice of pool. Phase 2 routes resolve the pool via
+ * `src/app/api/phase2/_shared/customer-pool.ts`; consumers of this helper
+ * should do the same.
+ *
+ * **Input trust.** The helper passes `eventKey` through as `$1::numeric` and
+ * relies on the PostgreSQL cast for shape rejection. Callers at the system
+ * boundary (HTTP routes, future analysis UI) are responsible for
+ * Zod-style validation (1–39 digits, non-negative) — mirroring
+ * `eventKeyString` in `src/app/api/phase2/_shared/schemas.ts`. This helper is
+ * internal and trusts its input.
+ *
+ * **Resolution.**
+ * 1. Look for any `baseline_event` row matching `event_key` across every
+ *    `baseline_version`. The same event may be re-sent under a bumped
+ *    version if it survives a rebaseline.
+ * 2. Return the row with the most recent `received_at` — the canonical
+ *    "current view of this event" for analysis. Ties on `received_at` are
+ *    broken by `baseline_version DESC` (textual) so the result is
+ *    deterministic.
+ * 3. No match → `{ source: "none" }`.
+ *
+ * **v1 limitation — Phase 1 not searchable by `event_key`.** Phase 1
+ * `detection_events` rows are NOT considered. `detection_events.payload` is
+ * an encrypted BYTEA blob and aimer-web does not maintain a plaintext
+ * `event_key` index on it; per-row decryption to determine membership would
+ * be expensive. Phase 1 rows are reached only through Phase 1-native
+ * surfaces (the Detection bridge audit log, or a future Phase 1 list page)
+ * by their internal `detection_events.id`, not by `event_key`. The Phase 2
+ * row is the canonical analysis row by design (RFC 0002 §8). If a future
+ * need arises to resolve Phase 1 by `event_key`, the path is to add a
+ * plaintext `event_key` column (or sibling index table) — a separate,
+ * additive RFC change. The `AnalysisLookupResult` union is shaped to admit
+ * a future `"phase1"` variant without an API break.
+ *
+ * **Operational meaning of `{ source: "none" }`.** Consumers (the future
+ * analysis UI) MUST treat `none` as ambiguous between two cases that v1
+ * cannot distinguish:
+ *   1. The event was never sent to aimer-web at all.
+ *   2. The event was sent via Phase 1 (Detection menu ad-hoc send) but not
+ *      via Phase 2 baseline push — the `detection_events` row exists but is
+ *      not reachable by `event_key` in v1 (the limitation above).
+ * Recommended UI copy: "No baseline analysis available for this event"
+ * rather than "Event not found." The first phrasing is true in both cases;
+ * the second is misleading in case (2). A future Phase 1 plaintext
+ * `event_key` index would let the UI distinguish them.
+ */
+export async function lookupAnalysisForEvent(
+  customerPool: Pool,
+  eventKey: string,
+): Promise<AnalysisLookupResult> {
+  const { rows } = await customerPool.query(
+    `SELECT
+       baseline_version,
+       event_key::text AS event_key,
+       event_time,
+       kind,
+       category,
+       primary_asset,
+       raw_score,
+       selector_tags,
+       raw_event,
+       score_window_context,
+       window_signals,
+       asset_context,
+       scoring_weights_snapshot,
+       source_aice_id,
+       received_at
+     FROM baseline_event
+     WHERE event_key = $1::numeric
+     ORDER BY received_at DESC, baseline_version DESC
+     LIMIT 1`,
+    [eventKey],
+  );
+  if (rows.length === 0) return { source: "none" };
+  return { source: "phase2", row: rows[0] as BaselineEventRow };
+}
+
+/**
+ * Row returned by {@link lookupAnalysisNarrative}.
+ *
+ * `target_keys` is typed `Record<string, unknown>` (not `Record<string,
+ * string>`) on the read side intentionally: the writer's payload may evolve,
+ * and a stricter return type would force callers into unsafe casts. The
+ * *input* `targetKeys` parameter on {@link lookupAnalysisNarrative} IS
+ * `Record<string, string>` because JSONB equality is value-type-sensitive
+ * (`{"story_id": 1}` ≠ `{"story_id": "1"}`) and the aice-web-next wire
+ * convention serializes BIGINT/NUMERIC ids as stringified digits. The
+ * asymmetry is by design.
+ */
+export interface AnalysisNarrativeRow {
+  content_hash: string;
+  target_kind: "baseline_event" | "story" | "policy_run";
+  target_keys: Record<string, unknown>;
+  narrative: string;
+  prompt_version: string;
+  model_version: string;
+  generated_at: Date;
+}
+
+/**
+ * Resolve `(target_kind, target_keys)` to the most recent
+ * `analysis_narrative` row, or `null`.
+ *
+ * **`targetKeys` value-type convention (string only).** All values in
+ * `targetKeys` MUST be strings. PostgreSQL JSONB equality is
+ * value-type-sensitive — `{"story_id": 1}` and `{"story_id": "1"}` do NOT
+ * match — and the aice-web-next wire convention sends BIGINT/NUMERIC
+ * identifiers as stringified digits (`eventKeyString` /
+ * `stringifiedBigintPositive` in `_shared/schemas.ts`). The writer (the
+ * LLM pipeline, separate track) MUST serialize `target_keys` using the same
+ * string-only convention so JSONB equality matches at read time. The
+ * `Record<string, string>` parameter type makes this contract unforgeable.
+ *
+ * Expected shape per kind:
+ *   - `baseline_event`: `{ baseline_version, event_key }`
+ *   - `story`:          `{ story_id, story_version }`
+ *   - `policy_run`:     `{ run_id }`
+ *
+ * **Re-generation semantics — INSERT-only, no UPDATE.** The
+ * `analysis_narrative` table is granted `SELECT, INSERT, DELETE` for
+ * `aimer_customer` — no UPDATE. A different `prompt_version` or
+ * `model_version` produces a different `content_hash`, so re-generation is
+ * always a fresh INSERT, never an in-place mutation. Two narratives for the
+ * same target (different `(prompt_version, model_version)` pairs) coexist
+ * as separate rows. This helper picks the row with the most recent
+ * `generated_at` across all such pairs — the "current narrative" for the
+ * target. A caller needing a specific `(prompt_version, model_version)`
+ * pair must narrow on the returned row's fields and re-query; a typed
+ * version selector is out of scope for v1.
+ *
+ * **Query plan and the v1 no-GIN decision.** The existing
+ * `(target_kind, generated_at)` btree index narrows by kind and supplies
+ * the `generated_at` order; the `target_keys` equality runs as a residual
+ * filter. Per-kind cardinality is bounded by retention. If observed p95
+ * latency on this helper exceeds 50 ms in production, the escalation path
+ * is `CREATE INDEX CONCURRENTLY analysis_narrative_target_keys_idx ON
+ * analysis_narrative USING GIN (target_keys)` in a follow-up migration. Do
+ * not pre-emptively add the index.
+ *
+ * **`content_hash` is not this helper's concern.** `content_hash` is
+ * computed by the writer (RFC 0002 §11.2) at INSERT time. This helper
+ * queries by `(target_kind, target_keys)` directly and surfaces the stored
+ * hash on the returned row.
+ *
+ * **Customer scoping.** Same caller contract as
+ * {@link lookupAnalysisForEvent}: `customerPool` is already scoped to the
+ * target customer's DB; the helper does not inspect `external_key` or
+ * `customer_id`.
+ */
+export async function lookupAnalysisNarrative(
+  customerPool: Pool,
+  targetKind: "baseline_event" | "story" | "policy_run",
+  targetKeys: Record<string, string>,
+): Promise<AnalysisNarrativeRow | null> {
+  const { rows } = await customerPool.query(
+    `SELECT
+       content_hash,
+       target_kind,
+       target_keys,
+       narrative,
+       prompt_version,
+       model_version,
+       generated_at
+     FROM analysis_narrative
+     WHERE target_kind = $1
+       AND target_keys = $2::jsonb
+     ORDER BY generated_at DESC
+     LIMIT 1`,
+    [targetKind, JSON.stringify(targetKeys)],
+  );
+  if (rows.length === 0) return null;
+  return rows[0] as AnalysisNarrativeRow;
+}


### PR DESCRIPTION
## Summary

Adds `src/lib/analysis/lookup.ts` with two read-side helpers per RFC 0002 §8:

- `lookupAnalysisForEvent(customerPool, eventKey)` — resolves an `event_key` to the most recent `baseline_event` row (ordered by `received_at DESC, baseline_version DESC` for determinism), returning a discriminated `AnalysisLookupResult` union. The `"phase2" | "none"` shape leaves room for a future `"phase1"` variant without an API break.
- `lookupAnalysisNarrative(customerPool, targetKind, targetKeys)` — resolves `(target_kind, target_keys)` to the most recent `analysis_narrative` row (across all `(prompt_version, model_version)` pairs), or `null`.

**v1 scope.** Phase 1 `detection_events` rows are intentionally not searchable by `event_key`: the payload is encrypted BYTEA and aimer-web maintains no plaintext index. The Phase 2 row is the canonical analysis row by design (RFC 0002 §8); a future Phase 1 plaintext index is the additive escalation path.

**Type contracts.** `NUMERIC(39, 0)` → `string` (overflows JS `number`), `TIMESTAMPTZ` → `Date`, `JSONB` → object (the schema only stores objects). The `targetKeys` *input* is `Record<string, string>` because PostgreSQL JSONB equality is value-type-sensitive; the *output* `target_keys` is `Record<string, unknown>` so the writer payload can evolve. This asymmetry is intentional and documented.

**No new index.** Narrative lookup relies on the existing `(target_kind, generated_at)` btree with a JSONB equality residual on `target_keys`. A GIN index is a follow-up if p95 latency on this helper exceeds 50 ms — documented inline in JSDoc as the escalation trigger.

JSDoc covers: the v1 Phase-2-only decision, the two operational meanings of `{ source: "none" }` and recommended UI copy, the INSERT-only re-generation semantics, the string-only `targetKeys` convention, the no-GIN-in-v1 plan, and the caller-pool-scoping contract.

Closes #220

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm check` passes
- [x] `pnpm test` passes (DB tests skip without local Postgres; CI runs them via `pnpm test:db`)
- [x] `pnpm build` succeeds
- [x] `lookupAnalysisForEvent` returns `{ source: "phase2", row }` when a `baseline_event` row exists
- [x] `lookupAnalysisForEvent` returns `{ source: "none" }` when no row matches
- [x] `lookupAnalysisForEvent` returns `{ source: "none" }` for a Phase 1 `detection_events` row (v1 limitation, no payload decryption attempted)
- [x] `lookupAnalysisForEvent` picks the most recent `baseline_event` by `received_at` across `baseline_version` values
- [x] `lookupAnalysisForEvent` breaks `received_at` ties with `baseline_version DESC`
- [x] `lookupAnalysisNarrative` returns `null` when no row matches
- [x] `lookupAnalysisNarrative` returns the matched row, with `target_keys` accessible as strings on the read side
- [x] `lookupAnalysisNarrative` picks the most recent row across `(prompt_version, model_version)` pairs
- [x] `lookupAnalysisNarrative` disambiguates by `target_kind` when `target_keys` shapes collide
