### PR TITLE
Add e2e specs and capture-density policy for environments/customers admin UI (#203)

### DIFF
--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -31,6 +31,36 @@ familiar with the interface.
   (e.g., `![dialog](../assets/account-create.png)`).
 - Update screenshots whenever the UI changes.
 
+### Screenshot capture procedure
+
+Capture screenshots through
+`e2e/capture-manual-screenshots.spec.ts`. Do not introduce a parallel
+capture path; add a new test case to that spec for each new image.
+
+- **Viewport**: `1280×720` (the spec's `VIEWPORT` constant). The
+  `mobile-menu.png` exception captures at `375×667` because the
+  mobile navigation is only rendered at narrow widths.
+- **`deviceScaleFactor`**: `0.75`. The browser re-rasterises at the
+  lower DPI rather than down-sampling a high-DPI render, so text
+  (including Korean glyphs) stays crisp at 1× zoom in the rendered
+  manual.
+- **Effective on-disk resolution**: `960×540` (or `281×500` for the
+  mobile exception). This is roughly half the pixel area of a
+  `1280×720` capture, which cuts LLM vision token cost per image by
+  ~44%. Anthropic recommends a 1568 px max longest side; we stay
+  comfortably under that ceiling.
+- **EN / KO parity**: each capture slot produces two PNGs (image
+  text is rendered through the app's i18n strings in the captured
+  locale). Use locale-suffixed filenames like
+  `admin-environments-thumbprint-confirm.en.png` /
+  `…ko.png`, and drive the app in the matching locale before
+  snapshotting.
+
+The capture spec already declares
+`base.use({ deviceScaleFactor: 0.75 })` at the top and passes the
+same value into every explicit `browser.newContext(...)` call, so
+contributors do not need to set the scale factor per test.
+
 ### Language parity
 
 - Every page in `docs/en/` must have a corresponding page in

--- a/e2e/admin-customers-ui.spec.ts
+++ b/e2e/admin-customers-ui.spec.ts
@@ -1,4 +1,38 @@
+import { Pool } from "pg";
 import { expect, test } from "./fixtures";
+
+async function openAuditPool(): Promise<Pool> {
+  const url =
+    process.env.AUDIT_DATABASE_MIGRATION_URL ?? process.env.AUDIT_DATABASE_URL;
+  if (!url) throw new Error("AUDIT_DATABASE_URL is required for E2E");
+  return new Pool({ connectionString: url });
+}
+
+// The customer-update audit row is written via fire-and-forget
+// `void auditLog(...)` in src/lib/auth/guards.ts:206, so it may not be
+// committed by the time the dialog closes. Poll until a matching row appears.
+async function waitForAuditRow<R extends Record<string, unknown>>(
+  pool: Pool,
+  sql: string,
+  params: unknown[],
+  predicate: (row: R) => boolean = () => true,
+  timeoutMs = 5_000,
+): Promise<R> {
+  const deadline = Date.now() + timeoutMs;
+  let lastRow: R | undefined;
+  while (Date.now() < deadline) {
+    const result = await pool.query<R>(sql, params);
+    const match = result.rows.find(predicate);
+    if (match) return match;
+    lastRow = result.rows[0];
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(
+    `Timed out waiting for audit row matching predicate. Last row seen: ${
+      lastRow ? JSON.stringify(lastRow) : "<none>"
+    }`,
+  );
+}
 
 // ---------------------------------------------------------------------------
 // E2E UI tests for the admin customers page — covers acceptance criteria
@@ -138,5 +172,213 @@ test.describe("Admin customers page — external_key change warning (edit)", () 
     await expect(
       adminPage.locator("tbody tr", { hasText: renamed }),
     ).toBeVisible();
+
+    // Audit row: name-only edit must carry changedFields=["name"] and must
+    // NOT include external_key in previous/next (#196 audit-shape acceptance).
+    // Polled because the route writes the row via `void auditLog(...)`.
+    const auditPool = await openAuditPool();
+    try {
+      const row = await waitForAuditRow<{
+        details: {
+          changedFields: string[];
+          previous: Record<string, unknown>;
+          next: Record<string, unknown>;
+          customerId: string;
+          customerName: string;
+        };
+      }>(
+        auditPool,
+        `SELECT details FROM audit_logs
+         WHERE customer_id = $1 AND action = 'customer.updated'
+         ORDER BY id DESC`,
+        [testData.customer.id],
+        (r) => r.details.customerName === renamed,
+      );
+      const details = row.details;
+      expect(details.changedFields).toEqual(["name"]);
+      expect(details.previous).not.toHaveProperty("external_key");
+      expect(details.next).not.toHaveProperty("external_key");
+      expect(details.customerId).toBe(testData.customer.id);
+    } finally {
+      await auditPool.end();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edit dialog — prefill, inline help, and confirmed external_key change path
+// (deferred from #196 acceptance criteria; existing tests above cancel out of
+// the warning instead of confirming.)
+// ---------------------------------------------------------------------------
+
+test.describe("Admin customers page — edit dialog (prefill + inline help)", () => {
+  test("edit dialog prefills fields and renders external_key inline help", async ({
+    adminPage,
+    testData,
+  }) => {
+    await adminPage.goto("/en/admin/customers");
+    await adminPage.waitForSelector("table tbody tr");
+
+    const row = adminPage.locator("tbody tr", {
+      hasText: testData.customer.name,
+    });
+    await row.getByRole("button", { name: "Edit" }).click();
+    await expect(
+      adminPage.getByRole("heading", { name: "Edit Customer" }),
+    ).toBeVisible();
+
+    // Prefill — name + external_key reflect the row's current values.
+    await expect(adminPage.locator("#customer-edit-name")).toHaveValue(
+      testData.customer.name,
+    );
+    await expect(adminPage.locator("#customer-edit-external-key")).toHaveValue(
+      testData.customer.externalKey,
+    );
+
+    // Inline help on the edit dialog points at the same operations guide as
+    // the create dialog and is wired up via aria-describedby.
+    const help = adminPage.locator("#customer-edit-external-key-help");
+    await expect(help).toBeVisible();
+    const link = help.getByRole("link", { name: "Operations guide" });
+    await expect(link).toHaveAttribute(
+      "href",
+      /cross-system-customer-identification/,
+    );
+    await expect(link).toHaveAttribute("target", "_blank");
+    await expect(
+      adminPage.locator("#customer-edit-external-key"),
+    ).toHaveAttribute("aria-describedby", "customer-edit-external-key-help");
+  });
+});
+
+test.describe("Admin customers page — external_key change confirm path", () => {
+  test("Yes, change external_key issues PATCH, row updates, audit captures previous/next", async ({
+    adminPage,
+    testData,
+  }) => {
+    await adminPage.goto("/en/admin/customers");
+    await adminPage.waitForSelector("table tbody tr");
+
+    const row = adminPage.locator("tbody tr", {
+      hasText: testData.customer.name,
+    });
+    await row.getByRole("button", { name: "Edit" }).click();
+    await expect(
+      adminPage.getByRole("heading", { name: "Edit Customer" }),
+    ).toBeVisible();
+
+    const newKey = `${testData.customer.externalKey}-changed`;
+    await adminPage.locator("#customer-edit-external-key").fill(newKey);
+    await adminPage.getByRole("button", { name: "Save" }).click();
+
+    // Confirm warning copy variant: "change external_key" (not "remove").
+    const warning = adminPage
+      .locator('[role="dialog"]')
+      .filter({ hasText: "Confirm external_key change" });
+    await expect(warning).toBeVisible();
+    await warning
+      .getByRole("button", { name: "Yes, change external_key" })
+      .click();
+
+    // Both dialogs close once the PATCH succeeds.
+    await expect(
+      adminPage.getByRole("heading", { name: "Confirm external_key change" }),
+    ).toBeHidden();
+    await expect(
+      adminPage.getByRole("heading", { name: "Edit Customer" }),
+    ).toBeHidden();
+
+    // The row reflects the new external_key.
+    const updatedRow = adminPage.locator("tbody tr", {
+      hasText: testData.customer.name,
+    });
+    await expect(updatedRow).toContainText(newKey);
+
+    // Audit details capture previous + next external_key values plus the
+    // customer id / name (#196 audit-shape acceptance). Polled because the
+    // route writes the row via `void auditLog(...)`.
+    const auditPool = await openAuditPool();
+    try {
+      const row = await waitForAuditRow<{
+        details: {
+          changedFields: string[];
+          previous: { external_key?: string };
+          next: { external_key?: string };
+          customerId: string;
+          customerName: string;
+        };
+      }>(
+        auditPool,
+        `SELECT details FROM audit_logs
+         WHERE customer_id = $1 AND action = 'customer.updated'
+         ORDER BY id DESC`,
+        [testData.customer.id],
+        (r) => r.details.next.external_key === newKey,
+      );
+      const details = row.details;
+      expect(details.changedFields).toEqual(["external_key"]);
+      expect(details.previous.external_key).toBe(testData.customer.externalKey);
+      expect(details.customerId).toBe(testData.customer.id);
+      expect(details.customerName).toBe(testData.customer.name);
+    } finally {
+      await auditPool.end();
+    }
+  });
+});
+
+test.describe("Admin customers page — authorization", () => {
+  // The customers admin surface has two distinct guards (#196):
+  //   - Page route: served under the admin layout; the client bootstraps via
+  //     `adminFetch` which 401s for a general-context session and forces a
+  //     redirect to /api/admin-auth/sign-in.
+  //   - PATCH endpoint: guarded by `withAuth({ ctx: "admin" })` directly.
+  // Both need explicit coverage — a passing API guard does not prove the
+  // page redirect path is wired correctly (or vice versa).
+  test("non-admin session is denied at the /en/admin/customers page route", async ({
+    userPage,
+  }) => {
+    // The general-context `userPage` carries `at` / `csrf` cookies but no
+    // `at_admin` / `csrf_admin`, so the admin layout's adminFetch call to
+    // /api/admin-auth/me 401s and the customer-page bootstrap redirects to
+    // /api/admin-auth/sign-in (see customers-page.tsx fetchCustomers).
+    await userPage.goto("/en/admin/customers", { waitUntil: "load" });
+    // Wait for the client-side redirect to land the URL anywhere outside
+    // the customers admin page. The destination is OIDC discovery dependent
+    // (admin sign-in → IdP), so the assertion is "we left the admin page",
+    // not a specific landing URL.
+    await userPage.waitForURL(
+      (url) => !url.pathname.endsWith("/admin/customers"),
+      { timeout: 10_000 },
+    );
+    expect(userPage.url()).not.toContain("/admin/customers");
+  });
+
+  test("PATCH /api/admin/customers/:id is denied for a non-admin session", async ({
+    userPage,
+    testData,
+  }) => {
+    const res = await userPage.request.patch(
+      `/api/admin/customers/${testData.customer.id}`,
+      {
+        headers: { origin: "http://localhost:3000" },
+        data: { name: `${testData.customer.name} should-not-apply` },
+      },
+    );
+    expect(res.status()).toBe(401);
+
+    // Defense-in-depth: confirm the DB row was not mutated.
+    const auditPool = await openAuditPool();
+    try {
+      const audit = await auditPool.query(
+        `SELECT id FROM audit_logs
+         WHERE customer_id = $1
+           AND action = 'customer.updated'
+           AND details::text LIKE '%should-not-apply%'`,
+        [testData.customer.id],
+      );
+      expect(audit.rowCount).toBe(0);
+    } finally {
+      await auditPool.end();
+    }
   });
 });

--- a/e2e/admin-environments-ui.spec.ts
+++ b/e2e/admin-environments-ui.spec.ts
@@ -1,0 +1,682 @@
+import { randomUUID } from "node:crypto";
+import type { Page } from "@playwright/test";
+import { Pool } from "pg";
+import { expect, getTestPool, test } from "./fixtures";
+
+// ---------------------------------------------------------------------------
+// E2E UI tests for the admin environments page — covers acceptance criteria
+// from issue #192 (JWK Thumbprint confirm flow) and issue #193 (expires_at
+// soft-expiry policy) that the unit + component tests cannot exercise.
+//
+// The cache hard-expiry regression (warm cache → advance clock past
+// expires_at → reject without a second DB load) stays at the unit layer:
+// see src/lib/auth/__tests__/trust-registry.unit.test.ts:213.
+// ---------------------------------------------------------------------------
+
+// All aice_ids the suite creates — cleaned up in afterAll regardless of
+// pass/fail so a flaky test cannot leak rows into the shared dev DB.
+const createdAiceIds: string[] = [];
+
+function uniqueAiceId(prefix: string): string {
+  const id = `${prefix}-${randomUUID().slice(0, 8)}`;
+  createdAiceIds.push(id);
+  return id;
+}
+
+// Distinct `n` values produce distinct thumbprints, so each test gets a fresh
+// JWK rather than sharing a thumbprint across tests. `jose.calculateJwkThumbprint`
+// accepts any RSA shape with `n` + `e`; the values do not need to be a real key.
+function rsaJwk(salt: string): { kty: "RSA"; n: string; e: string } {
+  return {
+    kty: "RSA",
+    n: `e2e-jwk-${salt}-${randomUUID().slice(0, 12)}`,
+    e: "AQAB",
+  };
+}
+
+async function openAuditPool(): Promise<Pool> {
+  const url =
+    process.env.AUDIT_DATABASE_MIGRATION_URL ?? process.env.AUDIT_DATABASE_URL;
+  if (!url) throw new Error("AUDIT_DATABASE_URL is required for E2E");
+  return new Pool({ connectionString: url });
+}
+
+// Audit rows are written via fire-and-forget `void auditLog(...)` (see
+// src/app/api/admin/environments/route.ts:328 and src/lib/auth/guards.ts:206),
+// so the row may not be committed by the time the UI action settles. Poll
+// the audit DB until a matching row appears (or fail loudly after a budget).
+async function waitForAuditRow<R extends Record<string, unknown>>(
+  pool: Pool,
+  sql: string,
+  params: unknown[],
+  predicate: (row: R) => boolean = () => true,
+  timeoutMs = 5_000,
+): Promise<R> {
+  const deadline = Date.now() + timeoutMs;
+  let lastRow: R | undefined;
+  while (Date.now() < deadline) {
+    const result = await pool.query<R>(sql, params);
+    const match = result.rows.find(predicate);
+    if (match) return match;
+    lastRow = result.rows[0];
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(
+    `Timed out waiting for audit row matching predicate. Last row seen: ${
+      lastRow ? JSON.stringify(lastRow) : "<none>"
+    }`,
+  );
+}
+
+test.afterAll(async () => {
+  if (createdAiceIds.length === 0) return;
+
+  const pool = getTestPool();
+  await pool.query("DELETE FROM trust_registry WHERE aice_id = ANY($1)", [
+    createdAiceIds,
+  ]);
+  await pool.query("DELETE FROM aice_environments WHERE aice_id = ANY($1)", [
+    createdAiceIds,
+  ]);
+
+  const auditPool = await openAuditPool();
+  try {
+    await auditPool.query("DELETE FROM audit_logs WHERE aice_id = ANY($1)", [
+      createdAiceIds,
+    ]);
+    // Bridge-verify denial rows for the unverified-context-token case carry
+    // `aiceId` only inside the JSONB `details` payload (the column is NULL),
+    // so they need a separate cleanup pass keyed off the JSONB field.
+    await auditPool.query(
+      "DELETE FROM audit_logs WHERE action = 'bridge.connection_denied' AND details->>'aiceId' = ANY($1)",
+      [createdAiceIds],
+    );
+  } finally {
+    await auditPool.end();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers — page navigation
+// ---------------------------------------------------------------------------
+
+// The toolbar buttons "Create Environment" / "Register Key" share the
+// accessible name of their respective dialog submit buttons, so submit
+// locators are always scoped to the open dialog via this helper to avoid
+// strict-mode collisions.
+function openDialog(adminPage: Page, title: string) {
+  return adminPage.locator('[role="dialog"]').filter({
+    has: adminPage.getByRole("heading", { name: title, exact: true }),
+  });
+}
+
+async function openCreateEnvDialog(adminPage: Page): Promise<void> {
+  await adminPage.goto("/en/admin/environments");
+  await expect(
+    adminPage.getByRole("heading", { name: "Create Environment" }),
+  ).toHaveCount(0);
+  await adminPage
+    .getByRole("button", { name: "Create Environment", exact: true })
+    .click();
+  await expect(
+    adminPage.getByRole("heading", { name: "Create Environment" }),
+  ).toBeVisible();
+}
+
+async function openKeysTab(adminPage: Page, aiceId: string): Promise<void> {
+  await adminPage.goto("/en/admin/environments");
+  const row = adminPage.locator("tbody tr", { hasText: aiceId });
+  await row.waitFor();
+  // Each row exposes a Keys-count button; clicking it opens the detail panel
+  // pre-selected on the keys tab (see environments-page.tsx openDetail()).
+  await row.getByRole("button", { name: /^\d+$/ }).nth(1).click();
+  await expect(
+    adminPage.getByRole("heading", { name: "Trust Registry Keys" }),
+  ).toBeVisible();
+}
+
+async function openRegisterKeyDialog(
+  adminPage: Page,
+  aiceId: string,
+): Promise<void> {
+  await openKeysTab(adminPage, aiceId);
+  // The toolbar "Register Key" is the only one visible before the dialog
+  // opens, so it can be matched directly without dialog scoping.
+  await adminPage
+    .getByRole("button", { name: "Register Key", exact: true })
+    .click();
+  await expect(
+    adminPage.getByRole("heading", { name: "Register Key" }),
+  ).toBeVisible();
+}
+
+// Seeds an environment via direct DB insert so that tests focused on the
+// per-environment "Register key" / keys-tab flow don't depend on a prior
+// create-flow test passing.
+async function seedEnvironment(name?: string): Promise<{
+  aiceId: string;
+  name: string;
+}> {
+  const aiceId = uniqueAiceId("env");
+  const envName = name ?? `E2E ${aiceId}`;
+  const pool = getTestPool();
+  await pool.query(
+    "INSERT INTO aice_environments (aice_id, name, status) VALUES ($1, $2, 'active')",
+    [aiceId, envName],
+  );
+  return { aiceId, name: envName };
+}
+
+// ---------------------------------------------------------------------------
+// JWK Thumbprint confirm scenarios (issue #192)
+// ---------------------------------------------------------------------------
+
+test.describe("Admin environments — JWK Thumbprint confirm flow", () => {
+  // The register-key flow on the keys tab chains a goto, two row-button
+  // clicks, a thumbprint API round-trip, and a submit POST — under CI load
+  // the cumulative wall-clock can push past the default 30 s test budget.
+  test.describe.configure({ timeout: 60_000 });
+
+  test("environment-creation path renders thumbprint, gates submit on confirmation", async ({
+    adminPage,
+  }) => {
+    const aiceId = uniqueAiceId("env");
+    const jwk = rsaJwk("create");
+
+    await openCreateEnvDialog(adminPage);
+
+    await adminPage.locator("#env-aice-id").fill(aiceId);
+    await adminPage.locator("#env-name").fill(`E2E ${aiceId}`);
+
+    // Enable the optional trust-registry-key sub-form.
+    await adminPage
+      .getByRole("checkbox", { name: /Trust Registry Key/ })
+      .check();
+
+    await adminPage.locator("#env-issuer").fill("https://issuer.example");
+    await adminPage.locator("#env-kid").fill("key-1");
+    await adminPage
+      .locator("#env-public-key")
+      .fill(JSON.stringify(jwk, null, 2));
+
+    // Thumbprint renders untruncated in both formats once /api/admin/trust-registry/thumbprint resolves.
+    const dialog = openDialog(adminPage, "Create Environment");
+    const base64Block = dialog
+      .locator("code", { hasText: /^[A-Za-z0-9_-]{43}$/ })
+      .first();
+    await expect(base64Block).toBeVisible();
+    const base64Value = (await base64Block.textContent())?.trim() ?? "";
+    expect(base64Value).toHaveLength(43); // RFC 7638 SHA-256 → 43 base64url chars
+
+    const hexBlock = dialog
+      .locator("code", { hasText: /^[0-9a-f]{8}(?::[0-9a-f]{8}){7}$/ })
+      .first();
+    await expect(hexBlock).toBeVisible();
+
+    // Submit stays disabled until the operator toggles the confirm checkbox.
+    const submitBtn = dialog.getByRole("button", {
+      name: "Create Environment",
+      exact: true,
+    });
+    await expect(submitBtn).toBeDisabled();
+
+    const confirmCheckbox = dialog.getByRole("checkbox", {
+      name: /I confirmed the thumbprint/,
+    });
+    await confirmCheckbox.check();
+    await expect(submitBtn).toBeEnabled();
+
+    await submitBtn.click();
+
+    // Wait for the dialog to close, indicating the POST succeeded.
+    await expect(
+      adminPage.getByRole("heading", { name: "Create Environment" }),
+    ).toBeHidden();
+
+    // Submitted environment + trust_registry row exist.
+    const pool = getTestPool();
+    const envRow = await pool.query(
+      "SELECT aice_id FROM aice_environments WHERE aice_id = $1",
+      [aiceId],
+    );
+    expect(envRow.rowCount).toBe(1);
+    const keyRow = await pool.query(
+      "SELECT id, issuer, kid FROM trust_registry WHERE aice_id = $1",
+      [aiceId],
+    );
+    expect(keyRow.rowCount).toBe(1);
+    expect(keyRow.rows[0]).toMatchObject({
+      issuer: "https://issuer.example",
+      kid: "key-1",
+    });
+
+    // Audit log records the server-computed thumbprint. Polled because the
+    // route writes the row via `void auditLog(...)`.
+    const auditPool = await openAuditPool();
+    try {
+      const row = await waitForAuditRow<{ details: Record<string, unknown> }>(
+        auditPool,
+        `SELECT details FROM audit_logs
+         WHERE aice_id = $1 AND action = 'trust_registry.key_registered'`,
+        [aiceId],
+      );
+      expect(row.details.jwkThumbprint).toBe(base64Value);
+    } finally {
+      await auditPool.end();
+    }
+  });
+
+  test("existing-environment Register key path renders thumbprint, gates submit", async ({
+    adminPage,
+  }) => {
+    const env = await seedEnvironment();
+    const jwk = rsaJwk("register");
+
+    await openRegisterKeyDialog(adminPage, env.aiceId);
+
+    await adminPage.locator("#reg-issuer").fill("https://issuer.example");
+    await adminPage.locator("#reg-kid").fill("key-reg-1");
+    await adminPage.locator("#reg-public-key").fill(JSON.stringify(jwk));
+
+    const dialog = openDialog(adminPage, "Register Key");
+    const base64Block = dialog
+      .locator("code", { hasText: /^[A-Za-z0-9_-]{43}$/ })
+      .first();
+    await expect(base64Block).toBeVisible();
+
+    const submitBtn = dialog.getByRole("button", {
+      name: "Register Key",
+      exact: true,
+    });
+    await expect(submitBtn).toBeDisabled();
+
+    await dialog
+      .getByRole("checkbox", { name: /I confirmed the thumbprint/ })
+      .check();
+    await expect(submitBtn).toBeEnabled();
+    await submitBtn.click();
+
+    await expect(
+      adminPage.getByRole("heading", { name: "Register Key" }),
+    ).toBeHidden();
+
+    const pool = getTestPool();
+    const keyRow = await pool.query(
+      "SELECT issuer, kid FROM trust_registry WHERE aice_id = $1",
+      [env.aiceId],
+    );
+    expect(keyRow.rowCount).toBe(1);
+    expect(keyRow.rows[0]).toMatchObject({
+      issuer: "https://issuer.example",
+      kid: "key-reg-1",
+    });
+  });
+
+  test("changing the JWK textarea clears confirmation, hides thumbprint, re-disables submit", async ({
+    adminPage,
+  }) => {
+    const env = await seedEnvironment();
+    const jwkA = rsaJwk("reset-a");
+    const jwkB = rsaJwk("reset-b");
+
+    await openRegisterKeyDialog(adminPage, env.aiceId);
+
+    await adminPage.locator("#reg-issuer").fill("https://issuer.example");
+    await adminPage.locator("#reg-kid").fill("key-reset");
+    await adminPage.locator("#reg-public-key").fill(JSON.stringify(jwkA));
+
+    const dialog = openDialog(adminPage, "Register Key");
+    const thumbprintBlock = dialog
+      .locator("code", { hasText: /^[A-Za-z0-9_-]{43}$/ })
+      .first();
+    await expect(thumbprintBlock).toBeVisible();
+    const valueA = (await thumbprintBlock.textContent())?.trim() ?? "";
+
+    const confirmCheckbox = dialog.getByRole("checkbox", {
+      name: /I confirmed the thumbprint/,
+    });
+    await confirmCheckbox.check();
+
+    const submitBtn = dialog.getByRole("button", {
+      name: "Register Key",
+      exact: true,
+    });
+    await expect(submitBtn).toBeEnabled();
+
+    // Replace the JWK input — confirmation should clear, thumbprint should
+    // hide, and submit should re-disable. Re-pasting a (different) valid JWK
+    // shows the new thumbprint and again requires fresh confirmation.
+    await adminPage.locator("#reg-public-key").fill(JSON.stringify(jwkB));
+
+    await expect(confirmCheckbox).not.toBeChecked();
+    await expect(submitBtn).toBeDisabled();
+
+    await expect(thumbprintBlock).toBeVisible();
+    const valueB = (await thumbprintBlock.textContent())?.trim() ?? "";
+    expect(valueB).not.toBe(valueA);
+
+    // Fresh confirmation required.
+    await confirmCheckbox.check();
+    await expect(submitBtn).toBeEnabled();
+  });
+
+  test("invalid JWK (unsupported kty) shows error, hides confirm UI, keeps submit disabled", async ({
+    adminPage,
+  }) => {
+    const env = await seedEnvironment();
+
+    await openRegisterKeyDialog(adminPage, env.aiceId);
+
+    await adminPage.locator("#reg-issuer").fill("https://issuer.example");
+    await adminPage.locator("#reg-kid").fill("key-invalid");
+    await adminPage
+      .locator("#reg-public-key")
+      .fill(JSON.stringify({ kty: "BOGUS" }));
+
+    // Error renders; thumbprint never shows; confirm UI is not present.
+    const dialog = openDialog(adminPage, "Register Key");
+    await expect(dialog.getByText(/Invalid JWK/)).toBeVisible();
+    await expect(
+      dialog.locator("code", { hasText: /^[A-Za-z0-9_-]{43}$/ }),
+    ).toHaveCount(0);
+    await expect(
+      dialog.getByRole("checkbox", {
+        name: /I confirmed the thumbprint/,
+      }),
+    ).toHaveCount(0);
+
+    await expect(
+      dialog.getByRole("button", { name: "Register Key", exact: true }),
+    ).toBeDisabled();
+
+    // No DB row written.
+    const pool = getTestPool();
+    const keyRow = await pool.query(
+      "SELECT id FROM trust_registry WHERE aice_id = $1",
+      [env.aiceId],
+    );
+    expect(keyRow.rowCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// expires_at lifecycle scenarios (issue #193)
+// ---------------------------------------------------------------------------
+
+test.describe("Admin environments — trust_registry expires_at", () => {
+  // Two of these scenarios loop the register-key flow three times each
+  // (open dialog → fill → thumbprint round-trip → submit) which exceeds the
+  // default 30 s test timeout under CI load.
+  test.describe.configure({ timeout: 90_000 });
+
+  test("accepts valid Z and +09:00 forms, persists canonical UTC; empty → NULL", async ({
+    adminPage,
+  }) => {
+    const env = await seedEnvironment();
+    const pool = getTestPool();
+
+    async function registerKey(
+      kid: string,
+      jwk: ReturnType<typeof rsaJwk>,
+      expiresAtInput: string,
+    ) {
+      await openRegisterKeyDialog(adminPage, env.aiceId);
+      const dialog = openDialog(adminPage, "Register Key");
+      await adminPage.locator("#reg-issuer").fill("https://issuer.example");
+      await adminPage.locator("#reg-kid").fill(kid);
+      await adminPage.locator("#reg-public-key").fill(JSON.stringify(jwk));
+      await expect(
+        dialog.locator("code", { hasText: /^[A-Za-z0-9_-]{43}$/ }).first(),
+      ).toBeVisible();
+      if (expiresAtInput) {
+        await adminPage.locator("#reg-key-expires-at").fill(expiresAtInput);
+      }
+      await dialog
+        .getByRole("checkbox", { name: /I confirmed the thumbprint/ })
+        .check();
+      await dialog
+        .getByRole("button", { name: "Register Key", exact: true })
+        .click();
+      await expect(
+        adminPage.getByRole("heading", { name: "Register Key" }),
+      ).toBeHidden();
+    }
+
+    // 1. valid Z form
+    await registerKey("kid-utc", rsaJwk("utc"), "2030-05-05T12:00:00Z");
+    // 2. valid +09:00 form — same instant as 2030-05-05T03:00:00Z
+    await registerKey("kid-kst", rsaJwk("kst"), "2030-05-05T12:00:00+09:00");
+    // 3. empty / omitted → NULL (soft-expiry)
+    await registerKey("kid-soft", rsaJwk("soft"), "");
+
+    const rows = await pool.query<{
+      kid: string;
+      expires_at: Date | null;
+    }>(
+      `SELECT kid, expires_at FROM trust_registry
+       WHERE aice_id = $1 ORDER BY kid`,
+      [env.aiceId],
+    );
+    const byKid = Object.fromEntries(
+      rows.rows.map((r) => [r.kid, r.expires_at]),
+    );
+    expect(byKid["kid-utc"]).toEqual(new Date("2030-05-05T12:00:00.000Z"));
+    expect(byKid["kid-kst"]).toEqual(new Date("2030-05-05T03:00:00.000Z"));
+    expect(byKid["kid-soft"]).toBeNull();
+
+    // The soft-expiry row's UI reflects "no expiry".
+    await openKeysTab(adminPage, env.aiceId);
+    const softRow = adminPage.locator("tbody tr", { hasText: "kid-soft" });
+    await expect(softRow).toContainText("No expiry (soft)");
+  });
+
+  test("rejects timezone-less, date-only, and out-of-range calendar inputs", async ({
+    adminPage,
+  }) => {
+    const env = await seedEnvironment();
+
+    const cases = [
+      "2030-05-05T12:00:00", // timezone-less
+      "2030-05-05", // date-only
+      "2026-02-30T00:00:00Z", // out-of-range calendar
+    ];
+
+    for (const [index, value] of cases.entries()) {
+      await openRegisterKeyDialog(adminPage, env.aiceId);
+      const dialog = openDialog(adminPage, "Register Key");
+      await adminPage.locator("#reg-issuer").fill("https://issuer.example");
+      await adminPage.locator("#reg-kid").fill(`kid-${index}`);
+      await adminPage
+        .locator("#reg-public-key")
+        .fill(JSON.stringify(rsaJwk(value)));
+      await expect(
+        dialog.locator("code", { hasText: /^[A-Za-z0-9_-]{43}$/ }).first(),
+      ).toBeVisible();
+      await adminPage.locator("#reg-key-expires-at").fill(value);
+      await dialog
+        .getByRole("checkbox", { name: /I confirmed the thumbprint/ })
+        .check();
+      await dialog
+        .getByRole("button", { name: "Register Key", exact: true })
+        .click();
+
+      // Error toast surfaces the invalid-format message; the dialog stays open.
+      await expect(
+        adminPage.getByText(
+          /Expires At must be a timezone-explicit ISO 8601 datetime\./,
+        ),
+      ).toBeVisible();
+      await expect(
+        adminPage.getByRole("heading", { name: "Register Key" }),
+      ).toBeVisible();
+
+      // Close the dialog so the next iteration starts clean.
+      await dialog.getByRole("button", { name: "Cancel" }).click();
+      await expect(
+        adminPage.getByRole("heading", { name: "Register Key" }),
+      ).toBeHidden();
+    }
+
+    // No rows written for any of the invalid inputs.
+    const pool = getTestPool();
+    const keys = await pool.query(
+      "SELECT id FROM trust_registry WHERE aice_id = $1",
+      [env.aiceId],
+    );
+    expect(keys.rowCount).toBe(0);
+  });
+
+  test("per-key row color signals reflect classifyExpiry thresholds", async ({
+    adminPage,
+  }) => {
+    const env = await seedEnvironment();
+    const pool = getTestPool();
+
+    // Seed three keys via direct DB insert so the test isolates the
+    // classifyExpiry → row class wiring (the threshold logic itself is
+    // unit-covered by expiry-status.unit.test.ts). Each key carries a
+    // distinctive kid so the test can address rows individually. The
+    // admin-UI/API acceptance path for a past `expires_at` and the
+    // bridge-verify reject behaviour live in the next test.
+    const now = Date.now();
+    const inDays = (n: number) => new Date(now + n * 24 * 60 * 60 * 1000);
+    await pool.query(
+      `INSERT INTO trust_registry (aice_id, issuer, kid, public_key, expires_at)
+       VALUES
+         ($1, 'iss', 'kid-yellow', '{}'::jsonb, $2),
+         ($1, 'iss', 'kid-red',    '{}'::jsonb, $3),
+         ($1, 'iss', 'kid-expired','{}'::jsonb, $4)`,
+      [env.aiceId, inDays(20), inDays(3), inDays(-1)],
+    );
+
+    await openKeysTab(adminPage, env.aiceId);
+
+    const yellowExpiry = adminPage
+      .locator("tbody tr", { hasText: "kid-yellow" })
+      .locator(".text-amber-600, .dark\\:text-amber-400");
+    await expect(yellowExpiry).toBeVisible();
+
+    const redExpiry = adminPage
+      .locator("tbody tr", { hasText: "kid-red" })
+      .locator(".text-destructive");
+    await expect(redExpiry).toBeVisible();
+
+    const expiredRow = adminPage.locator("tbody tr", {
+      hasText: "kid-expired",
+    });
+    await expect(expiredRow).toContainText("expired");
+    // The expired row's status text uses `text-xs text-muted-foreground` (the
+    // gray-after-expiry signal). Scope to that exact class pair to avoid
+    // matching the kid cell or the date-suffix span, which also use the
+    // muted-foreground colour for unrelated reasons.
+    await expect(
+      expiredRow.locator(".text-xs.text-muted-foreground"),
+    ).toBeVisible();
+  });
+
+  test("past expires_at accepted via admin UI; bridge verify rejects with trust_registry_key_expired audit reason", async ({
+    adminPage,
+  }) => {
+    const env = await seedEnvironment();
+    const pool = getTestPool();
+
+    // jose is ESM-only — match the dynamic-import convention used by
+    // e2e/fixtures/auth.ts.
+    const jose = await import("jose");
+    const kp = await jose.generateKeyPair("ES256", { extractable: true });
+    const publicJwk = await jose.exportJWK(kp.publicKey);
+
+    const issuer = `https://issuer-${randomUUID().slice(0, 8)}.example`;
+    const kid = `kid-past-${randomUUID().slice(0, 8)}`;
+    // "Burn" / emergency-revocation case from #193: the operator deliberately
+    // submits an `expires_at` that is already in the past. The admin form has
+    // no past-date guard (parseExpiresAtInput documents that past timestamps
+    // are accepted on purpose), so this exercises the real submit path.
+    const pastExpiry = "2020-01-01T00:00:00Z";
+
+    await openRegisterKeyDialog(adminPage, env.aiceId);
+    const dialog = openDialog(adminPage, "Register Key");
+    await adminPage.locator("#reg-issuer").fill(issuer);
+    await adminPage.locator("#reg-kid").fill(kid);
+    await adminPage.locator("#reg-public-key").fill(JSON.stringify(publicJwk));
+    await expect(
+      dialog.locator("code", { hasText: /^[A-Za-z0-9_-]{43}$/ }).first(),
+    ).toBeVisible();
+    await adminPage.locator("#reg-key-expires-at").fill(pastExpiry);
+    await dialog
+      .getByRole("checkbox", { name: /I confirmed the thumbprint/ })
+      .check();
+    await dialog
+      .getByRole("button", { name: "Register Key", exact: true })
+      .click();
+    // Dialog closes only on a 2xx response — proves the admin API accepted
+    // the past timestamp.
+    await expect(
+      adminPage.getByRole("heading", { name: "Register Key" }),
+    ).toBeHidden();
+
+    const keyRow = await pool.query<{ expires_at: Date | null }>(
+      "SELECT expires_at FROM trust_registry WHERE aice_id = $1 AND kid = $2",
+      [env.aiceId, kid],
+    );
+    expect(keyRow.rowCount).toBe(1);
+    expect(keyRow.rows[0].expires_at).toEqual(new Date(pastExpiry));
+
+    // Sign a context_token with the matching private key. The bridge verify
+    // path will look up the registered JWK by (aice_id, iss, kid), find it
+    // expired, and reject without ever validating the signature.
+    const jti = randomUUID();
+    const token = await new jose.SignJWT({
+      aice_id: env.aiceId,
+      customer_ids: [],
+    })
+      .setProtectedHeader({ alg: "ES256", kid })
+      .setSubject(`e2e-bridge-${jti}`)
+      .setJti(jti)
+      .setIssuer(issuer)
+      .setAudience("aimer-web")
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(kp.privateKey);
+
+    const res = await adminPage.request.post("/api/auth/bridge", {
+      multipart: { context_token: token },
+      maxRedirects: 0,
+    });
+    expect(res.status()).toBe(403);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toContain("Invalid context token");
+
+    // The bridge route emits this audit row with no top-level `aiceId` because
+    // the context token failed verification before claims were extracted (see
+    // src/app/api/auth/bridge/route.ts trust_registry_key_expired branch with
+    // `!claims`). The `aice_id` column is therefore NULL — the only
+    // identifying field is `details.aiceId`, taken from the unverified payload.
+    const auditPool = await openAuditPool();
+    try {
+      const row = await waitForAuditRow<{
+        details: {
+          reason?: string;
+          innerReason?: string;
+          aiceId?: string;
+          kid?: string;
+          issuer?: string;
+        };
+      }>(
+        auditPool,
+        `SELECT details FROM audit_logs
+         WHERE action = 'bridge.connection_denied'
+           AND details->>'aiceId' = $1
+           AND details->>'innerReason' = 'trust_registry_key_expired'
+         ORDER BY id DESC`,
+        [env.aiceId],
+      );
+      expect(row.details.reason).toBe("context_token_rejected");
+      expect(row.details.kid).toBe(kid);
+      expect(row.details.issuer).toBe(issuer);
+      expect(row.details.aiceId).toBe(env.aiceId);
+    } finally {
+      await auditPool.end();
+    }
+  });
+});

--- a/e2e/capture-manual-screenshots.spec.ts
+++ b/e2e/capture-manual-screenshots.spec.ts
@@ -15,6 +15,14 @@
  *
  * Viewport: 1280×720 for all shots except `mobile-menu.png` (375×667)
  * because the mobile navigation menu is only visible at narrow widths.
+ *
+ * Capture density: deviceScaleFactor 0.75, so the on-disk PNG is the
+ * effective resolution 960×540 (or 281×500 for the mobile case). The
+ * browser re-rasterises at that density rather than down-sampling a
+ * high-DPI render, which keeps Latin and Korean glyphs crisp at 1× zoom
+ * in the rendered manual while halving the per-image token cost of LLM
+ * vision reads. See docs/AUTHORING.md for the policy and #203 for the
+ * rationale (token economics, mirroring aice-web-next/#522).
  */
 
 import { randomUUID } from "node:crypto";
@@ -35,6 +43,19 @@ loadEnv();
 
 const ASSETS = resolve(process.cwd(), "docs/assets");
 const VIEWPORT = { width: 1280, height: 720 };
+/**
+ * Lower the rendered pixel density so the captured PNG is 960×540 rather
+ * than 1280×720 (or 281×500 instead of 375×667 for the mobile case),
+ * cutting per-image token cost by ~44% without shrinking the captured
+ * layout. Documented in docs/AUTHORING.md and applied to every browser
+ * context this spec creates (see browser.newContext calls below).
+ */
+const SCALE_FACTOR = 0.75;
+
+// Declared so any future test that uses the default `page` fixture inherits
+// the same density. The contexts opened explicitly via browser.newContext
+// below pass the same value through their options.
+base.use({ deviceScaleFactor: SCALE_FACTOR });
 
 /** Remove the Next.js dev overlay so it does not cover UI elements. */
 async function removeOverlay(page: Page): Promise<void> {
@@ -124,12 +145,18 @@ base.describe.serial("Manual screenshots", () => {
     // ── Browser contexts ──
     const baseURL = process.env.BASE_URL ?? "http://localhost:3000";
 
-    adminCtx = await browser.newContext({ baseURL });
+    adminCtx = await browser.newContext({
+      baseURL,
+      deviceScaleFactor: SCALE_FACTOR,
+    });
     await injectAuthCookies(adminCtx, testData.admin, "admin");
     adminPage = await adminCtx.newPage();
     await adminPage.setViewportSize(VIEWPORT);
 
-    mgrCtx = await browser.newContext({ baseURL });
+    mgrCtx = await browser.newContext({
+      baseURL,
+      deviceScaleFactor: SCALE_FACTOR,
+    });
     await injectAuthCookies(mgrCtx, testData.manager, "general");
     mgrPage = await mgrCtx.newPage();
     await mgrPage.setViewportSize(VIEWPORT);
@@ -172,7 +199,10 @@ base.describe.serial("Manual screenshots", () => {
     // The sign-in page is the Keycloak login form. Navigate to the
     // auth redirect endpoint which sends the browser to Keycloak.
     const baseURL = process.env.BASE_URL ?? "http://localhost:3000";
-    const ctx = await browser.newContext({ baseURL });
+    const ctx = await browser.newContext({
+      baseURL,
+      deviceScaleFactor: SCALE_FACTOR,
+    });
     const page = await ctx.newPage();
     await page.setViewportSize(VIEWPORT);
 
@@ -212,7 +242,10 @@ base.describe.serial("Manual screenshots", () => {
 
   base("deny-page.png", async ({ browser }) => {
     const baseURL = process.env.BASE_URL ?? "http://localhost:3000";
-    const ctx = await browser.newContext({ baseURL });
+    const ctx = await browser.newContext({
+      baseURL,
+      deviceScaleFactor: SCALE_FACTOR,
+    });
     const page = await ctx.newPage();
     await page.setViewportSize(VIEWPORT);
 

--- a/src/app/[locale]/(admin)/admin/environments/environments-page.tsx
+++ b/src/app/[locale]/(admin)/admin/environments/environments-page.tsx
@@ -967,7 +967,7 @@ export function EnvironmentsPage() {
 
         {/* Register key dialog */}
         <Dialog open={registerKeyOpen} onOpenChange={setRegisterKeyOpen}>
-          <DialogContent>
+          <DialogContent className="max-h-[90vh] overflow-y-auto">
             <DialogHeader>
               <DialogTitle>{t("registerKey")}</DialogTitle>
               <DialogDescription>


### PR DESCRIPTION
## Summary

Picks up part of the deferred follow-up work from the aimer-bridge sub-issue batch (#192/#193/#196 and #197):

- **`e2e/admin-environments-ui.spec.ts`** (new) — 8 tests covering the JWK Thumbprint confirm flow (#192) and the `expires_at` lifecycle (#193), including a real `/api/auth/bridge` round-trip for the emergency-revocation case: register a key with a past `expires_at` through the admin UI, sign a context token with the matching private key, POST to the bridge, and assert the 403 + `bridge.connection_denied` audit row with `innerReason: trust_registry_key_expired`. The cache hard-expiry security regression stays in the unit layer (`src/lib/auth/__tests__/trust-registry.unit.test.ts`) since Playwright cannot manipulate the in-process clock.
- **`e2e/admin-customers-ui.spec.ts`** (extended) — adds the edit-dialog prefill, edit-dialog inline help, `external_key`-change confirm path with audit-shape assertions, name-only `customer.updated` audit shape, the page-route DOM denial path for a non-admin session, and the non-admin PATCH denial — the #196 scenarios the existing 4 tests did not cover.
- **`e2e/capture-manual-screenshots.spec.ts` + `docs/AUTHORING.md`** — adopt `deviceScaleFactor: 0.75` for manual captures so committed PNGs are an effective 960×540 (281×500 for the mobile-menu case) instead of 1280×720, cutting per-image LLM vision token cost by ~44% without shrinking the captured layout. Mirrors the policy aice-web-next/#522 lands for Detection. `playwright.config.ts` is untouched so non-capture e2e specs keep asserting at full resolution.

Both specs also use a `waitForAuditRow` polling helper for audit-log assertions, since the routes emit those rows via fire-and-forget `void auditLog(...)` (see `src/app/api/admin/environments/route.ts:328`, `src/lib/auth/guards.ts:206`, `src/app/api/auth/bridge/route.ts`) and a direct `SELECT` immediately after the UI action is racy under CI load.

Matches PRs 1 and 2 of the suggested split in #203, plus the capture-policy half of PR 3.

Part of #203

## Not addressed

The aimer-bridge screenshot batch sweep itself (the remaining half of PR 3 in the suggested split) is not in this PR:

- The seven new capture cases listed in #203's "Capture slots" table have not been added to `e2e/capture-manual-screenshots.spec.ts`.
- The 14 `<!-- TODO: screenshot - aimer-bridge batch -->` placeholders are still present in `docs/{en,ko}/{authentication,environment-management,customer-management,cross-system-customer-identification}.md`.
- No locale-paired PNGs have been added to `docs/assets/` for those slots.
- `mkdocs --strict` cleanliness for the placeholder removal has therefore not been re-verified.

These items remain open against #203 and will be handled in a follow-up PR once the page state driven by this PR's specs has stabilised — the screenshot sweep was the last item in the suggested 2–3 PR split for exactly this reason.

## Test plan

- [x] \`pnpm test:e2e\` passes locally including the new \`admin-environments-ui.spec.ts\` (8 tests across JWK confirm + \`expires_at\` describes, including the bridge-verify reject case).
- [x] \`pnpm test:e2e\` passes locally including the extended \`admin-customers-ui.spec.ts\` (now 4 + 4 = 8 tests; the existing 4 still pass — and the existing name-only test gained a \`customer.updated\` audit-shape assertion — and the 4 new ones cover edit prefill + inline help, confirm-warning + audit-shape, page-route DOM denial, and non-admin PATCH denial).
- [x] \`e2e/capture-manual-screenshots.spec.ts\` runs without regression and produces PNGs at the new 960×540 (or 281×500 for mobile) effective resolution. Spot-check a Korean-glyph capture for crispness at 1× zoom.
- [x] \`pnpm tsc --noEmit\` is clean for the changed specs.
- [x] \`pnpm biome check\` is clean for the changed files.
- [x] The existing cache hard-expiry unit test in \`src/lib/auth/__tests__/trust-registry.unit.test.ts:213\` still passes (this PR explicitly leaves the central #193 cache regression at the unit layer).
- [x] \`docs/AUTHORING.md\` renders correctly under the project's docs build; the new "Screenshot capture procedure" subsection is reachable from the section index.
