### PR TITLE
Add mTLS SIGHUP handler and instrumentation hook (#229)

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2,5 +2,9 @@ export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     const { runStartupMigrations } = await import("@/lib/db/migrate");
     await runStartupMigrations();
+    const { installMtlsSighupHandler } = await import(
+      "@/lib/instrumentation/mtls-sighup"
+    );
+    await installMtlsSighupHandler();
   }
 }

--- a/src/lib/instrumentation/__tests__/mtls-sighup.unit.test.ts
+++ b/src/lib/instrumentation/__tests__/mtls-sighup.unit.test.ts
@@ -150,6 +150,44 @@ describe("installMtlsSighupHandler", () => {
     expect(getSlot()?.installed).toBe(true);
   });
 
+  it("resolves reload() dynamically so HMR re-evaluations of @/lib/mtls take effect", async () => {
+    const { installMtlsSighupHandler } = await import("../mtls-sighup");
+    await installMtlsSighupHandler();
+
+    // Simulate an HMR-like re-evaluation: `@/lib/mtls` is re-mocked with a
+    // *different* reload implementation. The previously attached SIGHUP
+    // listener must call the new reload, not the one captured at install.
+    const freshReload = vi
+      .fn<() => Promise<unknown>>()
+      .mockResolvedValue(undefined);
+    vi.resetModules();
+    vi.doMock("@/lib/mtls", () => ({ reload: freshReload }));
+
+    // Sanity-check that the dynamic import inside this test resolves to the
+    // re-mocked namespace; if Vitest's module resolver wires this through to
+    // the listener's `await import("@/lib/mtls")` correctly, the listener
+    // will see the same fresh namespace at SIGHUP time.
+    const probe = await import("@/lib/mtls");
+    expect(probe.reload).toBe(freshReload);
+
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    process.emit("SIGHUP");
+    // The listener does `await import("@/lib/mtls")` then `await reload()`;
+    // flush several macrotasks so both awaits settle before assertions.
+    for (let i = 0; i < 5; i++) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(freshReload).toHaveBeenCalledTimes(1);
+    expect(reloadMock).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledWith(
+      "[mtls] SIGHUP: reloaded mTLS materials",
+    );
+  });
+
   it("rejects with TypeError when @/lib/mtls exposes reload as undefined", async () => {
     vi.resetModules();
     vi.doMock("@/lib/mtls", () => ({ reload: undefined }));

--- a/src/lib/instrumentation/__tests__/mtls-sighup.unit.test.ts
+++ b/src/lib/instrumentation/__tests__/mtls-sighup.unit.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { reloadMock } = vi.hoisted(() => ({
+  reloadMock: vi.fn<() => Promise<unknown>>(),
+}));
+
+vi.mock("@/lib/mtls", () => ({
+  reload: (...args: unknown[]) => reloadMock(...(args as [])),
+}));
+
+const SIGHUP_SLOT = Symbol.for("aimer.mtls.sighup");
+
+type SighupSlot = {
+  installed: boolean;
+  installing: Promise<void> | null;
+};
+
+function clearSighupSlot(): void {
+  delete (globalThis as Record<symbol, unknown>)[SIGHUP_SLOT];
+}
+
+function getSlot(): SighupSlot | undefined {
+  return (globalThis as Record<symbol, unknown>)[SIGHUP_SLOT] as
+    | SighupSlot
+    | undefined;
+}
+
+function snapshotSighupListeners(): NodeJS.SignalsListener[] {
+  return [
+    ...(process.listeners("SIGHUP") as unknown as NodeJS.SignalsListener[]),
+  ];
+}
+
+function listenersAddedSince(
+  before: NodeJS.SignalsListener[],
+): NodeJS.SignalsListener[] {
+  const current = process.listeners(
+    "SIGHUP",
+  ) as unknown as NodeJS.SignalsListener[];
+  return current.filter((l) => !before.includes(l));
+}
+
+function removeListenersAddedSince(before: NodeJS.SignalsListener[]): void {
+  for (const l of listenersAddedSince(before)) {
+    process.off("SIGHUP", l);
+  }
+}
+
+describe("installMtlsSighupHandler", () => {
+  let listenersBefore: NodeJS.SignalsListener[];
+
+  beforeEach(() => {
+    clearSighupSlot();
+    vi.resetModules();
+    reloadMock.mockReset();
+    reloadMock.mockResolvedValue(undefined);
+    listenersBefore = snapshotSighupListeners();
+  });
+
+  afterEach(() => {
+    removeListenersAddedSince(listenersBefore);
+    clearSighupSlot();
+    vi.restoreAllMocks();
+  });
+
+  it("registers a single SIGHUP listener on first install", async () => {
+    const { installMtlsSighupHandler } = await import("../mtls-sighup");
+    await installMtlsSighupHandler();
+    expect(listenersAddedSince(listenersBefore)).toHaveLength(1);
+  });
+
+  it("is idempotent across sequential calls (HMR-like re-invocation)", async () => {
+    const { installMtlsSighupHandler } = await import("../mtls-sighup");
+    await installMtlsSighupHandler();
+    await installMtlsSighupHandler();
+    await installMtlsSighupHandler();
+    expect(listenersAddedSince(listenersBefore)).toHaveLength(1);
+  });
+
+  it("joins a shared installing promise across concurrent calls", async () => {
+    const { installMtlsSighupHandler } = await import("../mtls-sighup");
+    await Promise.all([
+      installMtlsSighupHandler(),
+      installMtlsSighupHandler(),
+      installMtlsSighupHandler(),
+    ]);
+    expect(listenersAddedSince(listenersBefore)).toHaveLength(1);
+  });
+
+  it("calls reload() exactly once per SIGHUP signal", async () => {
+    const { installMtlsSighupHandler } = await import("../mtls-sighup");
+    await installMtlsSighupHandler();
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    process.emit("SIGHUP");
+    // Flush microtasks created inside the listener.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledWith(
+      "[mtls] SIGHUP: reloaded mTLS materials",
+    );
+  });
+
+  it("logs reload failure via console.error without crashing", async () => {
+    const { installMtlsSighupHandler } = await import("../mtls-sighup");
+    await installMtlsSighupHandler();
+
+    const boom = new Error("disk read failed");
+    reloadMock.mockReset();
+    reloadMock.mockRejectedValueOnce(boom);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    process.emit("SIGHUP");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith("[mtls] SIGHUP: reload failed", boom);
+  });
+
+  it("rejects and allows retry when import('@/lib/mtls') fails", async () => {
+    vi.resetModules();
+    vi.doMock("@/lib/mtls", () => {
+      throw new Error("simulated import failure");
+    });
+    const failingMod = await import("../mtls-sighup");
+    await expect(failingMod.installMtlsSighupHandler()).rejects.toBeInstanceOf(
+      Error,
+    );
+
+    expect(listenersAddedSince(listenersBefore)).toHaveLength(0);
+
+    const slot = getSlot();
+    expect(slot?.installed).toBe(false);
+    expect(slot?.installing).toBe(null);
+
+    // Repair the import and retry: the next call must succeed and attach the
+    // single listener.
+    vi.resetModules();
+    vi.doUnmock("@/lib/mtls");
+    vi.doMock("@/lib/mtls", () => ({
+      reload: (...args: unknown[]) => reloadMock(...(args as [])),
+    }));
+    const retryMod = await import("../mtls-sighup");
+    await retryMod.installMtlsSighupHandler();
+
+    expect(listenersAddedSince(listenersBefore)).toHaveLength(1);
+    expect(getSlot()?.installed).toBe(true);
+  });
+
+  it("rejects with TypeError when @/lib/mtls exposes reload as undefined", async () => {
+    vi.resetModules();
+    vi.doMock("@/lib/mtls", () => ({ reload: undefined }));
+    const mod = await import("../mtls-sighup");
+
+    await expect(mod.installMtlsSighupHandler()).rejects.toBeInstanceOf(
+      TypeError,
+    );
+
+    expect(listenersAddedSince(listenersBefore)).toHaveLength(0);
+
+    const slot = getSlot();
+    expect(slot?.installed).toBe(false);
+    expect(slot?.installing).toBe(null);
+  });
+});

--- a/src/lib/instrumentation/mtls-sighup.ts
+++ b/src/lib/instrumentation/mtls-sighup.ts
@@ -45,15 +45,30 @@ export function installMtlsSighupHandler(): Promise<void> {
         "[mtls] SIGHUP install aborted: @/lib/mtls did not export a reload() function",
       );
     }
+    // Resolve `reload()` dynamically inside the handler rather than closing
+    // over the namespace from this install. Under HMR, `@/lib/mtls` can be
+    // re-evaluated to a fresh instance with its own module-local `state`
+    // while the SIGHUP listener registered here survives in the original
+    // module instance. Closing over `mtls.reload` would then rotate the
+    // stale instance's state — disconnected from the one serving requests.
+    // A per-signal dynamic `import()` resolves to whichever instance the
+    // module resolver currently considers current, keeping reload aligned
+    // with the live `state`.
     process.on("SIGHUP", () => {
-      mtls.reload().then(
-        () => {
+      void (async () => {
+        try {
+          const current = await import("@/lib/mtls");
+          if (typeof current.reload !== "function") {
+            throw new TypeError(
+              "@/lib/mtls did not export a reload() function",
+            );
+          }
+          await current.reload();
           console.info("[mtls] SIGHUP: reloaded mTLS materials");
-        },
-        (err) => {
+        } catch (err) {
           console.error("[mtls] SIGHUP: reload failed", err);
-        },
-      );
+        }
+      })();
     });
     slot.installed = true;
   })();

--- a/src/lib/instrumentation/mtls-sighup.ts
+++ b/src/lib/instrumentation/mtls-sighup.ts
@@ -1,0 +1,78 @@
+import "server-only";
+
+/**
+ * Reload mTLS materials when the process receives `SIGHUP`, so bootroot-driven
+ * certificate rotation takes effect without restarting the Next.js server.
+ *
+ * Install is idempotent across re-invocation (HMR, repeated instrumentation
+ * boots) via a `globalThis` slot. We track *our* installation specifically
+ * rather than `process.listenerCount("SIGHUP")` because another module may
+ * legitimately attach its own SIGHUP listener (e.g. a future graceful-shutdown
+ * hook); a `listenerCount > 0` check would then incorrectly skip our
+ * registration.
+ */
+
+const SIGHUP_SLOT = Symbol.for("aimer.mtls.sighup");
+
+interface SighupSlot {
+  installed: boolean;
+  installing: Promise<void> | null;
+}
+
+type GlobalWithSighupSlot = typeof globalThis & {
+  [SIGHUP_SLOT]?: SighupSlot;
+};
+
+function getSlot(): SighupSlot {
+  const g = globalThis as GlobalWithSighupSlot;
+  let slot = g[SIGHUP_SLOT];
+  if (!slot) {
+    slot = { installed: false, installing: null };
+    g[SIGHUP_SLOT] = slot;
+  }
+  return slot;
+}
+
+export function installMtlsSighupHandler(): Promise<void> {
+  const slot = getSlot();
+  if (slot.installed) return Promise.resolve();
+  if (slot.installing) return slot.installing;
+
+  const installing = (async () => {
+    const mtls = await import("@/lib/mtls");
+    if (typeof mtls.reload !== "function") {
+      throw new TypeError(
+        "[mtls] SIGHUP install aborted: @/lib/mtls did not export a reload() function",
+      );
+    }
+    process.on("SIGHUP", () => {
+      mtls.reload().then(
+        () => {
+          console.info("[mtls] SIGHUP: reloaded mTLS materials");
+        },
+        (err) => {
+          console.error("[mtls] SIGHUP: reload failed", err);
+        },
+      );
+    });
+    slot.installed = true;
+  })();
+
+  slot.installing = installing;
+  // Clear the in-flight slot once the install settles. On success `installed`
+  // is already true, so a subsequent call short-circuits. On failure
+  // `installed` stays false and `installing` is cleared, so the caller can
+  // retry. We attach this cleanup with a non-throwing handler so we never
+  // create an unhandled rejection here; the caller still observes the
+  // rejection via the returned promise.
+  installing.then(
+    () => {
+      slot.installing = null;
+    },
+    () => {
+      slot.installing = null;
+    },
+  );
+
+  return installing;
+}


### PR DESCRIPTION
## Summary

Reload mTLS materials on `SIGHUP` so bootroot-driven certificate rotation takes effect without restarting the Next.js server.

- New `src/lib/instrumentation/mtls-sighup.ts` installs a `process.on("SIGHUP", ...)` listener that calls `reload()` from `@/lib/mtls` and logs the outcome in the `[mtls] SIGHUP: ...` format.
- The listener resolves `reload()` via a dynamic `import("@/lib/mtls")` at SIGHUP dispatch time, not at install time. Under HMR, `@/lib/mtls` can be re-evaluated to a fresh instance with its own module-local `state` while the listener registered here survives in the original module instance; closing over the namespace from first install would rotate the stale instance's state, disconnected from the one serving requests.
- Idempotent install guarded by a `globalThis[Symbol.for("aimer.mtls.sighup")]` slot so HMR / repeated instrumentation boots never register duplicate listeners. Concurrent installs join a shared `installing` promise.
- Defensive guard after the install-time dynamic import throws `TypeError` if `@/lib/mtls` does not expose `reload()` as a function, so a stubbed/mocked namespace cannot silently attach a broken listener. The same guard runs again inside the handler.
- On import or guard failure, `installed` stays unset and `installing` is cleared so the caller can retry.
- `src/instrumentation.ts` calls `await installMtlsSighupHandler()` in the Node.js runtime branch, after `runStartupMigrations()` — migration failure must abort startup before any listeners attach.
- Unit tests cover single-listener install, sequential idempotency, concurrent join, single `reload()` per signal, reload-failure logging, import-failure retry, the `reload === undefined` defensive-guard path, and the HMR-like scenario where `@/lib/mtls` is re-mocked between install and SIGHUP. Tests snapshot SIGHUP listeners and remove only what they added, avoiding `process.removeAllListeners`.

Closes #229

## Test plan

- [x] `pnpm biome check` passes for the changed files
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm vitest run src/lib/instrumentation/` — all 8 unit tests pass
- [x] First `installMtlsSighupHandler()` call attaches exactly one SIGHUP listener
- [x] Sequential repeat calls (HMR-like) do not add additional listeners
- [x] Concurrent parallel calls join the shared `installing` promise and register exactly one listener
- [x] `process.emit("SIGHUP")` triggers `reload()` exactly once and logs `[mtls] SIGHUP: reloaded mTLS materials` on success
- [x] A rejected `reload()` is logged via `console.error` as `[mtls] SIGHUP: reload failed` and does not crash the process
- [x] After `@/lib/mtls` is re-mocked between install and SIGHUP, the listener calls the fresh `reload`, not the one captured at install — proving dynamic resolution
- [x] When `import("@/lib/mtls")` rejects, install rejects, no listener attaches, and a later call can retry successfully
- [x] When `@/lib/mtls` exposes `reload` as `undefined`, install rejects with `TypeError`, no listener attaches, and `installed` stays `false`
- [x] `installMtlsSighupHandler()` runs after `runStartupMigrations()` in `src/instrumentation.ts` so migration failure aborts startup before a listener is attached