### PR TITLE
Add mTLS operator manual pages (#231)

### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -11,7 +11,7 @@ same 4-column shape (`Name | Required | Description | Default`).
 
 | Name | Required | Description | Default |
 | --- | --- | --- | --- |
-| `MTLS_CERT_PATH` | Yes | Filesystem path to the client certificate PEM used for mTLS to the aimer backend. Also used as the source of the JWT signing key. See [mTLS](operations/mtls.md). | _(unset)_ |
-| `MTLS_KEY_PATH` | Yes | Filesystem path to the private key PEM that pairs with `MTLS_CERT_PATH`. PKCS#8, PKCS#1 RSA, and SEC1 EC are all accepted. See [mTLS](operations/mtls.md). | _(unset)_ |
+| `MTLS_CERT_PATH` | Yes | Filesystem path to the client certificate PEM used for mTLS to the aimer backend. Its public key determines the JWT signing algorithm and supplies the fingerprint / expiry that the monitor reports. See [mTLS](operations/mtls.md). | _(unset)_ |
+| `MTLS_KEY_PATH` | Yes | Filesystem path to the private key PEM that pairs with `MTLS_CERT_PATH`. This is the JWT signing key — aimer-web signs every outbound JWT with it. PKCS#8, PKCS#1 RSA, and SEC1 EC are all accepted. See [mTLS](operations/mtls.md). | _(unset)_ |
 | `MTLS_CA_PATH` | Yes | Filesystem path to the CA bundle PEM that validates the aimer server certificate. See [mTLS](operations/mtls.md). | _(unset)_ |
 | `AIMER_GRAPHQL_ENDPOINT` | Yes | URL of the aimer GraphQL endpoint (e.g. `https://aimer.internal/graphql`). The mTLS-routed GraphQL client refuses to dispatch if this is unset. | _(unset)_ |

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -1,3 +1,17 @@
 # Configuration
 
 This page will describe how to configure Aimer Web.
+
+## Environment variables
+
+aimer-web reads its configuration from process environment
+variables. The table below lists the variables this page documents
+so far; follow-up issues will append additional sections to the
+same 4-column shape (`Name | Required | Description | Default`).
+
+| Name | Required | Description | Default |
+| --- | --- | --- | --- |
+| `MTLS_CERT_PATH` | Yes | Filesystem path to the client certificate PEM used for mTLS to the aimer backend. Also used as the source of the JWT signing key. See [mTLS](operations/mtls.md). | _(unset)_ |
+| `MTLS_KEY_PATH` | Yes | Filesystem path to the private key PEM that pairs with `MTLS_CERT_PATH`. PKCS#8, PKCS#1 RSA, and SEC1 EC are all accepted. See [mTLS](operations/mtls.md). | _(unset)_ |
+| `MTLS_CA_PATH` | Yes | Filesystem path to the CA bundle PEM that validates the aimer server certificate. See [mTLS](operations/mtls.md). | _(unset)_ |
+| `AIMER_GRAPHQL_ENDPOINT` | Yes | URL of the aimer GraphQL endpoint (e.g. `https://aimer.internal/graphql`). The mTLS-routed GraphQL client refuses to dispatch if this is unset. | _(unset)_ |

--- a/docs/en/operations/mtls.md
+++ b/docs/en/operations/mtls.md
@@ -1,0 +1,235 @@
+# mTLS
+
+This page is for operators. It describes the end-to-end setup that
+makes aimer-web talk to the aimer backend over mutual TLS: how
+certificates are provisioned, which environment variables aimer-web
+reads, how to trigger a hot reload after rotation, and what log lines
+to alert on for expiry and reload outcomes.
+
+mTLS is **not** a client-only feature. aimer-web is the client; the
+aimer backend is the server. An operator following only the
+aimer-web steps cannot bring the channel up. For the server-side
+configuration (the `auth-mtls` Cargo feature, listener setup, and
+SIGHUP behavior on aimer) see the aimer operator documentation; if
+those pages have not yet been published, the work is tracked under
+the umbrella issue
+<https://github.com/aicers/aimer/issues/358> and the aimer SIGHUP
+docs land via
+<https://github.com/aicers/aimer/issues/367>.
+
+<!-- TODO(#231): replace the cross-repo umbrella links above with
+deep links to the aimer operator pages once they are published. -->
+
+## End-to-end setup checklist
+
+Follow these steps top-to-bottom on a fresh deployment. Steps 1–4
+bring the pipe up; step 5 is the cross-version smoke test that
+proves the wiring is correct.
+
+1. **bootroot provisions the certificate pair** (cert + key + CA) on
+   both the aimer-web host and the aimer host. aimer-web accepts
+   bootroot's private-key output in any of the three PEM formats
+   bootroot may emit — PKCS#8 (`-----BEGIN PRIVATE KEY-----`),
+   PKCS#1 RSA (`-----BEGIN RSA PRIVATE KEY-----`), and SEC1 EC
+   (`-----BEGIN EC PRIVATE KEY-----`). No operator action is
+   required to convert between them; aimer-web normalizes to PKCS#8
+   internally. (Recorded here so a future bootroot format change has
+   a documented anchor.)
+2. **Build aimer with the `auth-mtls` Cargo feature.** This is the
+   opt-in server build tracked under
+   <https://github.com/aicers/aimer/issues/358>. Configure the
+   server-side listener per the aimer operator documentation.
+3. **Configure aimer-web** by setting the environment variables in
+   the [Environment variables](#environment-variables) section
+   below. The same cert/key pair is used for both the TLS handshake
+   and for signing the per-request JWT — there is no separate
+   signing key.
+4. **(Optional smoke test) Trigger a SIGHUP on both sides** to
+   verify the reload path works. The aimer-web SIGHUP handler is
+   auto-registered by `src/instrumentation.ts` at boot and the cert
+   is loaded lazily on first request, so this step verifies reload
+   rather than being required for first-time setup. See
+   [Reloading after rotation](#reloading-after-rotation).
+5. **Run the cross-version smoke test** (verification item 41 from
+   <https://github.com/aicers/aimer-web/discussions/9>): make an
+   mTLS-routed GraphQL request against an `auth-mtls` aimer build
+   and assert the JWT contract — `aud = "aimer"`,
+   `exp - iat = 300`, and **no `customer_ids` claim**. This step
+   requires a live `auth-mtls` aimer build and is part of the
+   feature-complete deliverable under
+   <https://github.com/aicers/aimer-web/issues/44>; it is documented
+   here for operator reference, not as a prerequisite for pipe
+   acceptance.
+
+## Environment variables
+
+| Name | Required | Description | Default |
+| --- | --- | --- | --- |
+| `MTLS_CERT_PATH` | Yes | Filesystem path to the client certificate PEM provisioned by bootroot. | _(unset; aimer-web refuses to start the mTLS state)_ |
+| `MTLS_KEY_PATH` | Yes | Filesystem path to the private key PEM that pairs with `MTLS_CERT_PATH`. PKCS#8, PKCS#1 RSA, and SEC1 EC are all accepted. | _(unset; aimer-web refuses to start the mTLS state)_ |
+| `MTLS_CA_PATH` | Yes | Filesystem path to the CA bundle PEM that validates the aimer server certificate. | _(unset; aimer-web refuses to start the mTLS state)_ |
+| `AIMER_GRAPHQL_ENDPOINT` | Yes | URL of the aimer GraphQL endpoint (e.g. `https://aimer.internal/graphql`). | _(unset; the mTLS-routed client refuses to dispatch)_ |
+
+The values are read by `src/lib/mtls.ts` on first request (lazy
+init) and re-read on every SIGHUP. There is no separate config file:
+the environment is the source of truth.
+
+The same cert pair drives both legs of the conversation: it is the
+client certificate for the TLS handshake, **and** it is the signing
+key for the JWT aimer-web mints on every request. Rotating one
+rotates the other.
+
+### JWT contract
+
+The token aimer-web signs and sends on each request carries:
+
+- `sub` — the account id of the calling user.
+- `aice_id` — the AICE identity associated with the call.
+- `aud = "aimer"` — fixed in code; **not configurable**.
+- `exp = iat + 300` — fixed 5-minute lifetime.
+- `jti` — random UUID per request.
+- **No `customer_ids` claim.** Customer authorization is enforced by
+  aimer-web's BFF route layer **before** the call is made, not by
+  the JWT itself. Operators changing environment variables cannot
+  affect this contract.
+
+## Supported certificate algorithms
+
+aimer-web detects the certificate's algorithm from its public key
+and signs the JWT with a matching algorithm:
+
+| Public key | Algorithm |
+| --- | --- |
+| RSA, ≥ 4096-bit modulus | `RS512` |
+| RSA, ≥ 3072-bit modulus | `RS384` |
+| RSA, smaller modulus | `RS256` |
+| EC, `prime256v1` (P-256) | `ES256` |
+| EC, `secp384r1` (P-384) | `ES384` |
+
+**ES512 (EC P-521) is intentionally unsupported.** If bootroot is
+configured to emit a P-521 client certificate, aimer-web fails to
+build the mTLS state with a clear error
+(`Unsupported EC curve: secp521r1`). Do not deploy P-521 certs
+without first widening this list in code.
+
+## Certificate layout expectations
+
+bootroot writes the three PEM files to filesystem paths the operator
+selects. The recommended layout, used by the systemd / k8s examples
+below, is:
+
+| File | Ownership | Mode | Purpose |
+| --- | --- | --- | --- |
+| `<dir>/client.crt` | `aimer-web:aimer-web` | `0644` | Client certificate (`MTLS_CERT_PATH`) |
+| `<dir>/client.key` | `aimer-web:aimer-web` | `0600` | Private key (`MTLS_KEY_PATH`) |
+| `<dir>/ca.crt` | `aimer-web:aimer-web` | `0644` | CA bundle for verifying aimer (`MTLS_CA_PATH`) |
+
+The private key must be readable only by the aimer-web service
+account. The cert and CA bundle may be world-readable. bootroot
+rotates these files in place; aimer-web does not watch the
+filesystem, so a rotation is not picked up until SIGHUP (see below).
+
+## Reloading after rotation
+
+aimer-web installs a SIGHUP handler at boot via
+`src/instrumentation.ts`. The handler is registered in
+`src/lib/instrumentation/mtls-sighup.ts` and calls
+`reload()` in `src/lib/mtls.ts`, which:
+
+- re-reads the three PEM files from the same env-var paths,
+- builds a new TLS agent and a new JWT signing key,
+- atomically swaps the new state in,
+- retires the previous agent, draining it after the last in-flight
+  request finishes.
+
+There is no downtime and no dropped request across the swap.
+
+### Which PID to signal
+
+bootroot rotates files **on each host**, and each Node process
+holds its own in-memory cert state. Signal every Node process that
+serves traffic — not just one.
+
+- **Bare Node (`pnpm start` / `next start`):** signal the parent
+  `next` process. Example: `kill -HUP $(pgrep -f 'next start')`.
+- **Next.js standalone build (`output: "standalone"`):** signal the
+  `node server.js` process inside the standalone bundle.
+- **Container:** signal PID 1 inside the container, e.g.
+  `kill -HUP 1` (or `docker kill -s HUP <container>` /
+  `kubectl exec <pod> -- kill -HUP 1`).
+- **Node cluster mode / pm2 cluster / multiple replicas:** signal
+  **every** worker and **every** replica. For pm2 cluster mode,
+  `pm2 reload <app>` re-signals each worker. For a Kubernetes
+  Deployment with N replicas, iterate over all pods.
+
+### systemd
+
+A typical unit has:
+
+```ini
+[Service]
+ExecStart=/usr/bin/node /opt/aimer-web/server.js
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGTERM
+```
+
+After bootroot rotates the certs, the rotation hook runs
+`systemctl reload aimer-web`.
+
+### Kubernetes
+
+A lifecycle hook that signals the container PID after a cert
+ConfigMap / Secret rotation:
+
+```yaml
+spec:
+  containers:
+    - name: aimer-web
+      lifecycle:
+        # Run an in-cluster sidecar or external rotator that signals
+        # every replica's PID 1 after bootroot updates the mounted
+        # Secret. A simple `kubectl exec` loop also works:
+        #   kubectl get pods -l app=aimer-web -o name \
+        #     | xargs -I{} kubectl exec {} -- kill -HUP 1
+```
+
+### aimer
+
+To rotate certs on the server side, follow the aimer SIGHUP
+procedure documented under
+<https://github.com/aicers/aimer/issues/367>. aimer-web and aimer
+reload independently; rotating only one side leaves the channel in
+a mismatched state.
+
+## Log formats
+
+The strings below are emitted verbatim by `src/lib/mtls.ts` and
+`src/lib/instrumentation/mtls-sighup.ts`. Alert rules grepping for
+them must match these strings exactly.
+
+### Expiry monitor
+
+aimer-web checks the loaded certificate's expiry every 6 hours and
+on every reload. Within 3 days of expiry it emits a warn line at
+most once per 24h per fingerprint; once expired it emits an error
+line under the same rate limit.
+
+- Warn (within 3 days):
+  `[mtls] client certificate expires in <N> day(s) at <ISO-timestamp> (fingerprint <hex>)`
+- Error (already expired):
+  `[mtls] client certificate has EXPIRED at <ISO-timestamp> (fingerprint <hex>)`
+
+aimer emits its own expiry warnings independently. Operators must
+monitor both sides — a near-expiry cert on the server is not
+visible from aimer-web's logs.
+
+### SIGHUP reload
+
+Emitted by the SIGHUP handler after every signal:
+
+- Success: `[mtls] SIGHUP: reloaded mTLS materials`
+- Failure: `[mtls] SIGHUP: reload failed <error>`
+
+A failed reload leaves the previous state in place; aimer-web keeps
+serving with the old cert until the next successful reload or
+restart.

--- a/docs/en/operations/mtls.md
+++ b/docs/en/operations/mtls.md
@@ -70,9 +70,19 @@ proves the wiring is correct.
 | `MTLS_CA_PATH` | Yes | Filesystem path to the CA bundle PEM that validates the aimer server certificate. | _(unset; aimer-web refuses to start the mTLS state)_ |
 | `AIMER_GRAPHQL_ENDPOINT` | Yes | URL of the aimer GraphQL endpoint (e.g. `https://aimer.internal/graphql`). | _(unset; the mTLS-routed client refuses to dispatch)_ |
 
-The values are read by `src/lib/mtls.ts` on first request (lazy
-init) and re-read on every SIGHUP. There is no separate config file:
-the environment is the source of truth.
+The three `MTLS_*` paths are read by `src/lib/mtls.ts` on first
+request (lazy init) and re-read on every SIGHUP — rotating the cert
+files and signalling the process picks up the new values without a
+restart.
+
+`AIMER_GRAPHQL_ENDPOINT` is read from `process.env` on every
+dispatch by `src/lib/graphql/client.ts` and is **not** part of the
+SIGHUP reload path. Changing the endpoint in a service env file
+requires restarting the aimer-web process — SIGHUP will not pick it
+up the way it does for rotated certificate files.
+
+There is no separate config file: the environment is the source of
+truth.
 
 The same cert pair drives both legs of the conversation: it is the
 client certificate for the TLS handshake, **and** it is the signing
@@ -178,20 +188,35 @@ After bootroot rotates the certs, the rotation hook runs
 
 ### Kubernetes
 
-A lifecycle hook that signals the container PID after a cert
-ConfigMap / Secret rotation:
+Kubernetes does **not** fire a lifecycle hook when a mounted Secret
+or ConfigMap is rotated — `postStart` runs once on container start
+and `preStop` runs on shutdown. Reload must therefore be driven
+out-of-band by something that notices the new cert files and signals
+every pod.
 
-```yaml
-spec:
-  containers:
-    - name: aimer-web
-      lifecycle:
-        # Run an in-cluster sidecar or external rotator that signals
-        # every replica's PID 1 after bootroot updates the mounted
-        # Secret. A simple `kubectl exec` loop also works:
-        #   kubectl get pods -l app=aimer-web -o name \
-        #     | xargs -I{} kubectl exec {} -- kill -HUP 1
-```
+Two supported approaches:
+
+1. **`kubectl exec` loop driven by the rotator** (simplest). After
+   bootroot updates the mounted Secret, the rotator job runs:
+
+   ```sh
+   kubectl get pods -l app=aimer-web -o name \
+     | xargs -I{} kubectl exec {} -- kill -HUP 1
+   ```
+
+   Iterating over **every** pod is required — each Node process holds
+   its own in-memory cert state.
+
+2. **Sidecar watcher in the pod spec.** A small sidecar container
+   shares the cert volume, watches the mounted files with `inotify`
+   (or polls), and runs `kill -HUP 1` against the main container via
+   a shared process namespace (`shareProcessNamespace: true`). This
+   keeps the reload trigger inside the pod and avoids needing
+   cluster-wide `pods/exec` permissions on the rotator job.
+
+Whichever approach is used, signal every replica of the Deployment —
+bootroot rotates files on each node, and a partially-reloaded
+Deployment leaves some pods serving with the old cert.
 
 ### aimer
 

--- a/docs/en/operations/mtls.md
+++ b/docs/en/operations/mtls.md
@@ -209,10 +209,29 @@ Two supported approaches:
 
 2. **Sidecar watcher in the pod spec.** A small sidecar container
    shares the cert volume, watches the mounted files with `inotify`
-   (or polls), and runs `kill -HUP 1` against the main container via
-   a shared process namespace (`shareProcessNamespace: true`). This
-   keeps the reload trigger inside the pod and avoids needing
-   cluster-wide `pods/exec` permissions on the rotator job.
+   (or polls), and signals the main aimer-web process via a shared
+   process namespace (`shareProcessNamespace: true`). This keeps the
+   reload trigger inside the pod and avoids needing cluster-wide
+   `pods/exec` permissions on the rotator job.
+
+   **Do not** signal PID 1 from the sidecar. With
+   `shareProcessNamespace: true`, PID 1 inside the pod is the
+   Kubernetes pause container, not aimer-web (see the [Kubernetes
+   shared process namespace
+   docs](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/)).
+   The sidecar must discover the actual aimer-web process. Either
+   have the main container write a PID file to the shared volume on
+   startup and have the sidecar `kill -HUP "$(cat /shared/aimer-web.pid)"`,
+   or discover the PID by name from the sidecar, e.g.
+   `kill -HUP "$(pgrep -f 'node .*server.js')"` (adjust the pattern
+   to match the actual command line — `next start`, `node server.js`,
+   etc.). The sidecar image must include `pgrep` (or whatever
+   discovery tool is used).
+
+   Reserve `kill -HUP 1` for the `kubectl exec` approach above, where
+   the signal lands inside the main container's own PID namespace
+   (no `shareProcessNamespace`) and PID 1 is the aimer-web process
+   itself.
 
 Whichever approach is used, signal every replica of the Deployment —
 bootroot rotates files on each node, and a partially-reloaded

--- a/docs/ko/configuration.md
+++ b/docs/ko/configuration.md
@@ -1,3 +1,17 @@
 # 설정
 
 이 페이지에서는 Aimer Web을 설정하는 방법을 설명합니다.
+
+## 환경 변수
+
+aimer-web은 프로세스 환경 변수에서 설정값을 읽습니다. 아래 표는
+현재 이 페이지가 문서화한 변수들을 나열합니다. 이후 이슈에서 같은
+4열 형식(`이름 | 필수 | 설명 | 기본값`)으로 추가 섹션을
+이어붙입니다.
+
+| 이름 | 필수 | 설명 | 기본값 |
+| --- | --- | --- | --- |
+| `MTLS_CERT_PATH` | 예 | aimer 백엔드와의 mTLS에 사용할 클라이언트 인증서 PEM의 파일 경로. JWT 서명 키의 출처이기도 합니다. [mTLS](operations/mtls.md) 페이지를 참고하십시오. | _(미설정)_ |
+| `MTLS_KEY_PATH` | 예 | `MTLS_CERT_PATH`와 쌍을 이루는 비공개 키 PEM의 파일 경로. PKCS#8, PKCS#1 RSA, SEC1 EC 모두 허용. [mTLS](operations/mtls.md) 페이지를 참고하십시오. | _(미설정)_ |
+| `MTLS_CA_PATH` | 예 | aimer 서버 인증서를 검증할 CA 번들 PEM의 파일 경로. [mTLS](operations/mtls.md) 페이지를 참고하십시오. | _(미설정)_ |
+| `AIMER_GRAPHQL_ENDPOINT` | 예 | aimer GraphQL 엔드포인트 URL (예: `https://aimer.internal/graphql`). 미설정 시 mTLS로 라우팅된 GraphQL 클라이언트는 디스패치를 거부합니다. | _(미설정)_ |

--- a/docs/ko/configuration.md
+++ b/docs/ko/configuration.md
@@ -11,7 +11,7 @@ aimer-web은 프로세스 환경 변수에서 설정값을 읽습니다. 아래 
 
 | 이름 | 필수 | 설명 | 기본값 |
 | --- | --- | --- | --- |
-| `MTLS_CERT_PATH` | 예 | aimer 백엔드와의 mTLS에 사용할 클라이언트 인증서 PEM의 파일 경로. JWT 서명 키의 출처이기도 합니다. [mTLS](operations/mtls.md) 페이지를 참고하십시오. | _(미설정)_ |
-| `MTLS_KEY_PATH` | 예 | `MTLS_CERT_PATH`와 쌍을 이루는 비공개 키 PEM의 파일 경로. PKCS#8, PKCS#1 RSA, SEC1 EC 모두 허용. [mTLS](operations/mtls.md) 페이지를 참고하십시오. | _(미설정)_ |
+| `MTLS_CERT_PATH` | 예 | aimer 백엔드와의 mTLS에 사용할 클라이언트 인증서 PEM의 파일 경로. 이 인증서의 공개 키가 JWT 서명 알고리즘을 결정하며, 만료 감시기가 보고하는 핑거프린트와 만료 시점도 여기서 가져옵니다. [mTLS](operations/mtls.md) 페이지를 참고하십시오. | _(미설정)_ |
+| `MTLS_KEY_PATH` | 예 | `MTLS_CERT_PATH`와 쌍을 이루는 비공개 키 PEM의 파일 경로. 실제 JWT 서명 키는 이 파일이며, aimer-web은 모든 외부 호출의 JWT를 이 키로 서명합니다. PKCS#8, PKCS#1 RSA, SEC1 EC 모두 허용. [mTLS](operations/mtls.md) 페이지를 참고하십시오. | _(미설정)_ |
 | `MTLS_CA_PATH` | 예 | aimer 서버 인증서를 검증할 CA 번들 PEM의 파일 경로. [mTLS](operations/mtls.md) 페이지를 참고하십시오. | _(미설정)_ |
 | `AIMER_GRAPHQL_ENDPOINT` | 예 | aimer GraphQL 엔드포인트 URL (예: `https://aimer.internal/graphql`). 미설정 시 mTLS로 라우팅된 GraphQL 클라이언트는 디스패치를 거부합니다. | _(미설정)_ |

--- a/docs/ko/operations/mtls.md
+++ b/docs/ko/operations/mtls.md
@@ -69,9 +69,17 @@ aimer의 SIGHUP 문서는
 | `MTLS_CA_PATH` | 예 | aimer 서버 인증서를 검증할 CA 번들 PEM의 파일 경로. | _(미설정 시 aimer-web이 mTLS 상태 구축을 거부합니다)_ |
 | `AIMER_GRAPHQL_ENDPOINT` | 예 | aimer GraphQL 엔드포인트 URL (예: `https://aimer.internal/graphql`). | _(미설정 시 mTLS로 라우팅된 클라이언트가 디스패치를 거부합니다)_ |
 
-값은 `src/lib/mtls.ts`가 첫 요청 시점에 (지연 초기화로) 읽고,
-SIGHUP마다 다시 읽습니다. 별도의 설정 파일은 없으며 환경 변수가
-유일한 출처입니다.
+세 개의 `MTLS_*` 경로는 `src/lib/mtls.ts`가 첫 요청 시점에 (지연
+초기화로) 읽고, SIGHUP마다 다시 읽습니다 — 인증서 파일을 회전하고
+프로세스에 신호를 보내면 재시작 없이 새 값이 반영됩니다.
+
+`AIMER_GRAPHQL_ENDPOINT`는 `src/lib/graphql/client.ts`가 매 디스패치
+시점에 `process.env`에서 읽으며, SIGHUP 리로드 경로에 **포함되지
+않습니다**. 서비스 환경 파일에서 엔드포인트를 변경한 경우에는
+aimer-web 프로세스를 재시작해야 합니다 — 인증서 파일과 달리
+SIGHUP으로는 반영되지 않습니다.
+
+별도의 설정 파일은 없으며 환경 변수가 유일한 출처입니다.
 
 동일한 인증서 쌍이 대화의 양쪽 다리를 구동합니다. TLS 핸드셰이크의
 클라이언트 인증서이자, aimer-web이 요청마다 발급하는 JWT의 서명
@@ -179,21 +187,35 @@ bootroot이 인증서를 회전한 다음, 회전 훅에서
 
 ### Kubernetes
 
-인증서 ConfigMap / Secret 회전 후 컨테이너의 PID에 신호를 보내는
-라이프사이클 훅:
+Kubernetes는 마운트된 Secret 또는 ConfigMap이 회전될 때
+라이프사이클 훅을 발화하지 **않습니다** — `postStart`는 컨테이너
+시작 시 한 번만 실행되고, `preStop`은 종료 시에 실행됩니다. 따라서
+리로드는 새 인증서 파일을 감지하고 모든 파드에 신호를 보내는
+별도의 메커니즘으로 구동해야 합니다.
 
-```yaml
-spec:
-  containers:
-    - name: aimer-web
-      lifecycle:
-        # bootroot이 마운트된 Secret을 갱신한 후, 클러스터 내
-        # 사이드카 또는 외부 회전기가 각 레플리카의 PID 1에 신호를
-        # 보내도록 구성합니다. 간단한 `kubectl exec` 루프도
-        # 가능합니다:
-        #   kubectl get pods -l app=aimer-web -o name \
-        #     | xargs -I{} kubectl exec {} -- kill -HUP 1
-```
+지원되는 두 가지 방식:
+
+1. **회전기가 구동하는 `kubectl exec` 루프** (가장 단순). bootroot이
+   마운트된 Secret을 갱신한 후, 회전기 잡이 다음을 실행합니다:
+
+   ```sh
+   kubectl get pods -l app=aimer-web -o name \
+     | xargs -I{} kubectl exec {} -- kill -HUP 1
+   ```
+
+   **모든** 파드를 순회해야 합니다 — 각 Node 프로세스는 자체
+   인메모리 인증서 상태를 보유하기 때문입니다.
+
+2. **파드 스펙 안의 사이드카 워처.** 작은 사이드카 컨테이너가 인증서
+   볼륨을 공유하며 마운트된 파일을 `inotify`로 감시하거나 폴링하고,
+   공유 프로세스 네임스페이스(`shareProcessNamespace: true`)를 통해
+   메인 컨테이너의 PID 1에 `kill -HUP 1`을 실행합니다. 리로드 트리거를
+   파드 안에 두기 때문에, 회전기 잡에 클러스터 전역의 `pods/exec`
+   권한을 부여하지 않아도 됩니다.
+
+어느 방식을 쓰든 Deployment의 모든 레플리카에 신호를 보내야 합니다 —
+bootroot은 각 노드에서 파일을 회전하므로, 일부 파드만 리로드된 상태로
+남으면 이전 인증서로 계속 서비스를 제공하는 파드가 생깁니다.
 
 ### aimer
 

--- a/docs/ko/operations/mtls.md
+++ b/docs/ko/operations/mtls.md
@@ -1,0 +1,235 @@
+# mTLS
+
+이 문서는 운영자를 위한 페이지입니다. aimer-web이 aimer 백엔드와
+상호 TLS(mutual TLS)로 통신하도록 설정하는 종단 간 절차를
+설명합니다. 인증서가 어떻게 발급되는지, aimer-web이 읽는 환경
+변수는 무엇인지, 회전 후 핫 리로드를 어떻게 트리거하는지, 만료와
+리로드 결과를 알리는 로그 라인이 무엇인지 다룹니다.
+
+mTLS는 클라이언트 한쪽만의 기능이 **아닙니다**. aimer-web이
+클라이언트이고, aimer 백엔드가 서버입니다. aimer-web 쪽 절차만
+따라서는 채널을 올릴 수 없습니다. 서버 측 설정(`auth-mtls` Cargo
+기능, 리스너 구성, aimer의 SIGHUP 동작)에 대해서는 aimer 운영자
+문서를 참고하십시오. 해당 문서가 아직 공개되지 않았다면 작업은
+엄브렐러 이슈
+<https://github.com/aicers/aimer/issues/358> 에서 추적 중이며,
+aimer의 SIGHUP 문서는
+<https://github.com/aicers/aimer/issues/367> 을 통해 게시됩니다.
+
+<!-- TODO(#231): aimer 운영자 페이지가 공개되면 위의 교차 저장소
+엄브렐러 링크를 해당 페이지의 딥링크로 교체하십시오. -->
+
+## 종단 간 설정 체크리스트
+
+새 배포 환경에서 다음 단계를 위에서 아래로 따르십시오. 1–4단계는
+파이프를 올리는 단계이고, 5단계는 배선이 올바른지 입증하는 교차
+버전 스모크 테스트입니다.
+
+1. **bootroot이 인증서 쌍을 발급합니다** (cert + key + CA).
+   aimer-web 호스트와 aimer 호스트 양쪽에 모두 배치됩니다.
+   aimer-web은 bootroot이 출력할 수 있는 세 가지 PEM 형식의
+   비공개 키를 모두 받아들입니다 — PKCS#8
+   (`-----BEGIN PRIVATE KEY-----`), PKCS#1 RSA
+   (`-----BEGIN RSA PRIVATE KEY-----`), SEC1 EC
+   (`-----BEGIN EC PRIVATE KEY-----`). 운영자가 형식을 변환할
+   필요는 없으며, aimer-web이 내부적으로 PKCS#8로 정규화합니다.
+   (향후 bootroot 형식이 변경될 때 참고할 수 있도록 명시해
+   둡니다.)
+2. **aimer를 `auth-mtls` Cargo 기능으로 빌드합니다.** 이는
+   <https://github.com/aicers/aimer/issues/358> 에서 추적되는
+   옵트인 서버 빌드입니다. 서버 측 리스너는 aimer 운영자 문서에
+   따라 구성하십시오.
+3. **aimer-web을 구성합니다.** 아래 "환경 변수" 섹션의 환경
+   변수를 설정합니다. 동일한 인증서/키 쌍이 TLS 핸드셰이크와
+   요청당 JWT 서명 모두에 사용됩니다 — 별도의 서명 키는
+   없습니다.
+4. **(선택 사항) 양쪽에 SIGHUP을 보내 리로드 경로를
+   확인합니다.** aimer-web의 SIGHUP 핸들러는 부팅 시
+   `src/instrumentation.ts`에 의해 자동 등록되며, 인증서는 첫
+   요청에서 지연 로드되므로 이 단계는 최초 설정에 필수는 아니고
+   리로드 경로의 동작을 검증하는 의미를 가집니다. 아래 "회전 후
+   리로드" 섹션을 참고하십시오.
+5. **교차 버전 스모크 테스트를 실행합니다.**
+   <https://github.com/aicers/aimer-web/discussions/9> 의 검증
+   항목 41에 해당합니다. `auth-mtls` aimer 빌드에 대해 mTLS로
+   라우팅된 GraphQL 요청을 보내고, JWT 계약을 검증하십시오 —
+   `aud = "aimer"`, `exp - iat = 300`, **`customer_ids` 클레임
+   없음**. 이 단계는 살아 있는 `auth-mtls` aimer 빌드를
+   요구하며,
+   <https://github.com/aicers/aimer-web/issues/44> 의 기능 완성
+   목표물의 일부입니다. 본 문서는 운영자 참고용으로 절차를
+   기록할 뿐, 파이프 수용 조건은 아닙니다.
+
+## 환경 변수
+
+| 이름 | 필수 | 설명 | 기본값 |
+| --- | --- | --- | --- |
+| `MTLS_CERT_PATH` | 예 | bootroot이 발급한 클라이언트 인증서 PEM의 파일 경로. | _(미설정 시 aimer-web이 mTLS 상태 구축을 거부합니다)_ |
+| `MTLS_KEY_PATH` | 예 | `MTLS_CERT_PATH`와 쌍을 이루는 비공개 키 PEM의 파일 경로. PKCS#8, PKCS#1 RSA, SEC1 EC 모두 허용. | _(미설정 시 aimer-web이 mTLS 상태 구축을 거부합니다)_ |
+| `MTLS_CA_PATH` | 예 | aimer 서버 인증서를 검증할 CA 번들 PEM의 파일 경로. | _(미설정 시 aimer-web이 mTLS 상태 구축을 거부합니다)_ |
+| `AIMER_GRAPHQL_ENDPOINT` | 예 | aimer GraphQL 엔드포인트 URL (예: `https://aimer.internal/graphql`). | _(미설정 시 mTLS로 라우팅된 클라이언트가 디스패치를 거부합니다)_ |
+
+값은 `src/lib/mtls.ts`가 첫 요청 시점에 (지연 초기화로) 읽고,
+SIGHUP마다 다시 읽습니다. 별도의 설정 파일은 없으며 환경 변수가
+유일한 출처입니다.
+
+동일한 인증서 쌍이 대화의 양쪽 다리를 구동합니다. TLS 핸드셰이크의
+클라이언트 인증서이자, aimer-web이 요청마다 발급하는 JWT의 서명
+키이기도 합니다. 한쪽을 회전하면 다른 쪽도 함께 회전됩니다.
+
+### JWT 계약
+
+aimer-web이 요청마다 서명하여 보내는 토큰의 클레임은 다음과
+같습니다.
+
+- `sub` — 호출한 사용자의 account id.
+- `aice_id` — 호출과 연관된 AICE 식별자.
+- `aud = "aimer"` — 코드에 고정. **설정 불가**.
+- `exp = iat + 300` — 5분 고정 수명.
+- `jti` — 요청마다 무작위 UUID.
+- **`customer_ids` 클레임 없음.** 고객 권한 확인은 호출 전에
+  aimer-web의 BFF 라우트 계층에서 수행되며, JWT 자체에는 들어가지
+  않습니다. 환경 변수를 변경해도 이 계약은 영향을 받지 않습니다.
+
+## 지원하는 인증서 알고리즘
+
+aimer-web은 인증서의 공개 키에서 알고리즘을 감지하고, 그에 맞는
+알고리즘으로 JWT를 서명합니다.
+
+| 공개 키 | 알고리즘 |
+| --- | --- |
+| RSA, ≥ 4096-bit 모듈러스 | `RS512` |
+| RSA, ≥ 3072-bit 모듈러스 | `RS384` |
+| RSA, 더 작은 모듈러스 | `RS256` |
+| EC, `prime256v1` (P-256) | `ES256` |
+| EC, `secp384r1` (P-384) | `ES384` |
+
+**ES512 (EC P-521)는 의도적으로 지원하지 않습니다.** bootroot이
+P-521 클라이언트 인증서를 발급하도록 설정된 경우, aimer-web은
+명확한 오류(`Unsupported EC curve: secp521r1`)와 함께 mTLS 상태
+구축에 실패합니다. 코드에서 목록을 확장하기 전에 P-521 인증서를
+배포하지 마십시오.
+
+## 인증서 파일 배치 기대값
+
+bootroot은 운영자가 선택한 경로에 세 개의 PEM 파일을 기록합니다.
+아래 systemd / k8s 예시에서 사용하는 권장 배치는 다음과 같습니다.
+
+| 파일 | 소유권 | 권한 | 용도 |
+| --- | --- | --- | --- |
+| `<dir>/client.crt` | `aimer-web:aimer-web` | `0644` | 클라이언트 인증서 (`MTLS_CERT_PATH`) |
+| `<dir>/client.key` | `aimer-web:aimer-web` | `0600` | 비공개 키 (`MTLS_KEY_PATH`) |
+| `<dir>/ca.crt` | `aimer-web:aimer-web` | `0644` | aimer 검증용 CA 번들 (`MTLS_CA_PATH`) |
+
+비공개 키는 aimer-web 서비스 계정만 읽을 수 있어야 합니다.
+인증서와 CA 번들은 누구나 읽을 수 있어도 됩니다. bootroot은 이
+파일들을 in-place로 회전하지만 aimer-web은 파일시스템을 감시하지
+않으므로, SIGHUP을 보내기 전까지 회전이 반영되지 않습니다(아래
+참고).
+
+## 회전 후 리로드
+
+aimer-web은 부팅 시 `src/instrumentation.ts`를 통해 SIGHUP
+핸들러를 설치합니다. 핸들러는
+`src/lib/instrumentation/mtls-sighup.ts`에 등록되며,
+`src/lib/mtls.ts`의 `reload()`를 호출합니다. `reload()`는 다음을
+수행합니다.
+
+- 동일한 환경 변수 경로에서 세 PEM 파일을 다시 읽고,
+- 새 TLS 에이전트와 새 JWT 서명 키를 생성하고,
+- 새 상태를 원자적으로 교체하고,
+- 이전 에이전트를 은퇴 처리하여 마지막 진행 중 요청이 끝난 후
+  드레인합니다.
+
+교체 과정에서 다운타임은 없으며, 떨어지는 요청도 없습니다.
+
+### 어떤 PID로 신호를 보낼지
+
+bootroot은 **각 호스트**에서 파일을 회전하고, 각 Node 프로세스는
+자체 인메모리 인증서 상태를 보유합니다. 트래픽을 처리하는 모든
+Node 프로세스에 신호를 보내야 합니다 — 한 개만으로는 부족합니다.
+
+- **베어 Node (`pnpm start` / `next start`):** 부모 `next`
+  프로세스에 신호를 보냅니다. 예:
+  `kill -HUP $(pgrep -f 'next start')`.
+- **Next.js standalone 빌드 (`output: "standalone"`):** standalone
+  번들 안의 `node server.js` 프로세스에 신호를 보냅니다.
+- **컨테이너:** 컨테이너 내부의 PID 1에 신호를 보냅니다. 예:
+  `kill -HUP 1` (또는 `docker kill -s HUP <container>` /
+  `kubectl exec <pod> -- kill -HUP 1`).
+- **Node cluster 모드 / pm2 cluster / 다중 레플리카:** **모든**
+  워커와 **모든** 레플리카에 신호를 보내야 합니다. pm2 cluster
+  모드에서는 `pm2 reload <app>`이 각 워커를 다시 신호로
+  깨웁니다. 레플리카가 N개인 Kubernetes Deployment라면 모든
+  파드를 순회하십시오.
+
+### systemd
+
+일반적인 유닛 구성:
+
+```ini
+[Service]
+ExecStart=/usr/bin/node /opt/aimer-web/server.js
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGTERM
+```
+
+bootroot이 인증서를 회전한 다음, 회전 훅에서
+`systemctl reload aimer-web`을 실행하도록 구성하십시오.
+
+### Kubernetes
+
+인증서 ConfigMap / Secret 회전 후 컨테이너의 PID에 신호를 보내는
+라이프사이클 훅:
+
+```yaml
+spec:
+  containers:
+    - name: aimer-web
+      lifecycle:
+        # bootroot이 마운트된 Secret을 갱신한 후, 클러스터 내
+        # 사이드카 또는 외부 회전기가 각 레플리카의 PID 1에 신호를
+        # 보내도록 구성합니다. 간단한 `kubectl exec` 루프도
+        # 가능합니다:
+        #   kubectl get pods -l app=aimer-web -o name \
+        #     | xargs -I{} kubectl exec {} -- kill -HUP 1
+```
+
+### aimer
+
+서버 측에서 인증서를 회전하려면
+<https://github.com/aicers/aimer/issues/367> 에 기록된 aimer
+SIGHUP 절차를 따르십시오. aimer-web과 aimer는 독립적으로
+리로드합니다. 한쪽만 회전하면 채널이 불일치 상태로 남습니다.
+
+## 로그 형식
+
+아래 문자열은 `src/lib/mtls.ts`와
+`src/lib/instrumentation/mtls-sighup.ts`가 그대로 출력합니다.
+이 문자열을 grep하는 알림 규칙은 정확히 일치해야 합니다.
+
+### 만료 감시
+
+aimer-web은 6시간마다, 그리고 매 리로드 시점마다 적재된
+인증서의 만료를 점검합니다. 만료 3일 이내에는 핑거프린트당 24시간
+당 최대 1회 경고 라인을 출력하고, 이미 만료된 경우에는 동일한
+속도 제한 아래에서 오류 라인을 출력합니다.
+
+- 경고 (만료 3일 이내):
+  `[mtls] client certificate expires in <N> day(s) at <ISO-timestamp> (fingerprint <hex>)`
+- 오류 (이미 만료):
+  `[mtls] client certificate has EXPIRED at <ISO-timestamp> (fingerprint <hex>)`
+
+aimer는 자체 만료 경고를 독립적으로 출력합니다. 운영자는 양쪽을
+모두 감시해야 합니다 — 서버 쪽 만료 임박은 aimer-web 로그에
+드러나지 않습니다.
+
+### SIGHUP 리로드
+
+매 신호 처리 후 SIGHUP 핸들러가 출력합니다.
+
+- 성공: `[mtls] SIGHUP: reloaded mTLS materials`
+- 실패: `[mtls] SIGHUP: reload failed <error>`
+
+리로드가 실패하면 이전 상태가 그대로 남고, aimer-web은 다음 성공
+리로드 또는 재시작 전까지 기존 인증서로 계속 서비스를 제공합니다.

--- a/docs/ko/operations/mtls.md
+++ b/docs/ko/operations/mtls.md
@@ -209,9 +209,27 @@ Kubernetes는 마운트된 Secret 또는 ConfigMap이 회전될 때
 2. **파드 스펙 안의 사이드카 워처.** 작은 사이드카 컨테이너가 인증서
    볼륨을 공유하며 마운트된 파일을 `inotify`로 감시하거나 폴링하고,
    공유 프로세스 네임스페이스(`shareProcessNamespace: true`)를 통해
-   메인 컨테이너의 PID 1에 `kill -HUP 1`을 실행합니다. 리로드 트리거를
-   파드 안에 두기 때문에, 회전기 잡에 클러스터 전역의 `pods/exec`
-   권한을 부여하지 않아도 됩니다.
+   메인 aimer-web 프로세스에 신호를 보냅니다. 리로드 트리거를 파드
+   안에 두기 때문에, 회전기 잡에 클러스터 전역의 `pods/exec` 권한을
+   부여하지 않아도 됩니다.
+
+   사이드카에서 PID 1로는 신호를 보내지 **마십시오**.
+   `shareProcessNamespace: true`인 파드에서 PID 1은 Kubernetes의
+   pause 컨테이너이며 aimer-web이 아닙니다([Kubernetes 공유 프로세스
+   네임스페이스 문서](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/)
+   참조). 사이드카는 실제 aimer-web 프로세스를 찾아야 합니다. 시작
+   시 메인 컨테이너가 공유 볼륨에 PID 파일을 기록하고 사이드카가
+   `kill -HUP "$(cat /shared/aimer-web.pid)"`를 실행하거나, 사이드카
+   안에서 이름으로 PID를 찾는 방식을 쓸 수 있습니다. 예:
+   `kill -HUP "$(pgrep -f 'node .*server.js')"` (실제 커맨드라인에
+   맞게 패턴을 조정 — `next start`, `node server.js` 등). 사이드카
+   이미지에는 `pgrep` (또는 사용하는 발견 도구)이 포함되어 있어야
+   합니다.
+
+   `kill -HUP 1`은 위의 `kubectl exec` 방식에서만 사용하십시오. 그
+   경우 신호는 `shareProcessNamespace`가 없는 메인 컨테이너 자체의
+   PID 네임스페이스 안에서 처리되며, PID 1이 곧 aimer-web 프로세스
+   입니다.
 
 어느 방식을 쓰든 Deployment의 모든 레플리카에 신호를 보내야 합니다 —
 bootroot은 각 노드에서 파일을 회전하므로, 일부 파드만 리로드된 상태로

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ plugins:
             - Audit Logs: audit-logs.md
             - Backup & Restore: backup-restore.md
             - Phase 2 Ingest: operations/phase2-ingest.md
+            - mTLS: operations/mtls.md
         - locale: ko
           name: 한국어
           build: true
@@ -57,6 +58,7 @@ plugins:
             - Audit Logs: audit-logs.md
             - Backup & Restore: backup-restore.md
             - Phase 2 Ingest: operations/phase2-ingest.md
+            - mTLS: operations/mtls.md
           nav_translations:
             Overview: 개요
             Getting Started: 시작하기


### PR DESCRIPTION
## Summary

- Add `docs/en/operations/mtls.md` and `docs/ko/operations/mtls.md` — an end-to-end mTLS setup guide covering bootroot provisioning, the four mTLS env vars, the JWT contract aimer-web mints (`aud = "aimer"`, `exp - iat = 300`, no `customer_ids`), supported cert algorithms (and the intentional ES512 omission), expected file layout, SIGHUP reload guidance for bare Node / Next.js standalone / container / cluster deployments, and the verbatim expiry-monitor and SIGHUP reload log strings emitted by `src/lib/mtls.ts` and `src/lib/instrumentation/mtls-sighup.ts` so operator alert rules can grep them exactly.
- Register both pages in `mkdocs.yml` as siblings of Phase 2 Ingest under each language's `nav` block. "mTLS" is identical in EN and KO, so no `nav_translations` entry is added (per the issue's explicit guidance).
- Seed an environment-variable table on the previously-stub `docs/{en,ko}/configuration.md` with the four `MTLS_*` / `AIMER_GRAPHQL_ENDPOINT` rows, using the 4-column `Name | Required | Description | Default` shape so follow-up configuration work can append cleanly.
- Cross-repo aimer-side links point to umbrella issues [aicers/aimer#358](https://github.com/aicers/aimer/issues/358) and [aicers/aimer#367](https://github.com/aicers/aimer/issues/367) until the aimer-side operator docs land.

**AUTHORING.md "UI screenshots are included" checklist item: N/A.** This is an operator/CLI-only page under `operations/`, following the precedent set by `docs/en/operations/phase2-ingest.md`, which ships without screenshots. The issue explicitly closes the earlier open question in favor of this precedent.

Closes #231

## Test plan

- [x] `mkdocs serve` renders both `docs/en/operations/mtls.md` and `docs/ko/operations/mtls.md` without errors
- [x] Both pages appear in the EN and KO navigation as siblings of "Phase 2 Ingest"
- [x] `mkdocs build --strict` passes with no warnings
- [x] EN and KO pages have identical structure, heading hierarchy, and filenames
- [x] Prose wraps at 80 columns (tables and URLs may exceed)
- [x] All cross-links resolve (aimer-side links go to aicers/aimer#358 / aicers/aimer#367)
- [x] Expiry-monitor log strings on the page match `src/lib/mtls.ts` exactly
- [x] SIGHUP reload log strings on the page match `src/lib/instrumentation/mtls-sighup.ts` exactly
- [x] Setup checklist reads end-to-end: a fresh operator with bootroot output and an `auth-mtls` aimer build can follow the page top-to-bottom
- [x] Configuration table entries for `MTLS_CERT_PATH`, `MTLS_KEY_PATH`, `MTLS_CA_PATH`, `AIMER_GRAPHQL_ENDPOINT` are present in both EN and KO